### PR TITLE
Have Renovate refresh the real-world corpus submodules monthly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboard": true,
   "labels": ["dependencies", "no-stale"],
+  "git-submodules": {
+    "enabled": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
@@ -51,6 +54,20 @@
     {
       "matchManagers": ["pre-commit"],
       "addLabels": ["pre-commit"]
+    },
+    {
+      "description": "Refresh the real-world corpus submodules once a month, grouped into a single PR.",
+      "matchManagers": ["git-submodules"],
+      "matchDepNames": ["tests/data/realworld/**"],
+      "addLabels": ["maintenance"],
+      "groupName": "real-world corpus submodules",
+      "schedule": ["before 3am on the first day of the month"]
+    },
+    {
+      "description": "The YAML test suite is the compliance baseline; bumping it can change which cases pass and needs expectations regenerated, so update it by hand rather than via Renovate.",
+      "matchManagers": ["git-submodules"],
+      "matchDepNames": ["tests/data/yaml_test_suite/cases"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->
None.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Renovate was not managing the git submodules at all: the `git-submodules` manager is disabled by default, so the real-world test corpus under `tests/data/realworld/` never got refreshed. This enables it, scoped so it stays low-noise:

- Enables the `git-submodules` manager.
- Groups every `tests/data/realworld/**` submodule bump into a single PR, once a month (`before 3am on the first day of the month`), labeled `maintenance`. Without grouping this would be roughly 96 separate PRs.
- Excludes `tests/data/yaml_test_suite/cases` (the compliance baseline): bumping it can change which cases pass and requires regenerating the expectations, so it is updated by hand rather than by Renovate.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [x] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [ ] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
