### PR TITLE
🔧 Stop Renovate from pinning the setup-python python-version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -68,6 +68,12 @@
       "matchManagers": ["git-submodules"],
       "matchDepNames": ["tests/data/yaml_test_suite/cases"],
       "enabled": false
+    },
+    {
+      "description": "Do not let Renovate pin or bump the setup-python python-version. The GitHub Actions runner images lag CPython patch releases, so pinning to the newest patch (e.g. 3.14.6) breaks setup-python until the runners catch up. Keep the major.minor spec (3.14) and manage supported versions by hand.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Renovate's `github-actions` manager runs with `rangeStrategy: "pin"`, which is
correct for action digests but also rewrites the `setup-python`
`python-version` to the newest CPython patch. The GitHub Actions runner images
lag CPython patch releases, so when Renovate pinned the release driver jobs
from `python-version: "3.14"` to `3.14.6`, `setup-python` could not install it
and the release pipeline failed (and #24 was about to re-introduce the same
break).

This adds a `packageRule` that disables Renovate management of the `python`
dep (the `setup-python` version, datasource `actions/python-versions`). The
release jobs keep their major.minor spec (`3.14`), which always resolves to
whatever patch the runner ships, and the supported Python versions are managed
by hand. Action digests and every other github-actions dependency are still
pinned and updated as before.

Validated with `renovate-config-validator` (config validated successfully) and
`prettier@3.4.2 --check`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #23 (which set the major.minor spec), supersedes #24
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
