### PR TITLE
Use major.minor Python for the release driver jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
       - name: 🏗 Set package version from release tag
         shell: bash
         env:
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
       - name: 🏗 Set package version from release tag
         shell: bash
         env:
@@ -172,7 +172,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
       - name: 🏗 Set package version from release tag
         shell: bash
         env:
@@ -207,7 +207,7 @@ jobs:
       - name: 🏗 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
       - name: 🔍 Validate the artifact set
         shell: bash
         # A failed build job already blocks publishing via `needs:`; this catches


### PR DESCRIPTION
## What

The release failed: Renovate bumped the patch-pinned `setup-python` (`3.14.5` → `3.14.6`) in the `linux`/`musllinux`/`sdist`/`publish` jobs, but the GitHub Actions `python-versions` project has not published `3.14.6` yet (the live `versions-manifest.json` tops out at `3.14.5`), so `setup-python` could not fetch it.

## Why these four and not Windows/macOS

The Windows/macOS jobs use major.minor (`3.12`/`3.13`/`3.14`) because they must install all three target interpreters for maturin to resolve against, and Renovate does not bump minor specs. So Renovate only touched the four concrete patch pins.

## Fix

Those four jobs only need a *driver* Python (wheels are built per-interpreter via maturin's `--interpreter` flag), so pin them to `"3.14"` (major.minor), matching the others. `setup-python` then resolves the latest available patch, and Renovate has no concrete patch to bump, so this cannot recur.

`check-latest`/the live manifest would not have helped here: `3.14.6` is not in the manifest at all.