### PR TITLE
⚡ Format integers on the dumps path with itoa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +290,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "dunce",
+ "itoa",
  "pyo3",
  "smallvec",
  "stacker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ ahash = "0.8"
 # include-path confinement and the paths returned by `save()` compare and read
 # back the same on every platform.
 dunce = "1"
+# Fast integer-to-decimal formatting for the dumps hot path, avoiding the slower
+# generic `core::fmt` machinery (same digits, just a tighter specialized path).
+itoa = "1"
 pyo3 = { version = "0.29", features = ["extension-module", "py-clone"] }
 smallvec = "1"
 # Grows the native stack on demand so recursive descent over deeply nested input

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -10,7 +10,7 @@ change. Do not edit it by hand.
 
 ## Summary
 
-- MIT License: 31 crate(s)
+- MIT License: 32 crate(s)
 - Apache License 2.0: 3 crate(s)
 - Unicode License v3: 1 crate(s)
 
@@ -940,6 +940,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
+- [itoa 1.0.18](https://crates.io/crates/itoa)
 - [once_cell 1.21.4](https://crates.io/crates/once_cell)
 - [portable-atomic 1.13.1](https://crates.io/crates/portable-atomic)
 - [proc-macro2 1.0.106](https://crates.io/crates/proc-macro2)

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -16,8 +16,6 @@
 
 pub mod json;
 
-use std::io::Write as _;
-
 use crate::decode::Value;
 use crate::resolver::{ScalarKind, Schema};
 use crate::scanner::ScalarStyle;
@@ -370,10 +368,12 @@ impl<'a> Emitter<'a> {
                 .extend_from_slice(self.options.null_style.inline_token().as_bytes()),
             Value::Bool(true) => self.buf.extend_from_slice(b"true"),
             Value::Bool(false) => self.buf.extend_from_slice(b"false"),
-            // Format the integer straight into the output buffer (writing to a
-            // `Vec<u8>` is infallible), avoiding a throwaway `String` per int.
+            // Format the integer straight into the output buffer via itoa, a
+            // specialized integer formatter that is faster than `core::fmt` and
+            // produces the exact same digits, with no throwaway `String` per int.
             Value::Int(i) => {
-                let _ = write!(self.buf, "{i}");
+                let mut itoa_buf = itoa::Buffer::new();
+                self.buf.extend_from_slice(itoa_buf.format(*i).as_bytes());
             }
             // A big integer is already its exact decimal text; emit it verbatim
             // (it is all digits with an optional sign, so it needs no quoting).


### PR DESCRIPTION
## Breaking change

None. Emitted bytes are byte-for-byte identical; this is an internal hot-path change.

## Proposed change

The emit hot path formatted each integer with `write!(self.buf, "{i}")`, which goes through the generic `core::fmt` machinery. This switches to the `itoa` crate: a specialized integer-to-decimal formatter that produces the exact same digits on a tighter path, with no throwaway allocation. Big integers are unaffected, they are already stored as their exact decimal text (`Value::BigInt`) and emitted verbatim.

This was on the profiled `dumps` shortlist (~0.5 to 1%, +1 small dependency). CodSpeed will report the measured delta on this PR.

Verified the output digits are unchanged across the full `i64` range (0, negatives, and `i64::MIN`/`i64::MAX`) and that they round-trip, plus the whole `pytest` suite passes. The now-unused `use std::io::Write as _;` import is removed. `Cargo.lock` and `THIRD_PARTY_LICENSES.md` are regenerated for the new `itoa` dependency.

Validated locally against current main: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (140 passed), and the full `pytest` suite.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the loads/dumps profiling work (follow-up to the ahash/buffer PR #37)
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
