### PR TITLE
📝 Drop the stale scalar-string side table note from the decode fuzz docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,8 @@ pub mod fuzz {
     /// Drive the fast `loads` decode path (events → `Value` tree) under both the
     /// YAML 1.2 and 1.1 schemas, then re-emit each document through the fast
     /// emitter. This covers code distinct from [`parse`]: direct decoding, merge
-    /// keys, the scalar-string side table, scalar resolution, and the fast
-    /// `dumps` emitter, the path most callers actually hit. The contract is the
-    /// same, never panic on any input.
+    /// keys, scalar resolution, and the fast `dumps` emitter, the path most
+    /// callers actually hit. The contract is the same, never panic on any input.
     pub fn decode(input: &str) {
         for schema in [Schema::Yaml12, Schema::Yaml11] {
             if let Ok(documents) = decode_with(input, schema, false, false) {


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Comment only.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

#92 removed the scalar-string side table: the fast decoder now moves each scalar's text out of its event inline as it consumes it. The `decode` fuzz harness comment still listed "the scalar-string side table" among the code it covers, so it no longer matches reality. Drop that clause.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: #92

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
