### PR TITLE
👷 Drop s390x from the release wheel matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,16 @@ jobs:
           - { runner: ubuntu-22.04, target: x86 }
           - { runner: ubuntu-22.04, target: aarch64 }
           - { runner: ubuntu-22.04, target: armv7 }
-          - { runner: ubuntu-22.04, target: s390x }
           - { runner: ubuntu-22.04, target: ppc64le }
+          # s390x is intentionally omitted: the `psm` crate (pulled in by
+          # `stacker`, our recursion-depth guard) ships hand-written
+          # z/Architecture assembly that the manylinux s390x cross-image's
+          # binutils is too old to assemble (`Unrecognized opcode: lay`).
+          # There is no fixed psm/stacker release. The code itself is fine on
+          # big-endian s390x (built natively with a modern toolchain in
+          # tests-arch.yaml), so an s390x user can still build from the sdist;
+          # we just cannot cross-build a wheel here. Restore this target if
+          # psm gains a manylinux-compatible s390x build.
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -76,7 +76,7 @@ includes:
   <tbody>
     <tr>
       <td>Linux (manylinux)</td>
-      <td>x86_64, aarch64, armv7, ppc64le, s390x, i686</td>
+      <td>x86_64, aarch64, armv7, ppc64le, i686</td>
     </tr>
     <tr>
       <td>Linux (musllinux, e.g. Alpine)</td>


### PR DESCRIPTION
## Breaking change

None. s390x wheels were never published (the target failed in both the v0.1.0
and v0.1.1 release runs), so no existing user loses a wheel they had.

## Proposed change

Remove the `s390x` target from the release wheel matrix. The `psm` crate (a
transitive dependency of `stacker`, our recursion-depth guard) ships
hand-written z/Architecture assembly that the manylinux s390x cross-image's
binutils is too old to assemble:

```
src/arch/zseries_linux.s:50: Error: Unrecognized opcode: `lay'
error: failed to run custom build command for `psm v0.1.31`
```

`psm 0.1.31` and `stacker 0.1.24` are already the latest releases, so there is
no upstream fix to pin to. This is the only target that fails; every other
wheel (x86_64, x86, aarch64, armv7, ppc64le, musllinux, Windows x64/x86, macOS
x86_64/aarch64) and the sdist build cleanly.

s390x is a niche big-endian mainframe arch. The code itself is fine there:
`tests-arch.yaml` still builds and runs the full suite on s390x natively (with
a modern toolchain), so an s390x user can build from the published sdist. Only
the cross-built wheel is dropped. A comment in the matrix explains how to
restore the target if psm ever gains a manylinux-compatible s390x build.

The installation docs (`installation.mdx`) drop s390x from the wheels table to
match; the "No wheel for your platform?" note already covers the sdist fallback.

The artifact-validation step is unaffected: it checks for a `linux` wheel per
CPython version, which the other manylinux targets satisfy.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the v0.1.1 release run, whose only failing job was the s390x wheel
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.