### PR TITLE
⚡ Trim plain-scalar trailing blanks after the scan, not per byte

### DIFF
--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -200,15 +200,18 @@ impl<'input> Reader<'input> {
         let bytes = self.input.as_bytes();
         let start = self.pos;
         let mut i = self.pos;
-        let mut content_end = self.pos;
         while i < bytes.len() && !table[bytes[i] as usize] {
-            if !is_blank_byte(bytes[i]) {
-                content_end = i + 1;
-            }
             i += 1;
         }
         self.pos = i;
         self.column += (i - start) as u32;
+        // Trailing blanks before the stopping byte are not content, so the
+        // content ends at the last non-blank byte. Trimming once here keeps the
+        // scan loop above a pure table walk instead of testing every byte.
+        let mut content_end = i;
+        while content_end > start && is_blank_byte(bytes[content_end - 1]) {
+            content_end -= 1;
+        }
         (&self.input[start..i], content_end)
     }
 


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Same slice, same content end, byte-for-byte identical output.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

`take_plain_line_run` is the hottest loop in plain-scalar parsing: it bulk-consumes a run of plain content including internal blanks. It tracked the content end (the last non-blank byte) inside the scan loop, calling `is_blank_byte` and conditionally storing on every single byte.

This splits the two concerns. The scan loop becomes a pure stop-table walk (one indexed lookup per byte, nothing else), and the trailing blanks are trimmed once afterward by walking back from the stop position. Plain scalars rarely have trailing blanks, so the trim back-walk is short or empty in practice, while the per-byte hot path drops a branch and a conditional store.

Measured with callgrind (deterministic instruction counts, `cache-sim=no branch-sim=no`) over the real-world config corpus, loads pipeline:

- before: 6,709,066,996 instructions
- after: 6,651,078,823 instructions
- **−0.86%** on the full loads pipeline from this one localized change

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
