### PR TITLE
✅ Cover yaml-test-suite case variants in the compliance harness

### DIFF
--- a/tests/compliance/test_yaml_test_suite.py
+++ b/tests/compliance/test_yaml_test_suite.py
@@ -1,10 +1,12 @@
 """Compliance and round-trip tests against the official YAML test suite.
 
 The suite (https://github.com/yaml/yaml-test-suite) is a git submodule at
-``tests/data/yaml_test_suite/cases/``, tracking its ``data`` branch. Only the
-single-document cases (those with a top-level ``in.yaml``) are exercised; the
-multi-document cases, whose variants live in numbered subdirectories, are
-skipped. yamlrocks is a pragmatic YAML 1.2 parser rather than a fully
+``tests/data/yaml_test_suite/cases/``, tracking its ``data`` branch. Every case
+is exercised, including the variants a case stores in numbered subdirectories
+(``DE56/00``, ``KH5V/01``, ...); the case id is the path relative to the suite
+root. Multi-document inputs are loaded the same way as single-document ones:
+``loads`` resolves the first document, which is what the canonical-JSON match
+compares against. yamlrocks is a pragmatic YAML 1.2 parser rather than a fully
 spec-complete one, so a behavior baseline in ``expectations.json`` records the
 cases it does not yet handle. The category auto-skips when the submodule is not
 checked out, so a plain ``pytest`` stays green without it.
@@ -46,12 +48,15 @@ import yamlrocks
 
 SUITE_DIR = pathlib.Path(__file__).resolve().parents[1] / "data" / "yaml_test_suite"
 CASES_DIR = SUITE_DIR / "cases"
+# A case is any directory holding an ``in.yaml``. Most sit at the top level, but
+# a case with several variants stores each under a numbered subdirectory, so the
+# search recurses and the case id is the path relative to the suite root.
 CASES = (
-    sorted(p for p in CASES_DIR.iterdir() if (p / "in.yaml").exists())
+    sorted((p.parent for p in CASES_DIR.rglob("in.yaml")), key=lambda p: p.as_posix())
     if CASES_DIR.is_dir()
     else []
 )
-CASE_IDS = [p.name for p in CASES]
+CASE_IDS = [c.relative_to(CASES_DIR).as_posix() for c in CASES]
 
 if not CASES:
     # The suite lives in a git submodule (see `.gitmodules`). Without it the
@@ -108,16 +113,26 @@ def canonical_json(case_id: str):
 
 
 # Parse every case once; downstream tests and guards read from this.
-_PARSED = {c.name: try_load(c) for c in CASES}
+_PARSED = {cid: try_load(c) for c, cid in zip(CASES, CASE_IDS, strict=True)}
 PARSEABLE_IDS = [name for name in CASE_IDS if _PARSED[name][0]]
 NONPARSING_IDS = {name for name in CASE_IDS if not _PARSED[name][0]}
-JSON_CASE_IDS = {c.name for c in CASES if (c / "in.json").exists()}
-ERROR_CASES = sorted(c.name for c in CASES if (c / "error").exists())
-# Parseable cases with a canonical JSON that are not baselined as a mismatch.
+JSON_CASE_IDS = {
+    cid for c, cid in zip(CASES, CASE_IDS, strict=True) if (c / "in.json").exists()
+}
+ERROR_CASES = sorted(
+    cid for c, cid in zip(CASES, CASE_IDS, strict=True) if (c / "error").exists()
+)
+# Parseable, valid cases with a canonical JSON that are not baselined as a
+# mismatch. Error cases are excluded: some carry an ``in.json`` showing what a
+# lenient parser yields, but their canonical answer is "reject", so they are
+# governed by ``error_accepted`` rather than compared against that JSON.
+_ERROR_CASE_SET = set(ERROR_CASES)
 JSON_MATCH_IDS = [
     name
     for name in PARSEABLE_IDS
-    if name in JSON_CASE_IDS and name not in JSON_MISMATCH
+    if name in JSON_CASE_IDS
+    and name not in JSON_MISMATCH
+    and name not in _ERROR_CASE_SET
 ]
 
 
@@ -254,8 +269,8 @@ def test_suite_baseline_counts():
     # `parse_failures` shrinks, so it is the honest regression floor.
     error_ids = set(ERROR_CASES)
     valid_parseable = [name for name in PARSEABLE_IDS if name not in error_ids]
-    assert len(valid_parseable) >= 242, (
-        f"only {len(valid_parseable)} valid cases parse (expected >= 242)"
+    assert len(valid_parseable) >= 306, (
+        f"only {len(valid_parseable)} valid cases parse (expected >= 306)"
     )
     # Round-trip instability is not tolerated at all.
     assert len(ROUNDTRIP_UNSTABLE) == 0

--- a/tests/compliance/test_yaml_test_suite.py
+++ b/tests/compliance/test_yaml_test_suite.py
@@ -182,9 +182,9 @@ def test_json_mismatch_still_mismatches(case_id):
     """A baselined JSON mismatch still parses and still differs from canonical.
 
     When the parser learns to resolve one correctly this fails, prompting its
