### PR TITLE
👷 Build Windows arm64 wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,13 +98,18 @@ jobs:
 
   windows:
     name: Wheels (windows ${{ matrix.platform.target }})
-    runs-on: windows-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - { target: x64, arch: x64 }
-          - { target: x86, arch: x86 }
+          - { runner: windows-latest, target: x64, arch: x64 }
+          - { runner: windows-latest, target: x86, arch: x86 }
+          # Windows on ARM. Built natively on the windows-11-arm runner image
+          # (which ships Rust and Python), so maturin resolves the arm64
+          # interpreters exactly as the x64/x86 jobs do. setup-python has arm64
+          # builds for every CPython version we target.
+          - { runner: windows-11-arm, target: aarch64, arch: arm64 }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,11 @@ jobs:
   windows:
     name: Wheels (windows ${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
+    # The arm64 leg is flagged experimental, so continue-on-error makes only
+    # that leg non-fatal: the `release` job's `needs: [..., windows, ...]` still
+    # proceeds if arm64 fails, while x64/x86 stay required. Without this, a
+    # windows-11-arm failure would fail the whole job and block the publish.
+    continue-on-error: ${{ matrix.platform.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -108,8 +113,15 @@ jobs:
           # Windows on ARM. Built natively on the windows-11-arm runner image
           # (which ships Rust and Python), so maturin resolves the arm64
           # interpreters exactly as the x64/x86 jobs do. setup-python has arm64
-          # builds for every CPython version we target.
-          - { runner: windows-11-arm, target: aarch64, arch: arm64 }
+          # builds for every CPython version we target. Marked experimental so a
+          # failure on this newer runner does not block the release (see
+          # continue-on-error above).
+          - {
+              runner: windows-11-arm,
+              target: aarch64,
+              arch: arm64,
+              experimental: true,
+            }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,11 +99,6 @@ jobs:
   windows:
     name: Wheels (windows ${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
-    # The arm64 leg is flagged experimental, so continue-on-error makes only
-    # that leg non-fatal: the `release` job's `needs: [..., windows, ...]` still
-    # proceeds if arm64 fails, while x64/x86 stay required. Without this, a
-    # windows-11-arm failure would fail the whole job and block the publish.
-    continue-on-error: ${{ matrix.platform.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,15 +108,8 @@ jobs:
           # Windows on ARM. Built natively on the windows-11-arm runner image
           # (which ships Rust and Python), so maturin resolves the arm64
           # interpreters exactly as the x64/x86 jobs do. setup-python has arm64
-          # builds for every CPython version we target. Marked experimental so a
-          # failure on this newer runner does not block the release (see
-          # continue-on-error above).
-          - {
-              runner: windows-11-arm,
-              target: aarch64,
-              arch: arm64,
-              experimental: true,
-            }
+          # builds for every CPython version we target.
+          - { runner: windows-11-arm, target: aarch64, arch: arm64 }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -88,7 +88,7 @@ includes:
     </tr>
     <tr>
       <td>Windows</td>
-      <td>x86_64, i686</td>
+      <td>x86_64, i686, arm64</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Breaking change

None. This adds a new wheel; nothing existing changes.

## Proposed change

Build native **Windows arm64** (`win_arm64`) wheels for CPython 3.12, 3.13 and 3.14. Windows on ARM (Surface, Snapdragon X laptops) is a growing target that had no wheel until now, so those users fell back to a from-source build.

The build runs on the GitHub-hosted `windows-11-arm` runner, which ships Rust and Python, so maturin resolves the arm64 interpreters exactly as the existing x64/x86 jobs do. `actions/python-versions` publishes arm64 builds for every CPython version we target (3.12.10 / 3.13.13 / 3.14.5), so `setup-python` installs them on the host. This is the same native-runner approach [pydantic-core uses](https://github.com/pydantic/pydantic-core/blob/main/.github/workflows/ci.yml) for Windows arm64.

Mechanically: the `windows` job's `runs-on` is now parameterized per matrix entry (matching the `macos` job), and a single `{ runner: windows-11-arm, target: aarch64, arch: arm64 }` entry is added. The installation docs gain `arm64` in the Windows wheels row.

arm64 is a required wheel, treated exactly like x64/x86: it is part of the `windows` job that the `release` job lists in `needs:`, so if the arm64 build ever fails the release stops and we fix it, rather than silently publishing without an arm64 wheel. (An earlier revision of this PR tried to make the leg non-blocking via `continue-on-error`; Copilot and CodeRabbit correctly flagged that as inconsistent, and it was the wrong goal anyway. arm64 is expected to build on the verified `windows-11-arm` runner, so it should block like any other wheel.)

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the post-v0.1.1 wheel-matrix follow-up
- Link to a separate documentation pull request: None (docs updated here)

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
