### PR TITLE
👷 Run the suite against the manylinux i686 wheel natively

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,17 @@
     "automerge": true
   },
   "commitMessagePrefix": "⬆️",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the digest-pinned Python images that the wheel-test steps run with `docker run`. The built-in docker manager does not scan shell `run:` commands, so without this the pins would never be refreshed.",
+      "managerFilePatterns": ["/^\\.github/workflows/build-wheels\\.yaml$/"],
+      "matchStrings": [
+        "(?<depName>python):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["cargo"],

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -172,10 +172,10 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}-cp${{ matrix.python }}
           path: dist
 
-  # Cross-built Linux arches under QEMU. Only runs on the full matrix. The
-  # non-x86 wheels cannot be imported on the x86_64 host, so the testable arches
-  # (aarch64/armv7/ppc64le) install the built wheel and run the suite inside an
-  # emulated container; i686 is build-only.
+  # Cross-built Linux arches. Only runs on the full matrix. Every wheel is
+  # tested: aarch64/armv7/ppc64le install the built wheel and run the suite in an
+  # emulated container (the x86_64 host cannot import them), while i686 runs the
+  # suite in a 32-bit container natively on the x86_64 host (no QEMU needed).
   linux-cross:
     name: Linux ${{ matrix.target }} (emulated)
     if: inputs.full
@@ -208,8 +208,9 @@ jobs:
           args: --release --out dist --interpreter '3.12 3.13 3.14'
           manylinux: auto
       - name: 🧪 Test the built wheel under emulation
-        # i686 (x86) is 32-bit and not worth an emulated runtime; the other
-        # arches install the manylinux wheel and run the full suite in-container.
+        # aarch64/armv7/ppc64le install the manylinux wheel and run the full
+        # suite in an emulated container (i686 is handled natively in the next
+        # step instead, no QEMU needed for 32-bit on an x86_64 host).
         #
         # This runs against the container's default CPython (one version), not
         # all three that were built. That is deliberate: the purpose here is to
@@ -241,6 +242,23 @@ jobs:
             pip install pytest pytest-asyncio pyyaml
             pip install --no-index --no-deps --find-links dist yamlrocks
             pytest -q
+      - name: 🧪 Test the built wheel (i686, native 32-bit)
+        # i686 is 32-bit x86, which runs natively on the x86_64 host (no QEMU).
+        # Tests the image's CPython (one version) for the same reason as the
+        # emulated legs; pyyaml installs from its manylinux i686 wheel, so nothing
+        # compiles. python:3.13-slim, pinned by digest (Renovate keeps it current).
+        if: matrix.target == 'x86'
+        shell: bash
+        run: |
+          docker run --rm --platform linux/386 -v "${PWD}:/io" -w /io \
+            python:3.13-slim@sha256:f82c96458eedc847b233e582eb31336f4954b39cae020b6dcf5b3ed0e5cbcd74 \
+            sh -ec '
+              python3 -m venv /tmp/venv
+              . /tmp/venv/bin/activate
+              pip install --quiet pytest pytest-asyncio pyyaml
+              pip install --quiet --no-index --no-deps --find-links dist yamlrocks
+              pytest -q
+            '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-${{ matrix.target }}

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -267,8 +267,10 @@ jobs:
   # musllinux (Alpine) wheels. Only on the full matrix. Importing a musl wheel
   # needs a musl runtime, so every shipped musl wheel is installed and the suite
   # is run against it under Alpine: x86_64 natively, aarch64 and armv7 in an
-  # emulated Alpine container. i686 stays build-only, the same 32-bit-x86 tier as
-  # manylinux i686 (and pyyaml has no musllinux i686 wheel to test against).
+  # emulated Alpine container. musllinux i686 is the one wheel that stays
+  # build-only: unlike manylinux i686 (tested natively above), pyyaml ships no
+  # musllinux i686 wheel, so a test container would have to compile it under a
+  # 32-bit musl toolchain.
   musllinux:
     name: musllinux ${{ matrix.target }}
     if: inputs.full


### PR DESCRIPTION
## Breaking change

None. CI-only.

## Proposed change

i686 was the last shipped Linux wheel without a runtime test, the `linux-cross` job built it but skipped it (`if: matrix.target != 'x86'`). This adds a native runtime test for it.

i686 is 32-bit x86, which runs natively on the x86_64 runner with no QEMU, so the built manylinux i686 wheel is installed and the full pytest suite is run against it inside a pinned 32-bit `python:3.13-slim` container (`--platform linux/386`). pyyaml installs from its own manylinux i686 wheel, so nothing has to compile. The published v0.1.3 i686 wheel was confirmed to import and round-trip under 32-bit glibc while developing this (pointer size 4).

After this, **every shipped Linux wheel is runtime-tested**: glibc on x86_64/aarch64/armv7/ppc64le/i686, and musl on x86_64/aarch64/armv7. The only remaining build-only wheel anywhere is `musllinux` i686, which has no `musllinux_1_2_i686` pyyaml wheel to test against, the documented exception.

Runs only on the full matrix (push-to-main, weekly, manual, release), like the rest of `linux-cross`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the test-flow consolidation (#31) and musl wheel testing (#34)
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