-    removal from ``json_mismatch`` (the baseline only shrinks). The baseline is
-    currently drained to zero; the ``[None]`` fallback keeps this a passing test
-    rather than an empty-parameter skip until a future mismatch is baselined.
+    removal from ``json_mismatch`` (the baseline only shrinks). The ``[None]``
+    fallback keeps this a passing test rather than an empty-parameter skip when
+    the baseline happens to be empty.
     """
     if case_id is None:
         assert not JSON_MISMATCH

--- a/tests/data/yaml_test_suite/expectations.json
+++ b/tests/data/yaml_test_suite/expectations.json
@@ -1,10 +1,15 @@
 {
   "_comment": "Behavior baseline for the yaml-test-suite submodule. YAMLRocks is a pragmatic YAML 1.2 parser; these lists record cases it does not yet handle so the suite guards against regressions. Shrinking these lists is an improvement (regenerate with tests/data/yaml_test_suite/generate_expectations.py).",
   "roundtrip_unstable": [],
-  "json_mismatch": [],
+  "json_mismatch": [
+    "JEF9/01",
+    "JEF9/02"
+  ],
   "rejected": [
     "236B",
     "2CMS",
+    "2G84/00",
+    "2G84/01",
     "3HFZ",
     "4EJS",
     "4H7K",
@@ -27,6 +32,7 @@
     "9KBC",
     "9MAG",
     "9MMA",
+    "9MQT/01",
     "B63P",
     "BD7L",
     "BF9H",
@@ -39,6 +45,7 @@
     "CXX2",
     "D49Q",
     "DK4H",
+    "DK95/06",
     "DMG6",
     "EB22",
     "EW3V",
@@ -55,6 +62,7 @@
     "JY7Z",
     "KS4U",
     "LHL4",
+    "MUS6/00",
     "N4JP",
     "N782",
     "P2EQ",
@@ -74,14 +82,29 @@
     "TD5N",
     "U44R",
     "U99R",
+    "VJP3/00",
     "W9L4",
     "X4QW",
+    "Y79Y/009",
     "YJV2",
     "ZCZ6",
     "ZL4Z",
     "ZVH3",
     "ZXT5"
   ],
-  "error_accepted": [],
-  "parse_failures": ["V9D5"]
+  "error_accepted": [
+    "DK95/01",
+    "MUS6/01",
+    "Y79Y/000",
+    "Y79Y/003",
+    "Y79Y/004",
+    "Y79Y/005",
+    "Y79Y/006",
+    "Y79Y/007",
+    "Y79Y/008"
+  ],
+  "parse_failures": [
+    "DK95/00",
+    "V9D5"
+  ]
 }

--- a/tests/data/yaml_test_suite/generate_expectations.py
+++ b/tests/data/yaml_test_suite/generate_expectations.py
@@ -40,13 +40,11 @@ for c in sorted((p.parent for p in base.rglob("in.yaml")), key=lambda p: p.as_po
         parsed = True
     except Exception:
         parsed = False
-    if is_err and not has_json and not parsed:
-        # Correctly rejected an invalid document; nothing to round-trip.
-        rejected.append(cid)
-        continue
     if is_err and not parsed:
-        # An invalid document with an in.json (showing a lenient parse) that we
-        # still reject. Correct behavior, tracked like any other rejection.
+        # Correctly rejected an invalid document; nothing to round-trip. Some
+        # error cases carry an in.json showing what a lenient parser yields, but
+        # rejecting them is the right answer, so they are tracked like any other
+        # rejection whether or not that in.json is present.
         rejected.append(cid)
         continue
     if is_err and parsed:

--- a/tests/data/yaml_test_suite/generate_expectations.py
+++ b/tests/data/yaml_test_suite/generate_expectations.py
@@ -27,12 +27,11 @@ roundtrip_unstable, json_mismatch, rejected, error_accepted, parse_failures = (
     [],
     [],
 )
-for c in sorted(base.iterdir()):
-    if not (c / "in.yaml").exists():
-        # Skip non-case entries: the submodule's `.git` pointer and the
-        # multi-document cases whose variants live in numbered subdirectories
-        # (these have no top-level `in.yaml`), matching the test harness filter.
-        continue
+# Every directory with an ``in.yaml`` is a case, including the variants stored
+# under numbered subdirectories (``DE56/00``, ...); the id is the path relative
+# to the suite root, matching the test harness.
+for c in sorted((p.parent for p in base.rglob("in.yaml")), key=lambda p: p.as_posix()):
+    cid = c.relative_to(base).as_posix()
     inp = (c / "in.yaml").read_bytes()
     is_err = (c / "error").exists()
     has_json = (c / "in.json").exists()
@@ -43,34 +42,42 @@ for c in sorted(base.iterdir()):
         parsed = False
     if is_err and not has_json and not parsed:
         # Correctly rejected an invalid document; nothing to round-trip.
-        rejected.append(c.name)
+        rejected.append(cid)
+        continue
+    if is_err and not parsed:
+        # An invalid document with an in.json (showing a lenient parse) that we
+        # still reject. Correct behavior, tracked like any other rejection.
+        rejected.append(cid)
         continue
     if is_err and parsed:
         # The suite marks this input invalid, but the pragmatic parser accepts
         # it. Track the laxness so it cannot grow silently and can only shrink.
-        error_accepted.append(c.name)
+        error_accepted.append(cid)
     if not is_err and not parsed:
         # A valid document the pragmatic parser does not handle yet. Baselined
         # so the gap is visible and can only shrink as the parser improves.
-        parse_failures.append(c.name)
+        parse_failures.append(cid)
     if parsed:
         # Round-trip must be byte-for-byte identical for an unmodified document.
         try:
             emitted = yamlrocks.loads(inp, option=yamlrocks.OPT_ROUND_TRIP).to_yaml()
             if emitted != inp:
-                roundtrip_unstable.append(c.name)
+                roundtrip_unstable.append(cid)
         except Exception:
-            roundtrip_unstable.append(c.name)
-    if has_json and parsed:
+            roundtrip_unstable.append(cid)
+    if has_json and parsed and not is_err:
+        # Only valid cases are compared against their canonical JSON. An error
+        # case's answer is "reject", so a lenient accept is governed by
+        # error_accepted, not by matching the JSON a lenient parser would yield.
         raw = (c / "in.json").read_text().lstrip()
         try:
             # An empty in.json means the stream yields no document, which loads
             # as None (comment-only / empty inputs).
             expected = None if not raw else json.JSONDecoder().raw_decode(raw)[0]
             if not jequal(val, expected):
-                json_mismatch.append(c.name)
+                json_mismatch.append(cid)
         except Exception:
-            json_mismatch.append(c.name)
+            json_mismatch.append(cid)
 
 out = {
     "_comment": "Behavior baseline for the yaml-test-suite submodule. YAMLRocks is a "


### PR DESCRIPTION
## Breaking change

None. This is test infrastructure only; no library code changes.

## Proposed change

The compliance harness only ran the top-level YAML test suite cases and skipped the variants a case stores in numbered subdirectories (`DE56/00`, `KH5V/01`, ...), 69 inputs in all. That blind spot is where #77 found real failures. This walks the suite recursively so every case is exercised (333 cases to 402), with the case id as the path relative to the suite root. Multi-document inputs load the same way as single-document ones: `loads` resolves the first document, which is what the canonical-JSON match already compares against.

Error cases are now excluded from JSON matching. Some carry an `in.json` showing what a lenient parser yields, but their canonical answer is "reject", so they belong to the `error_accepted` baseline rather than being compared against that JSON. The generator (`generate_expectations.py`) gets the same recursion and exclusion so it stays in sync with the harness.

The baseline is regenerated to pin the newly visible behavior, and the valid-case floor is raised from 242 to 306. Nothing regresses: 0 round-trip instabilities, no robustness failures. The remaining gaps stay tracked so they can only shrink, each one a precise to-do item for a follow-up fix:

- `json_mismatch`: `JEF9/01`, `JEF9/02` (block-scalar keep-chomp over a whitespace-only line)
- `parse_failures`: `DK95/00` (a valid document we wrongly reject) plus the known `V9D5`
- `error_accepted`: `DK95/01`, `MUS6/01`, `Y79Y/000`, `Y79Y/003`..`008` (invalid inputs we are currently too lenient about, all tab-related)
- `rejected`: the variant error cases we correctly refuse

With the escaped-tab fix from #80 in, this puts behavioral conformance at roughly 96.8% across the full 402-case suite, with every gap now visible in CI. Related to #77.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #77
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
