### PR TITLE
⚡ Build free-threaded wheels for emulated aarch64 and musllinux 64-bit

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -220,7 +220,13 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
+          # aarch64 also builds the free-threaded wheel (cp314t): it is the only
+          # 64-bit arch here, and free-threaded CPython exists only on 64-bit.
+          # armv7 and ppc64le have no free-threaded build. These cp314t wheels are
+          # build-only (shipped, not run): a free-threaded interpreter is not
+          # readily available in the emulated container, and free-threaded runtime
+          # behaviour is already exercised natively on x86_64.
+          args: "--release --out dist --interpreter '3.12 3.13 3.14${{ matrix.target == 'aarch64' && ' 3.14t' || '' }}'"
           manylinux: auto
       - name: 🧪 Test the built wheel under emulation
         # aarch64/armv7/ppc64le install the manylinux wheel and run the full
@@ -274,7 +280,7 @@ jobs:
               python3 -m venv /tmp/venv
               . /tmp/venv/bin/activate
               pip install --quiet --require-hashes -r .github/scripts/test-requirements.txt
-              pip install --quiet --no-deps dist/*cp314*.whl
+              pip install --quiet --no-deps dist/*cp314-cp314-*.whl
               pytest -q
             '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -318,7 +324,13 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.12 3.13 3.14'
+          # x86_64 and aarch64 also build the free-threaded wheel (cp314t): they
+          # are the 64-bit arches, and free-threaded CPython exists only on
+          # 64-bit (x86 and armv7 are 32-bit, no free-threaded build). The cp314t
+          # musl wheels are build-only (shipped, not run): there is no
+          # free-threaded musl interpreter image to test them in, and
+          # free-threaded runtime behaviour is exercised natively on x86_64.
+          args: "--release --out dist --interpreter '3.12 3.13 3.14${{ (matrix.target == 'x86_64' || matrix.target == 'aarch64') && ' 3.14t' || '' }}'"
           manylinux: musllinux_1_2
       - name: 🧪 Test the built wheel on Alpine (musl, native x86_64)
         # Native musl runtime, no emulation. Tests the image's CPython (one
@@ -338,7 +350,7 @@ jobs:
               python3 -m venv /tmp/venv
               . /tmp/venv/bin/activate
               pip install --quiet --require-hashes -r .github/scripts/test-requirements.txt
-              pip install --quiet --no-deps dist/*cp314*.whl
+              pip install --quiet --no-deps dist/*cp314-cp314-*.whl
               pytest -q
             '
       - name: 🧪 Test the built wheel on Alpine (musl, emulated)


### PR DESCRIPTION
## Breaking change

None. Adds new wheels; nothing existing changes.

## Proposed change

Extends the free-threaded (`cp314t`) wheels, shipped for the native legs in #48, to the 64-bit emulated/musl targets, so free-threaded users on ARM Linux and Alpine get a prebuilt wheel instead of a from-source build:

- **manylinux aarch64** (the only 64-bit arch in `linux-cross`) now builds `cp314t`.
- **musllinux x86_64 and aarch64** now build `cp314t`.

`armv7`, `ppc64le`, and the `i686` legs are unchanged: they are 32-bit, or have no free-threaded CPython build. Free-threaded exists only on 64-bit.

The new `cp314t` wheels are **build-only** (shipped, not run): there is no free-threaded interpreter image readily available for the emulated/musl containers (`python:3.14t-alpine` does not exist), and free-threaded runtime behaviour is already exercised natively on x86_64 in #48. This matches the existing rationale that arch/libc behaviour is Python-version-independent and the per-version PyO3 boundary is covered by the native legs.

To make room for the new ABI, the native x86_64 and i686 wheel-test globs are tightened from `*cp314*` to `*cp314-cp314-*`, so they keep selecting the GIL wheel and never accidentally match the `cp314t` one.

The interpreter list is computed per target (only the free-threaded-capable 64-bit arches get `3.14t`).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: native free-threaded wheels (#48)
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [ ] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
