### PR TITLE
⚡ Move scalar text out of events during decode, dropping the pre-pass

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -60,17 +60,15 @@ pub fn decode_collecting(
         span: e.span,
     })?;
 
-    // Move each scalar's text out of its event up front. The decoder then owns
-    // these strings and can move them straight into `Value::String`, avoiding
-    // the re-allocation a borrowing `resolve` would do for every string scalar.
-    let scalars = take_scalar_strings(&mut events);
-
-    let mut decoder = Decoder::new(schema, scalars);
+    let mut decoder = Decoder::new(schema);
     decoder.duplicate_keys_error = duplicate_keys_error;
     decoder.reject_complex_keys = reject_complex_keys;
     decoder.duplicate_keys_warn = warn.duplicate_keys;
     decoder.yaml_11_warn = warn.yaml_1_1;
-    let mut documents = decoder.decode_stream(&events)?;
+    // The decoder moves each scalar's text straight out of its event into the
+    // value tree as it goes, so it borrows the events mutably; there is no
+    // separate pre-pass copying scalar texts into a side table.
+    let mut documents = decoder.decode_stream(&mut events)?;
     // The merge post-pass walks the whole tree; skip it unless a `<<` was seen.
     if decoder.saw_merge {
         for document in &mut documents {
@@ -88,17 +86,15 @@ pub fn is_custom_tag(tag: &str) -> bool {
     !(tag.starts_with("!!") || tag.starts_with("tag:yaml.org,2002:"))
 }
 
-/// Move the text out of every `Scalar` event into a position-indexed table, so
-/// the decoder can hand ownership of each string to a `Value::String` without a
-/// copy. The event still carries its style (the text field is left empty).
-fn take_scalar_strings<'input>(events: &mut [Event<'input>]) -> Vec<Option<Cow<'input, str>>> {
-    events
-        .iter_mut()
-        .map(|event| match &mut event.kind {
-            EventKind::Scalar(text, _) => Some(std::mem::take(text)),
-            _ => None,
-        })
-        .collect()
+/// Move ownership of the scalar text out of the `Scalar` event at `pos`, leaving
+/// the event's text empty. The decoder calls this exactly once as it consumes a
+/// scalar, handing the string straight to a `Value::String` without a copy. The
+/// caller has already matched the event at `pos` as a scalar.
+fn take_scalar<'input>(events: &mut [Event<'input>], pos: usize) -> Cow<'input, str> {
+    match &mut events[pos].kind {
+        EventKind::Scalar(text, _) => std::mem::take(text),
+        _ => Cow::default(),
+    }
 }
 
 /// Count the total number of nodes in a value tree (used to bound alias
