### PR TITLE
🐛 Clear the speculative simple key after a block scalar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Build context excludes for the ClusterFuzzLite image (.clusterfuzzlite/Dockerfile
+# does `COPY . $SRC/yamlrocks`). The fuzz targets only compile the library and run
+# on generated input, so the multi-gigabyte test corpora, build artifacts, git
+# history, and virtualenvs are pure context bloat. Left in, they push the Docker
+# build context past the CI runner's disk (it transferred 6.7 GB and failed with
+# "no space left on device"); excluded, the context is a few megabytes and the
+# build is reliable. This file only affects `docker build`, not the repo itself.
+
+# Version control history (submodule packs under .git/modules are the bulk of it).
+.git
+
+# Test corpora: the real-world config corpus and the YAML test suite submodules.
+tests/data
+
+# Compiled artifacts and caches.
+target
+fuzz/target
+fuzz/corpus
+fuzz/artifacts
+*.profraw
+
+# Python virtualenvs and the docs site with its node_modules.
+.venv
+.venv-ft
+docs
+node_modules

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1233,6 +1233,13 @@ impl<'input> Scanner<'input> {
             ScalarStyle::Folded
         };
         self.simple_key_allowed = true;
+        // A block scalar is a complete node and can never be an implicit key (a
+        // key must fit on one line). A property (tag or anchor) before it noted a
+        // speculative simple key at its own token; the block scalar consumes all
+        // of its lines in one go, so the per-line clearing in `scan_to_next_token`
+        // never runs to retract that note. Clear it here, or the stale entry
+        // suppresses the next line's key detection (`- !t |-\n  x\n- !t k: v`).
+        self.simple_key = None;
         // Record the block's source extent so the round-trip path can replay it
         // verbatim (folding a `>` block discards the original line breaks).
         let mut token = Token::new(TokenKind::Scalar(value, style), span);

--- a/tests/core/test_scalars.py
+++ b/tests/core/test_scalars.py
@@ -174,6 +174,18 @@ def test_literal_strip_chomping():
     assert yamlrocks.loads(b"x: |-\n  line1\n  line2\n")["x"] == "line1\nline2"
 
 
+def test_tagged_block_scalar_does_not_swallow_a_following_tagged_key():
+    """A tagged key after a tagged block scalar item still opens its mapping.
+
+    The block scalar's own tag noted a speculative simple key that the per-line
+    clearing never ran to retract (the block consumes all its lines at once), so
+    the stale note suppressed the next line's key detection: the tagged key was
+    read as a bare scalar and its ``:`` started a phantom mapping. Pins that the
+    second item stays a single-pair mapping.
+    """
+    assert yamlrocks.loads(b"- !t |-\n  f\n- !t k: v\n") == ["f", {"k": "v"}]
+
+
 @pytest.mark.parametrize(
     ("src", "expected"),
     [


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None, other than that affected inputs now decode correctly instead of to silently wrong data.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

A tagged block scalar followed by a tagged implicit key decoded to silently wrong data. `- !t |-\n  f\n- !t k: v` yielded `["f", "k", {None: None}]` instead of `["f", {"k": "v"}]`. The differential fuzzer (dumps then loads must agree on the data) found it; it is a `loads` bug, pre-existing on `main`, in the silent-corruption class the differential target exists to catch.

`fetch_block_scalar` set `simple_key_allowed = true` but never cleared the speculative simple key that a preceding tag or anchor had recorded via `note_possible_simple_key`. A block scalar consumes all of its lines in one pass, so the per-line retraction in `scan_to_next_token` never runs to drop that note. The stale note then made the next line's `note_possible_simple_key` bail (`simple_key` was already `Some`), so the tagged key was read as a bare scalar and its `:` started a phantom mapping.

The fix clears `self.simple_key` in `fetch_block_scalar`. A block scalar can never be an implicit key (a key must fit on one line), so any pending note belonged to the block's own node and must be retracted. Take away any one ingredient (untagged block, untagged key, a non-block scalar) and the path was already correct; the tag on the next key is what made both recognition mechanisms miss.

Verified: the original fuzzer crash input and its minimized 16-byte form both pass; a 150-second differential fuzz sweep (923k runs) finds no divergence; the full Python suite and Rust unit tests pass. A named regression test pins the case.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
