### PR TITLE
🐛 Wrap long plain scalars by quoting, not unsafe plain folding

### DIFF
--- a/docs/src/content/docs/guides/dumping.md
+++ b/docs/src/content/docs/guides/dumping.md
@@ -197,15 +197,18 @@ overrides the flag for a single call.
 
 By default `dumps` never wraps: a long scalar or flow collection emits on one
 line. Pass `width=N` to fold lines to a best-effort maximum, the way PyYAML's
-`width` does. Plain and quoted scalars fold at spaces, and flow collections break
-after commas:
+`width` does. A long scalar folds at spaces and flow collections break after
+commas. A plain scalar that needs wrapping is emitted double-quoted, because a
+bare plain scalar cannot fold safely (a continuation line could start an
+indicator or land at an enclosing indent), whereas a break inside quotes always
+folds back to a single space:
 
 ```python
 import yamlrocks
 
 config = {"description": "a fairly long sentence that we would like wrapped onto a few lines"}
 yamlrocks.dumps(config, width=40)
-# b'description: a fairly long sentence that\n  we would like wrapped onto a few lines\n'
+# b'description: "a fairly long sentence\n             that we would like wrapped\n             onto a few lines"\n'
 ```
 
 The one rule that is never broken is **value fidelity**: a fold only happens

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -415,7 +415,14 @@ impl<'a> Emitter<'a> {
             // scalar would end the entry or collection early; quoting keeps it a
             // single value. In block context those bytes are ordinary content.
             self.emit_quoted_string(value);
-        } else if self.options.width > 0 {
+        } else if self.options.width > 0 && !in_flow {
+            // Fold long plain scalars to the width, but only in block context. A
+            // fold inserts a newline at a space; in a flow collection the next
+            // line can begin with `?`, `:`, or `-`, which there are indicators
+            // (an explicit key, a value, a block entry), so the break would
+            // change the decoded value (`{k: a ? b}` folding to `a\n  ? b` reads
+            // back as the value `a` plus a key `b`). Width is a soft limit, so a
+            // flow plain scalar simply stays on one line instead.
             let cont_indent = self.current_line_indent() + self.step();
             self.emit_folded(value, cont_indent);
         } else {
@@ -753,6 +760,25 @@ mod tests {
     }
     fn emit(value: &Value<'_>, options: &EmitOptions) -> String {
         String::from_utf8(encode(value, options)).unwrap()
+    }
+
+    #[test]
+    fn flow_plain_scalar_is_not_folded_across_a_width_break() {
+        // A plain scalar carrying ` ? ` inside a flow mapping must not be folded
+        // to honor the width: a fold puts `? ...` at the start of a flow line,
+        // where `?` is an explicit-key indicator, so the value would read back as
+        // a value plus a spurious key. Width is a soft limit, so it stays inline.
+        let v = Value::Mapping(vec![(s("k"), s("a ? b c d e f"))]);
+        let opts = EmitOptions {
+            flow_style: true,
+            width: 8,
+            ..EmitOptions::default()
+        };
+        let out = emit(&v, &opts);
+        let reparsed =
+            crate::decode::decode_with(&out, crate::resolver::Schema::Yaml12, false, false)
+                .unwrap();
+        assert_eq!(reparsed, vec![v], "flow plain scalar round-trips: {out:?}");
     }
 
     #[test]

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -426,17 +426,17 @@ impl<'a> Emitter<'a> {
             // scalar would end the entry or collection early; quoting keeps it a
             // single value. In block context those bytes are ordinary content.
             self.emit_quoted_string(value);
-        } else if self.options.width > 0 && !in_flow && !self.emitting_key {
-            // Fold long plain scalars to the width, but only in block value
-            // position (never a key, see `emit_key`). A
-            // fold inserts a newline at a space; in a flow collection the next
-            // line can then begin with `?` or `:`, which are indicators there (an
-            // explicit key, a value), so the break would change the decoded value
-            // (`{k: a ? b}` folding to `a\n  ? b` reads back as the value `a` plus
-            // a key `b`). Width is a soft limit, so a flow plain scalar simply
-            // stays on one line instead.
-            let cont_indent = self.current_line_indent() + self.step();
-            self.emit_folded(value, cont_indent);
+        } else if self.would_wrap(value) {
+            // A plain scalar that would exceed the width is emitted double-quoted
+            // and folded inside the quotes, never folded as a bare plain scalar.
+            // Inserting a newline into a plain scalar is unsafe: the continuation
+            // line can begin with an indicator (`?`/`:`/`!`/`&`/`*`/...) or land
+            // at an enclosing collection's indent, either of which changes the
+            // decoded value (`M !` folding to `M\n  !` reads `!` as a tag;
+            // `{k: a ? b}` folding reads `? b` as a key). A break inside quotes
+            // always folds back to a single space, so quoting makes wrapping safe
+            // in every position. Keys are excluded by `would_wrap`.
+            self.emit_quoted_string(value);
         } else {
             self.buf.extend_from_slice(value.as_bytes());
         }
@@ -457,7 +457,13 @@ impl<'a> Emitter<'a> {
             // body folds the same way as in a plain scalar; the surrounding
             // quotes are unaffected. Never fold a key: a quoted key spread across
             // lines stops being a valid implicit key, so the `:` detaches.
-            let cont_indent = self.current_line_indent() + self.step();
+            //
+            // Continuation lines indent to the scalar's start column, which always
+            // sits past the enclosing key/dash (the scalar is emitted after them).
+            // A multi-line quoted scalar must be indented past its block context,
+            // so the line's leading indent is too shallow for a value after a dash
+            // (`- k: ...`, where it would land at the mapping's own column).
+            let cont_indent = self.current_column();
             let (quote, body) = if single_ok {
                 (b'\'', crate::emit_util::single_quoted_body(value))
             } else {
@@ -555,13 +561,25 @@ impl<'a> Emitter<'a> {
         self.buf[start..].iter().take_while(|&&b| b == b' ').count()
     }
 
+    /// Whether a plain `value` at the current column would exceed the width and
+    /// has a foldable break point, so it is worth emitting quoted-and-folded
+    /// rather than leaving it to overflow on one line. False in key position: a
+    /// key must stay on one line, so width never applies to it.
+    fn would_wrap(&self, value: &str) -> bool {
+        self.options.width > 0
+            && !self.emitting_key
+            && self.current_column() + value.len() > self.options.width
+            && has_breakable_space(value)
+    }
+
     /// Append `content` to `buf`, folding it across lines so each stays at or
     /// below `self.options.width`. A fold replaces one space with a newline plus
     /// `cont_indent` spaces; on reload that whole break collapses back to the
     /// single space, so the decoded value is unchanged. Breaks are only taken at
     /// a single space flanked by non-spaces, never inside a run of spaces (which
     /// would lose one), so a run of spaces or a break-free span may exceed the
-    /// width. Used for plain and quoted scalar bodies alike.
+    /// width. Used only for quoted scalar bodies (a break inside quotes is safe);
+    /// a plain scalar that needs wrapping is quoted first (see `emit_string_inline`).
     fn emit_folded(&mut self, content: &str, cont_indent: usize) {
         let width = self.options.width;
         let bytes = content.as_bytes();
@@ -612,6 +630,16 @@ fn has_flow_indicator(value: &str) -> bool {
     value
         .bytes()
         .any(|b| matches!(b, b',' | b'[' | b']' | b'{' | b'}'))
+}
+
+/// Whether `value` contains a space flanked by non-spaces: the only place a fold
+/// may break, since breaking inside a run of spaces would drop one. Used to
+/// decide whether wrapping a long scalar can actually shorten any line.
+fn has_breakable_space(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.iter().enumerate().any(|(i, &b)| {
+        b == b' ' && i > 0 && bytes[i - 1] != b' ' && bytes.get(i + 1).is_some_and(|&n| n != b' ')
+    })
 }
 
 /// Determine whether a plain scalar string would be misinterpreted and thus
@@ -779,41 +807,62 @@ mod tests {
         String::from_utf8(encode(value, options)).unwrap()
     }
 
-    #[test]
-    fn a_quoted_key_is_not_folded_across_a_width_break() {
-        // A mapping key must stay on one line to remain a valid implicit key.
-        // Folding a long quoted key at a small width would split it across lines,
-        // detaching the `:` so the value reads back as a separate node. The key
-        // here needs quoting (control byte) and is long enough to tempt a fold.
-        let v = Value::Mapping(vec![(s("a long \u{1} key here"), Value::Null)]);
-        let opts = EmitOptions {
-            width: 1,
-            ..EmitOptions::default()
-        };
-        let out = emit(&v, &opts);
-        let reparsed =
-            crate::decode::decode_with(&out, crate::resolver::Schema::Yaml12, false, false)
-                .unwrap();
-        assert_eq!(reparsed, vec![v], "quoted key round-trips: {out:?}");
+    /// Decode `out` under the 1.2 schema, asserting it is a single document, and
+    /// return that document (borrowing `out`).
+    fn reparse(out: &str) -> Value<'_> {
+        let mut docs =
+            crate::decode::decode_with(out, crate::resolver::Schema::Yaml12, false, false).unwrap();
+        assert_eq!(docs.len(), 1, "one document: {out:?}");
+        docs.remove(0)
     }
 
     #[test]
-    fn flow_plain_scalar_is_not_folded_across_a_width_break() {
-        // A plain scalar carrying ` ? ` inside a flow mapping must not be folded
-        // to honor the width: a fold puts `? ...` at the start of a flow line,
-        // where `?` is an explicit-key indicator, so the value would read back as
-        // a value plus a spurious key. Width is a soft limit, so it stays inline.
+    fn a_key_is_never_wrapped_across_the_width() {
+        // A mapping key must stay on one line to remain a valid implicit key.
+        // Wrapping a long key at a small width would split it across lines,
+        // detaching the `:` so the value reads back as a separate node. The key
+        // needs quoting (control byte) and is long enough to tempt a fold.
+        let v = Value::Mapping(vec![(s("a long \u{1} key here"), Value::Null)]);
+        let out = emit(
+            &v,
+            &EmitOptions {
+                width: 1,
+                ..EmitOptions::default()
+            },
+        );
+        assert_eq!(reparse(&out), v, "key round-trips: {out:?}");
+    }
+
+    #[test]
+    fn a_plain_value_with_an_indicator_word_wraps_safely_under_width() {
+        // A plain value `M !` folded as plain to honor the width would put `!` at
+        // line start, where it reads as a tag (a phantom key). Quote-to-wrap emits
+        // it double-quoted and folds inside the quotes, where the break is safe.
+        let v = Value::Sequence(vec![Value::Mapping(vec![(s("-"), s("M !"))])]);
+        let out = emit(
+            &v,
+            &EmitOptions {
+                width: 1,
+                ..EmitOptions::default()
+            },
+        );
+        assert_eq!(reparse(&out), v, "block plain value round-trips: {out:?}");
+    }
+
+    #[test]
+    fn a_flow_plain_value_with_an_indicator_wraps_safely_under_width() {
+        // Inside flow, folding `a ? b` as plain would start a line with `?` (an
+        // explicit-key indicator). Quote-to-wrap keeps it a single value.
         let v = Value::Mapping(vec![(s("k"), s("a ? b c d e f"))]);
-        let opts = EmitOptions {
-            flow_style: true,
-            width: 8,
-            ..EmitOptions::default()
-        };
-        let out = emit(&v, &opts);
-        let reparsed =
-            crate::decode::decode_with(&out, crate::resolver::Schema::Yaml12, false, false)
-                .unwrap();
-        assert_eq!(reparsed, vec![v], "flow plain scalar round-trips: {out:?}");
+        let out = emit(
+            &v,
+            &EmitOptions {
+                flow_style: true,
+                width: 8,
+                ..EmitOptions::default()
+            },
+        );
+        assert_eq!(reparse(&out), v, "flow plain value round-trips: {out:?}");
     }
 
     #[test]

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -111,6 +111,10 @@ pub fn encode(value: &Value<'_>, options: &EmitOptions) -> Vec<u8> {
 struct Emitter<'a> {
     buf: Vec<u8>,
     options: &'a EmitOptions,
+    /// True while emitting a mapping key. A key must stay on one line to remain a
+    /// valid implicit key, so all width-driven line breaking (scalar folding and
+    /// flow-separator breaks) is suppressed for the whole key subtree.
+    emitting_key: bool,
 }
 
 impl<'a> Emitter<'a> {
@@ -122,6 +126,7 @@ impl<'a> Emitter<'a> {
             // for tiny ones.
             buf: Vec::with_capacity(1024),
             options,
+            emitting_key: false,
         }
     }
 
@@ -394,7 +399,13 @@ impl<'a> Emitter<'a> {
     /// scalar key sits in block context (`false`); a collection key descends into
     /// flow internally, flagging its own elements.
     fn emit_key(&mut self, key: &Value) {
+        // Suppress all width-driven line breaking for the whole key subtree: a
+        // key folded or broken across lines is no longer a valid implicit key, so
+        // the `:` after it detaches and the data changes on reload.
+        let was_key = self.emitting_key;
+        self.emitting_key = true;
         self.emit_inline(key, false);
+        self.emitting_key = was_key;
     }
 
     fn emit_float(&mut self, value: f64) {
@@ -415,8 +426,9 @@ impl<'a> Emitter<'a> {
             // scalar would end the entry or collection early; quoting keeps it a
             // single value. In block context those bytes are ordinary content.
             self.emit_quoted_string(value);
-        } else if self.options.width > 0 && !in_flow {
-            // Fold long plain scalars to the width, but only in block context. A
+        } else if self.options.width > 0 && !in_flow && !self.emitting_key {
+            // Fold long plain scalars to the width, but only in block value
+            // position (never a key, see `emit_key`). A
             // fold inserts a newline at a space; in a flow collection the next
             // line can then begin with `?` or `:`, which are indicators there (an
             // explicit key, a value), so the break would change the decoded value
@@ -440,10 +452,11 @@ impl<'a> Emitter<'a> {
             && !value.contains('\n')
             && !value.contains('\r')
             && !value.bytes().any(|b| b < 0x20 || b == 0x7f);
-        if self.options.width > 0 {
+        if self.options.width > 0 && !self.emitting_key {
             // Fold the (already-escaped) body between the quotes. A space in the
             // body folds the same way as in a plain scalar; the surrounding
-            // quotes are unaffected.
+            // quotes are unaffected. Never fold a key: a quoted key spread across
+            // lines stops being a valid implicit key, so the `:` detaches.
             let cont_indent = self.current_line_indent() + self.step();
             let (quote, body) = if single_ok {
                 (b'\'', crate::emit_util::single_quoted_body(value))
@@ -489,10 +502,14 @@ impl<'a> Emitter<'a> {
 
     /// The `, ` between flow entries, broken onto a new indented line when the
     /// current line has reached the width. Whitespace between flow tokens is
-    /// insignificant, so a break here never changes the decoded value.
+    /// insignificant, so a break here never changes the decoded value, except
+    /// inside a key, where it would split the implicit key across lines.
     fn emit_flow_separator(&mut self, cont_indent: usize) {
         self.buf.push(b',');
-        if self.options.width > 0 && self.current_column() >= self.options.width {
+        if self.options.width > 0
+            && !self.emitting_key
+            && self.current_column() >= self.options.width
+        {
             self.buf.push(b'\n');
             self.write_indent(cont_indent);
         } else {
@@ -760,6 +777,24 @@ mod tests {
     }
     fn emit(value: &Value<'_>, options: &EmitOptions) -> String {
         String::from_utf8(encode(value, options)).unwrap()
+    }
+
+    #[test]
+    fn a_quoted_key_is_not_folded_across_a_width_break() {
+        // A mapping key must stay on one line to remain a valid implicit key.
+        // Folding a long quoted key at a small width would split it across lines,
+        // detaching the `:` so the value reads back as a separate node. The key
+        // here needs quoting (control byte) and is long enough to tempt a fold.
+        let v = Value::Mapping(vec![(s("a long \u{1} key here"), Value::Null)]);
+        let opts = EmitOptions {
+            width: 1,
+            ..EmitOptions::default()
+        };
+        let out = emit(&v, &opts);
+        let reparsed =
+            crate::decode::decode_with(&out, crate::resolver::Schema::Yaml12, false, false)
+                .unwrap();
+        assert_eq!(reparsed, vec![v], "quoted key round-trips: {out:?}");
     }
 
     #[test]

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -418,11 +418,11 @@ impl<'a> Emitter<'a> {
         } else if self.options.width > 0 && !in_flow {
             // Fold long plain scalars to the width, but only in block context. A
             // fold inserts a newline at a space; in a flow collection the next
-            // line can begin with `?`, `:`, or `-`, which there are indicators
-            // (an explicit key, a value, a block entry), so the break would
-            // change the decoded value (`{k: a ? b}` folding to `a\n  ? b` reads
-            // back as the value `a` plus a key `b`). Width is a soft limit, so a
-            // flow plain scalar simply stays on one line instead.
+            // line can then begin with `?` or `:`, which are indicators there (an
+            // explicit key, a value), so the break would change the decoded value
+            // (`{k: a ? b}` folding to `a\n  ? b` reads back as the value `a` plus
+            // a key `b`). Width is a soft limit, so a flow plain scalar simply
+            // stays on one line instead.
             let cont_indent = self.current_line_indent() + self.step();
             self.emit_folded(value, cont_indent);
         } else {

--- a/tests/features/test_width.py
+++ b/tests/features/test_width.py
@@ -24,11 +24,17 @@ def test_default_does_not_wrap():
 
 
 def test_plain_scalar_wraps_and_round_trips():
-    """A long plain scalar folds at spaces and reloads unchanged."""
+    """A long plain scalar wraps to the width and reloads unchanged.
+
+    Wrapping a bare plain scalar is unsafe (a continuation line can start an
+    indicator or collide with an enclosing indent), so a plain value that needs
+    wrapping is emitted double-quoted and folded inside the quotes instead.
+    """
     obj = {"msg": "one two three four five six seven eight nine ten eleven twelve"}
     out = yamlrocks.dumps(obj, width=30)
     assert yamlrocks.loads(out) == obj
     assert _max_line(out) <= 30
+    assert b'"' in out  # wrapped by quoting, which is the only safe way to fold
 
 
 def test_quoted_scalar_wraps_and_round_trips():


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

A long plain scalar that gets wrapped under `width` is now emitted double-quoted (and folded inside the quotes) instead of folded as a bare plain scalar. The decoded value is unchanged; only the on-the-wire style differs (quoted), and it is the only style that wraps safely. No API change.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

A new emit-options differential fuzzer (separate PR) showed that width-folding a bare plain scalar is unsafe in several positions, not just one. A fold inserts a newline at a space, and the continuation line can:

- begin with an indicator: `M !` folds to `M\n  !`, where `!` reparses as a tag (and a phantom key);
- begin with `?`/`:` inside flow, reparsing as an explicit key or value (`{k: a ? b}`);
- land at an enclosing collection's indent, reparsing as a sibling key.

All are silent dumps/loads corruption.

The fix stops folding bare plain scalars. A plain scalar that would exceed the width is emitted double-quoted and folded inside the quotes, where a line break always folds back to a single space, safe in every position. Width remains a soft limit, so a value with no foldable break, or a value in key position (a key must stay on one line), simply stays on its line.

This also fixes the continuation indent for folded quoted scalars: it used the line's leading whitespace, which after a dash (`- k: ...`) lands at the mapping's own column and is too shallow (our own loader then rejects the output). Continuation lines now indent to the scalar's start column, always past the enclosing key.

Verified by the full suite, the `width` feature suite (updated to lock the new quoted-wrap behavior), three new Rust regression tests, and a differential fuzz pass with no width-related divergence.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
