### PR TITLE
👷 Test the musllinux wheels under a musl runtime (x86_64 native, ARM emulated)

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -246,8 +246,14 @@ jobs:
           name: wheels-linux-${{ matrix.target }}
           path: dist
 
-  # musllinux (Alpine) wheels. Only on the full matrix. Built here; importing a
-  # musl wheel needs an Alpine runtime, so runtime testing is handled separately.
+  # musllinux (Alpine) wheels. Only on the full matrix. Importing a musl wheel
+  # needs a musl runtime, so the x86_64 wheel is installed and the suite is run
+  # inside an Alpine container (native, no QEMU). The ARM musl wheels stay
+  # build-only on purpose: coverage has two axes, libc (glibc vs musl) and arch
+  # (x86_64 vs ARM). glibc is tested on x86_64/aarch64/armv7 (the linux and
+  # linux-cross jobs) and musl is tested on x86_64 here, so musl-on-ARM is the
+  # intersection of two already-covered axes and not worth doubling the slow
+  # emulated runs for. i686 stays build-only as elsewhere.
   musllinux:
     name: musllinux ${{ matrix.target }}
     if: inputs.full
@@ -260,6 +266,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: ⤵️ Check out the YAML test suite submodule
+        run: |
+          git config --global core.autocrlf false
+          git submodule update --init tests/data/yaml_test_suite/cases
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
@@ -275,6 +285,24 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.12 3.13 3.14'
           manylinux: musllinux_1_2
+      - name: 🧪 Test the built wheel on Alpine (musl)
+        # x86_64 only: native musl runtime, no emulation. Tests the container's
+        # CPython (one version) for the same reason as the emulated legs, the
+        # arch/libc behaviour is version-independent and every version is covered
+        # by the native legs. Deps are unpinned for parity with those legs.
+        if: matrix.target == 'x86_64'
+        shell: bash
+        # python:3.13-alpine, pinned by digest (Renovate keeps it current).
+        run: |
+          docker run --rm -v "${PWD}:/io" -w /io \
+            python:3.13-alpine@sha256:d67e0c999afea29aa8e07a201cf653a7e5379a1b32530f433f26cfcfd94ef367 \
+            sh -ec '
+              python3 -m venv /tmp/venv
+              . /tmp/venv/bin/activate
+              pip install --quiet pytest pytest-asyncio pyyaml
+              pip install --quiet --no-index --no-deps --find-links dist yamlrocks
+              pytest -q
+            '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-musllinux-${{ matrix.target }}

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -247,13 +247,10 @@ jobs:
           path: dist
 
   # musllinux (Alpine) wheels. Only on the full matrix. Importing a musl wheel
-  # needs a musl runtime, so the x86_64 wheel is installed and the suite is run
-  # inside an Alpine container (native, no QEMU). The ARM musl wheels stay
-  # build-only on purpose: coverage has two axes, libc (glibc vs musl) and arch
-  # (x86_64 vs ARM). glibc is tested on x86_64/aarch64/armv7 (the linux and
-  # linux-cross jobs) and musl is tested on x86_64 here, so musl-on-ARM is the
-  # intersection of two already-covered axes and not worth doubling the slow
-  # emulated runs for. i686 stays build-only as elsewhere.
+  # needs a musl runtime, so every shipped musl wheel is installed and the suite
+  # is run against it under Alpine: x86_64 natively, aarch64 and armv7 in an
+  # emulated Alpine container. i686 stays build-only, the same 32-bit-x86 tier as
+  # manylinux i686 (and pyyaml has no musllinux i686 wheel to test against).
   musllinux:
     name: musllinux ${{ matrix.target }}
     if: inputs.full
@@ -285,11 +282,10 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.12 3.13 3.14'
           manylinux: musllinux_1_2
