### PR TITLE
🐛 Reject a directive that does not start a document

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -79,6 +79,11 @@ pub struct Scanner<'input> {
     /// Whether the cursor is still on the line of a `---` document-start marker.
     /// A block collection may not begin inline there (`--- key: value`).
     on_doc_start_line: bool,
+    /// Whether a `%` directive is allowed at the current point: only at the start
+    /// of the stream or right after a `...` document-end marker. Any document
+    /// content or a `---` start closes the window; a `...` reopens it. A directive
+    /// reached while closed (`%YAML 1.2\n---\n%YAML 1.2`) is invalid.
+    directives_allowed: bool,
     /// Source line on which the outermost open flow collection began. Used to
     /// reject a multiline flow collection used as an implicit mapping key.
     flow_start_line: u32,
@@ -161,6 +166,7 @@ impl<'input> Scanner<'input> {
             unwound_block_level: false,
             simple_key: None,
             tab_before_token: false,
+            directives_allowed: true,
             stream_started: false,
             stream_ended: false,
             simple_key_allowed: true,
@@ -392,6 +398,16 @@ impl<'input> Scanner<'input> {
         // entry can tell whether it follows an empty parent entry.
         let after_entry = self.after_block_entry;
         self.after_block_entry = false;
+        // Directives are only valid before a document. A `%` keeps the window
+        // open and `...` reopens it (handled in their fetchers); anything else
+        // here, document content or a `---` start, closes it.
+        let is_directive = ch == '%' && self.reader.column() == 0;
+        let is_doc_end = ch == '.'
+            && self.reader.check_ahead("...")
+            && self.reader.peek_at(3).map_or(true, is_whitespace_or_break);
+        if !is_directive && !is_doc_end {
+            self.directives_allowed = false;
+        }
         match ch {
             '-' if self.reader.check_next_is_blank()
                 || self.reader.check_next_is_break_or_eof() =>
@@ -664,12 +680,23 @@ impl<'input> Scanner<'input> {
             ));
         }
         self.simple_key_allowed = false;
+        // A `...` ends the document, so directives may introduce the next one.
+        self.directives_allowed = true;
         self.tokens
             .push_back(Token::new(TokenKind::DocumentEnd, span));
         Ok(())
     }
 
     fn fetch_directive(&mut self) -> Result<(), ScanError> {
+        // A directive is valid only at the start of the stream or right after a
+        // `...` document-end marker; otherwise the previous document is still
+        // open and must be closed with `...` first.
+        if !self.directives_allowed {
+            return Err(ScanError::new(
+                "a directive must start the stream or follow a document-end marker (...)",
+                self.reader.span(),
+            ));
+        }
         self.unwind_indents(-1);
         let span = self.reader.span();
         self.reader.advance(); // skip '%'

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -102,3 +102,21 @@ def test_tab_in_document_level_quoted_continuation_is_separation():
     """A document-level quoted scalar has no block to out-indent, so a leading
     tab on its continuation line is just folded separation (spec example 7.6)."""
     assert yamlrocks.loads(b'"a\n\tb"\n') == "a b"
+
+
+def test_directive_after_open_document_is_rejected():
+    """A directive must start the stream or follow a `...` document-end marker.
+
+    The second `%YAML` here belongs to a new document, but the first was started
+    by `---` and never closed with `...`, so it is invalid (suite case MUS6/01).
+    """
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="directive"):
+        yamlrocks.loads_all(b"%YAML 1.2\n---\n%YAML 1.2\n---\n")
+
+
+def test_directive_after_document_end_is_allowed():
+    """A directive may introduce a new document once the previous one ended."""
+    assert yamlrocks.loads_all(b"%YAML 1.2\n---\nfoo\n...\n%YAML 1.2\n---\nbar\n") == [
+        "foo",
+        "bar",
+    ]

--- a/tests/data/yaml_test_suite/expectations.json
+++ b/tests/data/yaml_test_suite/expectations.json
@@ -61,6 +61,7 @@
     "KS4U",
     "LHL4",
     "MUS6/00",
+    "MUS6/01",
     "N4JP",
     "N782",
     "P2EQ",
@@ -97,9 +98,7 @@
     "ZVH3",
     "ZXT5"
   ],
-  "error_accepted": [
-    "MUS6/01"
-  ],
+  "error_accepted": [],
   "parse_failures": [
     "V9D5"
   ]


### PR DESCRIPTION
## Breaking change

None for well-formed documents. One class of malformed input changes verdict toward the spec: a `%YAML`/`%TAG` directive that does not start a document is now rejected instead of silently accepted.

## Proposed change

A directive is valid only at the start of the stream or immediately after a `...` document-end marker; the previous document must be closed with `...` before a new one may carry directives. The scanner emitted a directive token wherever a `%` sat at column 0, so `%YAML 1.2\n---\n%YAML 1.2\n---` was accepted: the second directive opens a document while the first, started by `---`, is still open.

The scanner now tracks whether directives are allowed, set at stream start and after `...`, cleared by any document content or a `---` start, and rejects a directive that appears while a document is open. A `%` is a YAML c-indicator and can never begin plain-scalar content, so a `%` at column 0 in that position is unambiguously the invalid directive, not data.

Against the official YAML test suite this fixes `MUS6/01`. Combined with the scalar work already merged, `error_accepted` is now empty: yamlrocks rejects every input the suite marks invalid. The only remaining baseline entry is `V9D5` (a compact block mapping used as a key, spec example 8.19), tracked separately.

This is related to #77.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #77
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
