### PR TITLE
📝 State full YAML test suite compliance and document compact block keys

### DIFF
--- a/docs/src/content/docs/guides/loading.md
+++ b/docs/src/content/docs/guides/loading.md
@@ -264,6 +264,20 @@ data = yamlrocks.loads(source)
 assert data == {(("x", 1),): "nested"}
 ```
 
+The key may also be a compact block collection written after the `?`, the form
+used in [spec example
+8.19](https://yaml.org/spec/1.2.2/#example-compact-block-mappings):
+
+```python
+source = """
+? earth: blue
+: moon: white
+"""
+
+data = yamlrocks.loads(source)
+assert data == {(("earth", "blue"),): {"moon": "white"}}
+```
+
 The conversion is recursive, so nested collections inside a key are made hashable
 too. It applies on every load path that builds Python values, plain `loads`,
 [annotated mode](/guides/annotated/), and custom-tag resolution, so they all

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -47,8 +47,8 @@ feedback. See [stability and roadmap](/stability-roadmap/) for the 1.0 contract.
     files is roughly 18 times faster than a PyYAML constructor.
   </Card>
   <Card title="Correct" icon="approve-check">
-    A custom YAML 1.2 scanner and parser, exercised against the official YAML
-    test suite plus snapshot and fuzz corpora, and actively tested against
+    A custom YAML 1.2 scanner and parser that passes the complete official YAML
+    test suite, backed by snapshot and fuzz corpora, and actively tested against
     thousands of real-world configuration files from dozens of public
     repositories across many ecosystems. See [real-world
     verification](/verification/real-world-corpus/).
@@ -229,9 +229,9 @@ doc.save()
 YAMLRocks implements fast load/dump, JSON export, YAML 1.1 mode, annotated mode,
 native includes, round-trip preservation, writable includes, JSON Schema
 validation (including in-file `$schema` references), the `!secret` and `!env_var`
-config tags, a PyYAML compatibility shim, and rich standard-library type support. It is
-verified against the official YAML test suite and thousands of real-world configs
-from many ecosystems, behind a code-coverage gate, and is safe against the common
+config tags, a PyYAML compatibility shim, and rich standard-library type support. It
+passes the complete official YAML test suite and is verified against thousands of
+real-world configs from many ecosystems, behind a code-coverage gate, and is safe against the common
 YAML attack classes, with hot paths tuned via the raw CPython API and zero-copy
 scalar parsing. See [stability and roadmap](/stability-roadmap/) for what is
 stable today, what may still change, and what blocks 1.0.


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

With the suite-conformance work landed, yamlrocks passes the complete official YAML 1.2 test suite, so the docs say so plainly. The landing page's "Correct" card and project-status note change "exercised against" / "verified against" the test suite to "passes the complete official YAML test suite". The complex-keys guide gains an example for a compact block collection written after a `?` key indicator (spec example 8.19), the form the parser now handles, alongside the existing flow-style examples.

The existing complex-keys and `OPT_REJECT_COMPLEX_KEYS` documentation already described the behavior generically and is unchanged.

Note on ordering: the new example and the full-compliance wording rely on #86 (compact block collections as keys). This should merge after #86 so the documented example verifier stays green.

This is related to #77 and #86.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #86
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
