### PR TITLE
👷 Reliable, continuously-tested wheel builds (fix retired macOS runners + shared build matrix)

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -23,7 +23,11 @@ permissions:
   contents: read
 
 jobs:
-  # manylinux wheels across architectures.
+  # manylinux wheels across architectures. Unlike the native Windows and macOS
+  # jobs below, these are not split by ABI or smoke-tested in place: the non
+  # x86_64 targets are built under QEMU emulation, so the x86_64 host cannot
+  # import them. Functional coverage for those arches comes from tests-arch.yaml,
+  # which runs the full suite on aarch64/armv7/ppc64le natively-emulated.
   linux:
     name: Wheels (manylinux ${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
@@ -105,8 +109,15 @@ jobs:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
 
+  # Windows builds run natively on their target runner, so the matrix is split
+  # by CPython version (ABI): each job sets up exactly one interpreter, builds
+  # the wheel for that one ABI, and then imports it. The job's single interpreter
+  # is the host default, so the smoke step exercises precisely the wheel just
+  # built (this ABI and architecture), with no cross-platform interpreter
+  # juggling. x64/x86 run on windows-latest; arm64 runs natively on the
+  # windows-11-arm image (which ships Rust and Python).
   windows:
-    name: Wheels (windows ${{ matrix.platform.target }})
+    name: Wheels (windows ${{ matrix.platform.target }} cp${{ matrix.python }})
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -114,24 +125,15 @@ jobs:
         platform:
           - { runner: windows-latest, target: x64, arch: x64 }
           - { runner: windows-latest, target: x86, arch: x86 }
-          # Windows on ARM. Built natively on the windows-11-arm runner image
-          # (which ships Rust and Python), so maturin resolves the arm64
-          # interpreters exactly as the x64/x86 jobs do. setup-python has arm64
-          # builds for every CPython version we target.
           - { runner: windows-11-arm, target: aarch64, arch: arm64 }
+        python: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          # All three interpreters must be present on the host: this runner is
-          # not containerized, so maturin resolves `--interpreter 3.12 3.13 3.14`
-          # against the installed Pythons (only 3.12 would yield only cp312).
-          python-version: |
-            3.12
-            3.13
-            3.14
+          python-version: ${{ matrix.python }}
           architecture: ${{ matrix.platform.arch }}
       - name: 🏗 Set package version from release tag
         if: inputs.release-tag != ''
@@ -139,57 +141,72 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release-tag }}
         run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build wheels
+      - name: 🏗 Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
+          args: --release --out dist --interpreter ${{ matrix.python }}
+      - name: 🚬 Smoke-test the built wheel
+        shell: bash
+        # Install the just-built wheel offline (never PyPI) into this job's only
+        # interpreter, which matches the wheel's ABI and arch, and exercise the
+        # public API so a wheel that builds but cannot import fails here.
+        run: |
+          set -euo pipefail
+          python -m pip install --no-index --find-links dist yamlrocks
+          python -c "import yamlrocks; assert yamlrocks.loads(b'x: 1') == {'x': 1}; print('smoke OK', yamlrocks.dumps({'a': [1, 2]}))"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-windows-${{ matrix.platform.target }}
+          name: wheels-windows-${{ matrix.platform.target }}-cp${{ matrix.python }}
           path: dist
 
+  # macOS builds run natively on their target runner, so (like Windows) the
+  # matrix is split by CPython version (ABI) and each wheel is imported on the
+  # interpreter that built it. macOS 26 (Tahoe) is the newest GA image and
+  # Apple's last Intel-supporting release, so macos-26-intel is the final Intel
+  # runner generation and has the longest runway. This replaces the previous
+  # pair: macos-13 (Intel), retired by GitHub in December 2025, and macos-14
+  # (arm64), which begins deprecation in 2026.
   macos:
-    name: Wheels (macos ${{ matrix.platform.target }})
+    name: Wheels (macos ${{ matrix.platform.target }} cp${{ matrix.python }})
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         platform:
-          # macOS 26 (Tahoe) is the newest GA image and Apple's last Intel-
-          # supporting release, so macos-26-intel is the final Intel runner
-          # generation and has the longest runway. This replaces the previous
-          # pair: macos-13 (Intel), retired by GitHub in December 2025, and
-          # macos-14 (arm64), which begins deprecation in 2026.
           - { runner: macos-26-intel, target: x86_64 }
           - { runner: macos-26, target: aarch64 }
+        python: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          # All three interpreters must be present on the host: this runner is
-          # not containerized, so maturin resolves `--interpreter 3.12 3.13 3.14`
-          # against the installed Pythons (only 3.12 would yield only cp312).
-          python-version: |
-            3.12
-            3.13
-            3.14
+          python-version: ${{ matrix.python }}
       - name: 🏗 Set package version from release tag
         if: inputs.release-tag != ''
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.release-tag }}
         run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build wheels
+      - name: 🏗 Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
+          args: --release --out dist --interpreter ${{ matrix.python }}
+      - name: 🚬 Smoke-test the built wheel
+        shell: bash
+        # Install the just-built wheel offline (never PyPI) into this job's only
+        # interpreter, which matches the wheel's ABI and arch, and exercise the
+        # public API so a wheel that builds but cannot import fails here.
+        run: |
+          set -euo pipefail
+          python -m pip install --no-index --find-links dist yamlrocks
+          python -c "import yamlrocks; assert yamlrocks.loads(b'x: 1') == {'x': 1}; print('smoke OK', yamlrocks.dumps({'a': [1, 2]}))"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-macos-${{ matrix.platform.target }}-cp${{ matrix.python }}
           path: dist
 
   sdist:

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,219 @@
+---
+name: Build wheels
+
+# Reusable workflow that builds the full wheel + sdist matrix. It is called by
+# release.yaml (with a release tag, to stamp the version) and by wheels.yaml
+# (without a tag, as a continuous build check). Keeping the matrix here, in one
+# place, guarantees CI builds the exact same artifacts the release publishes, so
+# a broken runner image or target is caught before a tag is ever cut.
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+    inputs:
+      release-tag:
+        description: >-
+          The release tag to stamp into the package version (e.g. v0.1.3). Leave
+          empty for a plain build check, which builds from the in-tree version.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  # manylinux wheels across architectures.
+  linux:
+    name: Wheels (manylinux ${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { runner: ubuntu-22.04, target: x86_64 }
+          - { runner: ubuntu-22.04, target: x86 }
+          - { runner: ubuntu-22.04, target: aarch64 }
+          - { runner: ubuntu-22.04, target: armv7 }
+          - { runner: ubuntu-22.04, target: ppc64le }
+          # s390x is intentionally omitted: the `psm` crate (pulled in by
+          # `stacker`, our recursion-depth guard) ships hand-written
+          # z/Architecture assembly that the manylinux s390x cross-image's
+          # binutils is too old to assemble (`Unrecognized opcode: lay`).
+          # There is no fixed psm/stacker release. The code itself is fine on
+          # big-endian s390x (built natively with a modern toolchain in
+          # tests-arch.yaml), so an s390x user can still build from the sdist;
+          # we just cannot cross-build a wheel here. Restore this target if
+          # psm gains a manylinux-compatible s390x build.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: 🏗 Set package version from release tag
+        if: inputs.release-tag != ''
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
+      - name: 🏗 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter '3.12 3.13 3.14'
+          manylinux: auto
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}
+          path: dist
+
+  # musllinux (Alpine) wheels.
+  musllinux:
+    name: Wheels (musllinux ${{ matrix.platform.target }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { target: x86_64 }
+          - { target: x86 }
+          - { target: aarch64 }
+          - { target: armv7 }
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: 🏗 Set package version from release tag
+        if: inputs.release-tag != ''
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
+      - name: 🏗 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter '3.12 3.13 3.14'
+          manylinux: musllinux_1_2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-musllinux-${{ matrix.platform.target }}
+          path: dist
+
+  windows:
+    name: Wheels (windows ${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { runner: windows-latest, target: x64, arch: x64 }
+          - { runner: windows-latest, target: x86, arch: x86 }
+          # Windows on ARM. Built natively on the windows-11-arm runner image
+          # (which ships Rust and Python), so maturin resolves the arm64
+          # interpreters exactly as the x64/x86 jobs do. setup-python has arm64
+          # builds for every CPython version we target.
+          - { runner: windows-11-arm, target: aarch64, arch: arm64 }
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          # All three interpreters must be present on the host: this runner is
+          # not containerized, so maturin resolves `--interpreter 3.12 3.13 3.14`
+          # against the installed Pythons (only 3.12 would yield only cp312).
+          python-version: |
+            3.12
+            3.13
+            3.14
+          architecture: ${{ matrix.platform.arch }}
+      - name: 🏗 Set package version from release tag
+        if: inputs.release-tag != ''
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
+      - name: 🏗 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter '3.12 3.13 3.14'
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: dist
+
+  macos:
+    name: Wheels (macos ${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          # macOS 26 (Tahoe) is the newest GA image and Apple's last Intel-
+          # supporting release, so macos-26-intel is the final Intel runner
+          # generation and has the longest runway. This replaces the previous
+          # pair: macos-13 (Intel), retired by GitHub in December 2025, and
+          # macos-14 (arm64), which begins deprecation in 2026.
+          - { runner: macos-26-intel, target: x86_64 }
+          - { runner: macos-26, target: aarch64 }
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          # All three interpreters must be present on the host: this runner is
+          # not containerized, so maturin resolves `--interpreter 3.12 3.13 3.14`
+          # against the installed Pythons (only 3.12 would yield only cp312).
+          python-version: |
+            3.12
+            3.13
+            3.14
+      - name: 🏗 Set package version from release tag
+        if: inputs.release-tag != ''
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
+      - name: 🏗 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter '3.12 3.13 3.14'
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+
+  sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: 🏗 Set package version from release tag
+        if: inputs.release-tag != ''
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
+      - name: 🏗 Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-sdist
+          path: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,12 +146,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # Intel macOS. macos-13 was the last plain Intel runner and was
-          # retired by GitHub in December 2025; macos-15-intel is its
-          # replacement. GitHub drops Intel macOS entirely after macos-15 is
-          # retired (Fall 2027), at which point this leg goes away.
-          - { runner: macos-15-intel, target: x86_64 }
-          - { runner: macos-14, target: aarch64 }
+          # macOS 26 (Tahoe) is the newest GA image and Apple's last Intel-
+          # supporting release, so macos-26-intel is the final Intel runner
+          # generation and has the longest runway. This replaces the previous
+          # pair: macos-13 (Intel), retired by GitHub in December 2025, and
+          # macos-14 (arm64), which begins deprecation in 2026.
+          - { runner: macos-26-intel, target: x86_64 }
+          - { runner: macos-26, target: aarch64 }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,7 +146,11 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: macos-13, target: x86_64 }
+          # Intel macOS. macos-13 was the last plain Intel runner and was
+          # retired by GitHub in December 2025; macos-15-intel is its
+          # replacement. GitHub drops Intel macOS entirely after macos-15 is
+          # retired (Fall 2027), at which point this leg goes away.
+          - { runner: macos-15-intel, target: x86_64 }
           - { runner: macos-14, target: aarch64 }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,200 +16,22 @@ permissions:
   contents: read
 
 jobs:
-  # manylinux wheels across architectures.
-  linux:
-    name: Wheels (manylinux ${{ matrix.platform.target }})
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: ubuntu-22.04, target: x86_64 }
-          - { runner: ubuntu-22.04, target: x86 }
-          - { runner: ubuntu-22.04, target: aarch64 }
-          - { runner: ubuntu-22.04, target: armv7 }
-          - { runner: ubuntu-22.04, target: ppc64le }
-          # s390x is intentionally omitted: the `psm` crate (pulled in by
-          # `stacker`, our recursion-depth guard) ships hand-written
-          # z/Architecture assembly that the manylinux s390x cross-image's
-          # binutils is too old to assemble (`Unrecognized opcode: lay`).
-          # There is no fixed psm/stacker release. The code itself is fine on
-          # big-endian s390x (built natively with a modern toolchain in
-          # tests-arch.yaml), so an s390x user can still build from the sdist;
-          # we just cannot cross-build a wheel here. Restore this target if
-          # psm gains a manylinux-compatible s390x build.
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.14"
-      - name: 🏗 Set package version from release tag
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
-          manylinux: auto
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
-
-  # musllinux (Alpine) wheels.
-  musllinux:
-    name: Wheels (musllinux ${{ matrix.platform.target }})
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { target: x86_64 }
-          - { target: x86 }
-          - { target: aarch64 }
-          - { target: armv7 }
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.14"
-      - name: 🏗 Set package version from release tag
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
-          manylinux: musllinux_1_2
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
-          path: dist
-
-  windows:
-    name: Wheels (windows ${{ matrix.platform.target }})
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: windows-latest, target: x64, arch: x64 }
-          - { runner: windows-latest, target: x86, arch: x86 }
-          # Windows on ARM. Built natively on the windows-11-arm runner image
-          # (which ships Rust and Python), so maturin resolves the arm64
-          # interpreters exactly as the x64/x86 jobs do. setup-python has arm64
-          # builds for every CPython version we target.
-          - { runner: windows-11-arm, target: aarch64, arch: arm64 }
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          # All three interpreters must be present on the host: this runner is
-          # not containerized, so maturin resolves `--interpreter 3.12 3.13 3.14`
-          # against the installed Pythons (only 3.12 would yield only cp312).
-          python-version: |
-            3.12
-            3.13
-            3.14
-          architecture: ${{ matrix.platform.arch }}
-      - name: 🏗 Set package version from release tag
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
-
-  macos:
-    name: Wheels (macos ${{ matrix.platform.target }})
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          # macOS 26 (Tahoe) is the newest GA image and Apple's last Intel-
-          # supporting release, so macos-26-intel is the final Intel runner
-          # generation and has the longest runway. This replaces the previous
-          # pair: macos-13 (Intel), retired by GitHub in December 2025, and
-          # macos-14 (arm64), which begins deprecation in 2026.
-          - { runner: macos-26-intel, target: x86_64 }
-          - { runner: macos-26, target: aarch64 }
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          # All three interpreters must be present on the host: this runner is
-          # not containerized, so maturin resolves `--interpreter 3.12 3.13 3.14`
-          # against the installed Pythons (only 3.12 would yield only cp312).
-          python-version: |
-            3.12
-            3.13
-            3.14
-      - name: 🏗 Set package version from release tag
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
-
-  sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.14"
-      - name: 🏗 Set package version from release tag
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: python .github/scripts/set_version.py "${RELEASE_TAG}"
-      - name: 🏗 Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          command: sdist
-          args: --out dist
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-sdist
-          path: dist
+  # Build the full wheel + sdist matrix via the shared reusable workflow, the
+  # same one wheels.yaml exercises on every build-config change, so the runners
+  # and targets are proven before a tag is ever cut. The release tag is passed
+  # in to stamp the package version.
+  build:
+    name: Build
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-wheels.yaml
+    with:
+      release-tag: ${{ github.event.release.tag_name }}
 
   release:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [build]
     environment:
       name: release
       url: https://pypi.org/p/yamlrocks

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,46 @@
+---
+name: Wheels
+
+# Continuously build the full wheel + sdist matrix (the same reusable workflow
+# the release uses), so a broken runner image, retired label, or target failure
+# is caught here instead of during a release. Three things trigger it:
+#   - changes to the build configuration (the workflows, crate manifests, or
+#     packaging metadata), which is exactly when the matrix can break;
+#   - a weekly schedule, to catch runner-image retirements and toolchain drift
+#     before they surface mid-release (a retired macos label, for example);
+#   - manual dispatch, to validate on demand right before cutting a tag.
+# It deliberately does not run on every source change: the test workflows and
+# tests-arch.yaml already cover that, and a full emulated matrix is expensive.
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/wheels.yaml"
+      - ".github/workflows/build-wheels.yaml"
+      - ".github/workflows/release.yaml"
+      - ".github/scripts/set_version.py"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "pyproject.toml"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays at 05:00 UTC
+
+# Cancel superseded runs for the same ref to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # No release tag, so the build uses the in-tree version. This is a pure build
+  # check: it proves every runner and target produces a wheel, nothing is
+  # published.
+  build:
+    name: Build
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-wheels.yaml


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Three releases in a row (v0.1.0, v0.1.1, v0.1.2) stalled on a wheel build leg that had never actually run, because the build matrix only ever executed during a real release. A Renovate Python pin, a retired s390x assembler, and a retired `macos-13` runner each surfaced only *after* a tag was cut. This PR fixes the immediate runner problem and removes the structural reason these keep slipping through.

**1. Fix the macOS runners.** `macos-13` (Intel x86_64) was retired by GitHub in December 2025, which is what stalled the v0.1.2 release: the job sat queued forever waiting for an image that no longer exists. `macos-14` (arm64) also begins deprecation in 2026. Both legs move to macOS 26: `macos-26-intel` for x86_64 and `macos-26` for arm64. macOS 26 (Tahoe) is Apple's last Intel-supporting release, so `macos-26-intel` is the final Intel runner generation and has the longest runway. Both are free standard runners.

**2. Build the wheels continuously, sharing one matrix with the release.** The build matrix is extracted into a reusable workflow, `build-wheels.yaml`, called from two places:

- `release.yaml` passes the release tag (to stamp the version) and then runs the unchanged publish job.
- a new `wheels.yaml` runs the same jobs as a build check: on changes to the build configuration (the workflows, crate manifests, `set_version.py`, packaging metadata), on a weekly schedule, and on demand via `workflow_dispatch`.

Because both paths call the *same* jobs, CI now builds the exact artifacts the release publishes. A broken runner image, a retired label, or a failing target is caught before a tag is cut, not during the release. The weekly run also surfaces runner-image retirements ahead of time (it would have caught `macos-13`). It deliberately does not run on every source change: the test workflows and `tests-arch.yaml` already cover that, and a full emulated matrix is expensive.

**3. Smoke-test every native wheel on its own platform and Python version.** The Windows and macOS matrices are split by CPython version (ABI): each job sets up one interpreter, builds that single ABI, and then imports the wheel it just built and round-trips a document. The job's only interpreter matches the wheel, so it tests exactly that artifact, no cross-platform interpreter juggling. So a wheel that builds but cannot import (wrong ABI, bad cross-compile, missing symbol) fails here. The brand-new `windows-11-arm` and `macos-26-intel` wheels, which had zero runtime coverage before, are now imported on real arm64 Windows and Intel macOS. The emulated manylinux/musllinux jobs stay multi-ABI and unsmoked, since the x86_64 host cannot import their cross-built wheels; `tests-arch.yaml` already runs the full suite on aarch64/armv7/ppc64le.

There is no change to what gets published or how; the publish job (validation, hash-pinned smoke test, SBOM, attestation, trusted publishing) is untouched and still gated on the full matrix succeeding.

Note: opening this PR triggers `wheels.yaml` (it touches the build workflows), so the full matrix, including the new macOS 26 and Windows arm64 legs, builds here. That green run is the proof the next release will go through.

Validated locally with prettier, actionlint, zizmor (pedantic), and codespell.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the stalled v0.1.2 release run
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
