### PR TITLE
⚡ Build, test, and ship free-threaded (cp314t) wheels

### DIFF
--- a/.github/scripts/test_wheel.sh
+++ b/.github/scripts/test_wheel.sh
@@ -22,6 +22,14 @@ uv pip install --python "${pyexe}" --group numpy \
 # none of its own).
 uv pip install --python "${pyexe}" --no-index --no-deps --find-links dist yamlrocks
 
+# On a free-threaded (no-GIL) build, fail loudly if the GIL is actually enabled,
+# i.e. the build silently fell back to a GIL build or the import re-enabled it.
+# On a regular build Py_GIL_DISABLED is unset and this is a no-op.
+"${pyexe}" -c "import sys, sysconfig
+if sysconfig.get_config_var('Py_GIL_DISABLED'):
+    assert not sys._is_gil_enabled(), 'GIL is enabled on a free-threaded build'
+    print('free-threaded build: GIL is disabled')"
+
 # Run against the installed wheel via the exact interpreter the wheel was built
 # for and installed into, not whatever "python" happens to resolve to on PATH.
 "${pyexe}" -m pytest -q

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -49,7 +49,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.12", "3.13", "3.14"]
+        # 3.14t is the free-threaded (no-GIL) build. CPython declares
+        # free-threading supported from 3.14 (3.13t was experimental and PyO3
+        # 0.29 dropped it), and it exists only on 64-bit plus Windows x86, which
+        # is exactly these native targets. The emulated/musl legs do not build
+        # it yet.
+        python: ["3.12", "3.13", "3.14", "3.14t"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -92,7 +97,12 @@ jobs:
           - { runner: windows-latest, target: x64, arch: x64 }
           - { runner: windows-latest, target: x86, arch: x86 }
           - { runner: windows-11-arm, target: aarch64, arch: arm64 }
-        python: ["3.12", "3.13", "3.14"]
+        # 3.14t is the free-threaded (no-GIL) build. CPython declares
+        # free-threading supported from 3.14 (3.13t was experimental and PyO3
+        # 0.29 dropped it), and it exists only on 64-bit plus Windows x86, which
+        # is exactly these native targets. The emulated/musl legs do not build
+        # it yet.
+        python: ["3.12", "3.13", "3.14", "3.14t"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -140,7 +150,12 @@ jobs:
           # generation. Replaces the retired macos-13 and deprecating macos-14.
           - { runner: macos-26-intel, target: x86_64 }
           - { runner: macos-26, target: aarch64 }
-        python: ["3.12", "3.13", "3.14"]
+        # 3.14t is the free-threaded (no-GIL) build. CPython declares
+        # free-threading supported from 3.14 (3.13t was experimental and PyO3
+        # 0.29 dropped it), and it exists only on 64-bit plus Windows x86, which
+        # is exactly these native targets. The emulated/musl legs do not build
+        # it yet.
+        python: ["3.12", "3.13", "3.14", "3.14t"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,9 @@ name: Tests
 # The single entry point for testing. The wheel build-and-test matrix lives in
 # the reusable build-wheels.yaml (shared with release.yaml, so CI tests exactly
 # what the release ships); this workflow calls it and adds the checks that do
-# not need a built wheel (free-threaded, real-world corpus, Rust unit tests).
+# not need a built wheel (real-world corpus, Rust unit tests). Free-threaded
+# (no-GIL) is covered by the build matrix, which builds and tests the real
+# cp313t/cp314t wheels and asserts the GIL is disabled.
 #
 # On pull requests only the fast native targets build and test. On pushes to
 # main, the weekly schedule, and manual runs, the full matrix runs too (the
@@ -40,40 +42,6 @@ jobs:
     uses: ./.github/workflows/build-wheels.yaml
     with:
       full: ${{ github.event_name != 'pull_request' }}
-
-  free-threaded:
-    name: Free-threaded CPython (no-GIL)
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: ⤵️ Check out the YAML test suite submodule
-        # Just the compliance corpus, not the large real-world config submodules.
-        # Force LF: a CRLF checkout (the Windows default) changes the test data
-        # bytes and breaks byte-exact and control-character cases (e.g. G4RS).
-        run: |
-          git config --global core.autocrlf false
-          git submodule update --init tests/data/yaml_test_suite/cases
-      - name: 🏗 Set up uv and free-threaded Python 3.14
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-          python-version: "3.14t"
-      - name: 🏗 Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # zizmor: ignore[superfluous-actions,stale-action-refs] stable; canonical pinned Rust toolchain installer
-      - name: 🏗 Install dependencies
-        # numpy is omitted: free-threaded wheels are not universally published yet
-        # and the numpy tests skip cleanly when it is absent.
-        run: uv sync --locked --no-install-project --no-default-groups --group build --group test
-      - name: 🏗 Build and install yamlrocks
-        run: uv run --no-sync maturin develop --release
-      - name: 🚀 Run pytest with the GIL disabled
-        # Fail loudly if the build silently re-enabled the GIL.
-        run: |
-          uv run --no-sync python -c "import sys; assert not sys._is_gil_enabled(), 'GIL is enabled'"
-          uv run --no-sync pytest -q
 
   realworld:
     name: Real-world configs (multi-ecosystem)


### PR DESCRIPTION
## Breaking change

None. Adds new wheels; nothing existing changes.

## Proposed change

The docs advertise free-threaded ("nogil") CPython as a first-class target, and the code runs free-threaded (the CI free-threaded job proved it on every PR), but no `cp314t` wheels were ever built, so a free-threaded user fell back to a from-source build. This builds and ships them.

- Adds **3.14t** to the native build matrices (Linux x86_64, Windows x64/x86/arm64, macOS x86_64/arm64), the only targets where free-threaded exists per the `actions/python-versions` manifest. CPython declares free-threading supported from 3.14; **3.13t was experimental and PyO3 0.29 dropped it**, so only 3.14t is built. The emulated/musl legs do not build it yet (a follow-up).
- `test_wheel.sh` now asserts the GIL is actually disabled when the wheel is a free-threaded build, so a silent fallback to a GIL build fails loudly.
- Drops the standalone `free-threaded` job: the native legs now build and run the full suite against the real `cp314t` wheels plus that GIL assertion, which strictly supersedes the old dev-build, ubuntu-only check.

Since the native tier runs on pull requests, this PR's own CI builds and tests the `cp314t` wheels.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the test-flow consolidation (#31); needed PyO3 0.29 (#44) which dropped 3.13t
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