@@ -255,8 +251,6 @@ fn named_tag_handle(tag: &str) -> Option<&str> {
 struct Decoder<'input> {
     /// The scalar-resolution schema (1.2, 1.1, or 1.1-PyYAML).
     schema: Schema,
-    /// Scalar texts moved out of the events, indexed by event position.
-    scalars: Vec<Option<Cow<'input, str>>>,
     // Each anchor stores its resolved value and its precomputed node count, so
     // an alias is an O(1) budget check instead of re-walking the subtree on
     // every reference (which also speeds up rejecting an alias bomb).
@@ -293,10 +287,9 @@ struct Decoder<'input> {
 }
 
 impl<'input> Decoder<'input> {
-    fn new(schema: Schema, scalars: Vec<Option<Cow<'input, str>>>) -> Self {
+    fn new(schema: Schema) -> Self {
         Self {
             schema,
-            scalars,
             anchors: HashMap::new(),
             duplicate_keys_error: false,
             reject_complex_keys: false,
@@ -374,14 +367,6 @@ impl<'input> Decoder<'input> {
         })
     }
 
-    /// Take ownership of the scalar text recorded for the event at `pos`.
-    fn take_scalar(&mut self, pos: usize) -> Cow<'input, str> {
-        self.scalars
-            .get_mut(pos)
-            .and_then(Option::take)
-            .unwrap_or_default()
-    }
-
     /// Account for `count` newly created nodes, erroring if the budget is
     /// exceeded.
     fn charge_nodes(&mut self, count: usize, span: Span) -> Result<(), DecodeError> {
@@ -398,7 +383,7 @@ impl<'input> Decoder<'input> {
 
     fn decode_stream(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
     ) -> Result<Vec<Value<'input>>, DecodeError> {
         let mut documents = Vec::new();
         // A directive is only meaningful at the start of the stream or right
@@ -552,7 +537,7 @@ impl<'input> Decoder<'input> {
     /// work in [`decode_node_inner`].
     fn decode_node(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
     ) -> Result<Option<Value<'input>>, DecodeError> {
         self.depth += 1;
         if self.depth > MAX_DEPTH {
@@ -574,7 +559,7 @@ impl<'input> Decoder<'input> {
 
     fn decode_node_inner(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
     ) -> Result<Option<Value<'input>>, DecodeError> {
         if self.pos >= events.len() {
             return Ok(None);
@@ -675,7 +660,7 @@ impl<'input> Decoder<'input> {
                 // Take ownership of the scanned text; classify the type without
                 // re-allocating, then move the text straight into the string
                 // case instead of cloning it.
-                let text = self.take_scalar(pos);
+                let text = take_scalar(events, pos);
                 if self.yaml_11_warn {
                     if let Some((t11, t12)) = crate::resolver::yaml_11_divergence(
                         self.schema,
@@ -864,7 +849,7 @@ impl<'input> Decoder<'input> {
 
     fn decode_mapping(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
         flow: bool,
     ) -> Result<Vec<(Value<'input>, Value<'input>)>, DecodeError> {
         let mut pairs = Vec::new();
@@ -949,7 +934,7 @@ impl<'input> Decoder<'input> {
 
     fn decode_sequence(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
         flow: bool,
     ) -> Result<Vec<Value<'input>>, DecodeError> {
         let mut items = Vec::new();
@@ -1002,7 +987,7 @@ impl<'input> Decoder<'input> {
     /// is consumed and the pair wrapped in a mapping.
     fn decode_sequence_item(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
         flow: bool,
     ) -> Result<Option<Value<'input>>, DecodeError> {
         // An empty block entry (the next event is a sibling `-` or the
@@ -1050,7 +1035,7 @@ impl<'input> Decoder<'input> {
 
     fn decode_block_sequence(
         &mut self,
-        events: &[Event<'input>],
+        events: &mut [Event<'input>],
     ) -> Result<Vec<Value<'input>>, DecodeError> {
         let mut items = Vec::new();
 

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -88,12 +88,16 @@ pub fn is_custom_tag(tag: &str) -> bool {
 
 /// Move ownership of the scalar text out of the `Scalar` event at `pos`, leaving
 /// the event's text empty. The decoder calls this exactly once as it consumes a
-/// scalar, handing the string straight to a `Value::String` without a copy. The
-/// caller has already matched the event at `pos` as a scalar.
+/// scalar, handing the string straight to a `Value::String` without a copy.
+///
+/// The caller has just matched the event at `pos` as a scalar, so the non-scalar
+/// arm is unreachable; it panics rather than returning an empty string, so a
+/// future caller that breaks that invariant fails loudly instead of silently
+/// decoding the wrong event as `""`.
 fn take_scalar<'input>(events: &mut [Event<'input>], pos: usize) -> Cow<'input, str> {
     match &mut events[pos].kind {
         EventKind::Scalar(text, _) => std::mem::take(text),
-        _ => Cow::default(),
+        other => unreachable!("take_scalar called on a non-scalar event: {other:?}"),
     }
 }
 


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Same decoded values, same zero-copy string ownership, byte-for-byte identical output.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The fast decoder copied every scalar's text into a parallel side table (`Vec<Option<Cow>>`) in a separate pass over the whole event stream, before decoding, then pulled each string from that table by position. The decoder is a single forward pass that only ever mutated the side table, never the events themselves, so the table was pure overhead: one extra walk of the stream and one allocation sized to it.

This borrows the events mutably and `mem::take`s each scalar's text straight out of its event as the decoder consumes it, handing the string to `Value::String` with the exact same zero-copy ownership transfer. Same result, one fewer pass and one fewer allocation.

The change is mechanical: the decoder already copied each bound pattern value (`let flow = *flow;`) before recursing, which releases the scrutinee borrow, so flipping the seven recursing methods from `&[Event]` to `&mut [Event]` and moving the single scalar-take inline was accepted by the borrow checker without restructuring. The two read-only helpers stay on `&[Event]`.

Measured with callgrind (deterministic instruction counts, `cache-sim=no branch-sim=no`) over the real-world config corpus, loads pipeline:

- before: 6,708,729,277 instructions
- after: 6,633,513,011 instructions
- **−1.1%** on the full loads pipeline (the Rust-relative share is higher; the workload denominator includes file I/O)

This is the safe, isolated first step toward eliminating the materialized event vector on the fast path. Full streaming (dropping `Vec<Event>` entirely) remains a possible follow-up, to be re-measured once this lands.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
