### PR TITLE
🔧 Refresh the oss-fuzz base image only once a month

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -85,6 +85,13 @@
       "matchManagers": ["github-actions"],
       "matchDepNames": ["python"],
       "enabled": false
+    },
+    {
+      "description": "The oss-fuzz base image republishes its :latest digest daily, which otherwise opens a digest-bump PR every day. Refresh the fuzzing base image only once a month.",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["gcr.io/oss-fuzz-base/base-builder-rust"],
+      "addLabels": ["maintenance"],
+      "schedule": ["before 3am on the first day of the month"]
     }
   ]
 }


### PR DESCRIPTION
## Breaking change

None. Renovate configuration only.

## Proposed change

`gcr.io/oss-fuzz-base/base-builder-rust:latest` (the base image for the ClusterFuzzLite Dockerfile) republishes its `:latest` digest **daily**, so Renovate's `helpers:pinGitHubActionDigests`/dockerfile digest pinning was opening a digest-bump PR for it every single day (#42, #46, ...).

This adds a `packageRule` that schedules just that one image to refresh **once a month** (`before 3am on the first day of the month`), the same cadence already used for the real-world corpus submodules. The pin is still kept current, just monthly instead of daily, so the fuzzing base image stays fresh without the daily PR noise. No other dependency is affected.

Validated with `renovate-config-validator` (config validated successfully) and `prettier@3.4.2`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the daily oss-fuzz base-image digest PRs (#42, #46)
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