-      - name: 🧪 Test the built wheel on Alpine (musl)
-        # x86_64 only: native musl runtime, no emulation. Tests the container's
-        # CPython (one version) for the same reason as the emulated legs, the
-        # arch/libc behaviour is version-independent and every version is covered
-        # by the native legs. Deps are unpinned for parity with those legs.
+      - name: 🧪 Test the built wheel on Alpine (musl, native x86_64)
+        # Native musl runtime, no emulation. Tests the image's CPython (one
+        # version) for the same reason as the emulated legs: arch/libc behaviour
+        # is version-independent and every version is covered by the native legs.
         if: matrix.target == 'x86_64'
         shell: bash
         # python:3.13-alpine, pinned by digest (Renovate keeps it current).
@@ -303,6 +299,25 @@ jobs:
               pip install --quiet --no-index --no-deps --find-links dist yamlrocks
               pytest -q
             '
+      - name: 🧪 Test the built wheel on Alpine (musl, emulated)
+        # aarch64/armv7 musl wheels run the suite in an emulated Alpine container.
+        # pyyaml comes from Alpine's py3-yaml (a prebuilt musl package) so nothing
+        # has to compile under QEMU; pytest is pure Python via pip. Installs into
+        # the system interpreter (--break-system-packages) since Alpine marks it
+        # externally managed.
+        if: matrix.target == 'aarch64' || matrix.target == 'armv7'
+        uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
+        with:
+          arch: ${{ matrix.target }}
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          install: |
+            apk add --no-cache python3 py3-pip py3-yaml
+          run: |
+            pip install --break-system-packages --quiet pytest pytest-asyncio
+            pip install --break-system-packages --quiet \
+              --no-index --no-deps --find-links dist yamlrocks
+            pytest -q
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-musllinux-${{ matrix.target }}

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -305,6 +305,17 @@ jobs:
         # has to compile under QEMU; pytest is pure Python via pip. Installs into
         # the system interpreter (--break-system-packages) since Alpine marks it
         # externally managed.
+        #
+        # `alpine_latest` is intentionally not pinned to a specific Alpine
+        # release: run-on-arch only ships that one Alpine preset (and it is what
+        # reliably wires up QEMU; a pinned base_image does not). Its system
+        # CPython always sits within the 3.12-3.14 range we build wheels for, so
+        # pip finds a matching wheel in dist. If Alpine ever ships a CPython we do
+        # not yet build, this fails loudly and we add that version to the build
+        # list (which we would do to support it anyway). Using base Alpine plus
+        # apk py3-yaml, rather than the digest-pinned python:alpine image, is
+        # deliberate: it gives a prebuilt musl pyyaml and avoids compiling it
+        # under QEMU on armv7.
         if: matrix.target == 'aarch64' || matrix.target == 'armv7'
         uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
         with:


### PR DESCRIPTION
## Breaking change

None. CI-only.

## Proposed change

The consolidated build-and-test engine builds the musllinux wheels but never ran them: a musl wheel needs a musl runtime, which the glibc host cannot provide, so the musllinux legs were build-only. This adds a runtime test for every musllinux wheel that can be run: the **x86_64** wheel in a native Alpine container (no QEMU), and the **aarch64** and **armv7** wheels in an emulated Alpine container. Each installs the just-built wheel and runs the full pytest suite against it, so a musl-specific break is caught before publish. (The published v0.1.3 musl wheel was confirmed to import and round-trip under Alpine while developing this.)

Only **i686** stays build-only, the same 32-bit-x86 tier as manylinux i686, and pyyaml ships no `musllinux_1_2_i686` wheel, so a test container would have to compile it under a 32-bit musl toolchain.

Mechanics worth noting:
- The native x86_64 step uses `python:3.13-alpine` pinned by digest (Renovate keeps it current).
- The emulated aarch64/armv7 steps use `run-on-arch` with base Alpine plus `apk py3-yaml`, so pyyaml is a prebuilt musl package and nothing compiles under QEMU. `alpine_latest` is intentionally unpinned, the workflow comment explains why (it is run-on-arch's only Alpine preset, its CPython always falls within the 3.12 to 3.14 range we build, and a future jump fails loudly).
- The musllinux job now checks out the YAML test-suite submodule so the in-container run includes the compliance corpus.

This runs only on the full matrix (push-to-main, weekly, manual, release), like the rest of the emulated/cross legs.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the test-flow consolidation (#31)
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
