### PR TITLE
Keep symbols in the CodSpeed build so profiles resolve function names

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -38,7 +38,15 @@ jobs:
       - name: 🏗 Install dependencies
         run: uv sync --locked --no-install-project --no-default-groups --group build --group codspeed
       - name: 🏗 Build and install yamlrocks
-        # Optimized build so CodSpeed measures the instruction counts users get.
+        # Optimized build so CodSpeed measures the instruction counts users get,
+        # but keep the symbol table and debug line info so CodSpeed attributes
+        # costs to functions instead of reporting "unknown symbol". `release`
+        # strips symbols by default; these env overrides change only that metadata
+        # (LTO/opt-level/codegen-units are untouched, so the measured counts match
+        # the shipped wheels). The binary is only used for this benchmark run.
+        env:
+          CARGO_PROFILE_RELEASE_STRIP: "false"
+          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
         run: uv run --no-sync maturin develop --release
       - name: 🚀 Run benchmarks under CodSpeed
         uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

CodSpeed reported every function in the benchmark profiles as "unknown symbol", so the graphs were unusable for spotting regressions.

The cause: the `release` Cargo profile sets `strip = "symbols"`, and the CodSpeed workflow builds the extension with `maturin develop --release`. The resulting `.so` that CodSpeed instruments therefore ships with no symbol table and no debug info, so there is nothing to attribute instruction counts to.

This sets two Cargo profile overrides on the CodSpeed build step only:

- `CARGO_PROFILE_RELEASE_STRIP: "false"` keeps the symbol table.
- `CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"` adds DWARF line info.

These change metadata only. `lto`, `opt-level`, and `codegen-units` stay exactly as in `release`, so CodSpeed still measures the same instruction counts the shipped (stripped) wheels execute; they are simply attributable to functions now.

The unstripped binary is used only for this benchmark run, so the published release wheels are unaffected.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [ ] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
