### PR TITLE
⚡ Import asyncio lazily so `import yamlrocks` stays cheap

### DIFF
--- a/pysrc/yamlrocks/__init__.py
+++ b/pysrc/yamlrocks/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import os
 from collections.abc import Callable, Iterator
@@ -583,6 +582,11 @@ async def async_loads(
     on_missing_env_var: Callable[[str, str | None, int], None] | None = None,
 ) -> Any:
     """Parse YAML off the event loop thread; see :func:`loads`."""
+    # Imported lazily, not at module top, so `import yamlrocks` does not pull in
+    # asyncio (and its transitive ssl / logging / concurrent.futures), which
+    # otherwise dominates import time on the sync path. See issue #52.
+    import asyncio
+
     return await asyncio.to_thread(
         loads,
         data,
@@ -615,6 +619,8 @@ async def async_load(
     Both the disk read and the parse run in a worker thread, so this is the
     natural call for loading configuration inside an async application.
     """
+    import asyncio  # lazy; see async_loads (issue #52)
+
     return await asyncio.to_thread(
         load,
         source,
@@ -638,6 +644,8 @@ async def async_load_all(
     tags: dict[str, Callable[[Any], Any]] | None = None,
 ) -> list[Any]:
     """Read and parse a multi-document file off the event loop; see :func:`load_all`."""
+    import asyncio  # lazy; see async_loads (issue #52)
+
     return await asyncio.to_thread(
         load_all,
         source,
@@ -662,6 +670,8 @@ async def async_dump(
 
     The serialization and the disk write both run in a worker thread.
     """
+    import asyncio  # lazy; see async_loads (issue #52)
+
     await asyncio.to_thread(
         dump,
         obj,

--- a/tests/features/test_async.py
+++ b/tests/features/test_async.py
@@ -23,6 +23,21 @@ def test_no_async_serializers():
     assert not hasattr(yamlrocks, "async_to_json")
 
 
+def test_import_does_not_pull_in_asyncio():
+    """`import yamlrocks` must not import asyncio: it is imported lazily inside the
+    async_* helpers, so the sync import path stays cheap (issue #52)."""
+    import subprocess
+    import sys
+
+    code = "import sys, yamlrocks; sys.exit(1 if 'asyncio' in sys.modules else 0)"
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        f"importing yamlrocks pulled in asyncio; keep it lazy.\n{result.stderr}"
+    )
+
+
 async def test_async_loads_matches_loads():
     """async_loads returns the same result as loads."""
     src = b"name: app\nport: 8080\nlist:\n  - 1\n  - 2\n"


### PR DESCRIPTION
## Breaking change

None. The async API is unchanged; only the timing of the `asyncio` import moves.

## Proposed change

`pysrc/yamlrocks/__init__.py` imported `asyncio` at module top, but `asyncio` is only used by the `async_*` helpers (via `asyncio.to_thread`). That eager import dominated `import yamlrocks`: ~23 ms of a ~25 ms import, because `asyncio` transitively drags in `ssl`, `logging`, and `concurrent.futures`. For a one-shot CLI that loads a small config at startup, that import cost dwarfs the parse, and it made YAMLRocks the **slowest** of the common YAML libraries end-to-end on a small file (~49 ms/run) despite having the fastest parser.

This moves `import asyncio` into the four `async_*` helpers, where it is only reached at await-time. `import yamlrocks` no longer pulls in `asyncio`, taking the cost off the common sync path (the reporter measured roughly **10x faster** import, ~25 ms to ~2.5 ms), and the async API works exactly as before (asyncio loads on first await).

A regression test (`test_import_does_not_pull_in_asyncio`) runs a fresh interpreter and asserts `asyncio` is not in `sys.modules` after `import yamlrocks`, so this cannot silently come back.

Reported and diagnosed in impressive detail (with `-X importtime` numbers and a cross-library, fresh-process benchmark) by @pdecat. Thank you.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #52
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
