### PR TITLE
🐛 Keep an empty indentless sequence entry before a sibling key

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1051,8 +1051,14 @@ impl<'input> Decoder<'input> {
             match &events[self.pos].kind {
                 EventKind::SequenceEntry => {
                     self.pos += 1;
-                    // An empty entry (next is a sibling `-` or the end) is null,
-                    // not a nested sequence absorbing the sibling.
+                    // An empty entry (next is a sibling `-`, the end, or a sibling
+                    // mapping key) is null, not a nested node absorbing it. `Key`
+                    // belongs here for the indentless case: an empty entry whose
+                    // sibling mapping key sits at the sequence's own column dedents
+                    // straight to a `Key` with no `BlockEnd` (the sequence shares
+                    // the mapping's level), e.g. `9:\n-\nq:` is `{9: [null], q: null}`.
+                    // A non-empty `- key: val` entry opens with `MappingStart`, not
+                    // a bare `Key`, so this never swallows real content.
                     if self.pos < events.len()
                         && matches!(
                             events[self.pos].kind,
@@ -1060,6 +1066,7 @@ impl<'input> Decoder<'input> {
                                 | EventKind::SequenceEnd
                                 | EventKind::MappingEnd
                                 | EventKind::BlockEnd
+                                | EventKind::Key
                         )
                     {
                         items.push(Value::Null);

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -903,10 +903,16 @@ impl<'input> Composer<'input> {
     }
 
     /// Compose the value of a block sequence entry whose `-` was just consumed.
-    /// An empty entry (the next event is a sibling `-` or a terminator) is a null
-    /// node, mirroring the fast decoder's `decode_sequence_item`. Returning here
-    /// keeps [`compose_node`](Self::compose_node) from absorbing the sibling `-`
-    /// as a nested sequence, so `-\n-\n-` stays three nulls, not `[[[]]]`.
+    /// An empty entry (the next event is a sibling `-`, a terminator, or a sibling
+    /// mapping key) is a null node, mirroring the fast decoder's
+    /// `decode_block_sequence`. Returning here keeps
+    /// [`compose_node`](Self::compose_node) from absorbing the sibling `-` as a
+    /// nested sequence, so `-\n-\n-` stays three nulls, not `[[[]]]`. `Key`
+    /// covers the indentless case: an empty entry whose sibling mapping key sits
+    /// at the sequence's own column dedents straight to a `Key` with no
+    /// `BlockEnd` (the sequence shares the mapping's level), e.g. `9:\n-\nq:`. A
+    /// non-empty `- key: val` entry opens with `MappingStart`, never a bare `Key`,
+    /// so this never drops real content.
     fn compose_block_entry(
         &mut self,
         events: &[Event],
@@ -919,6 +925,7 @@ impl<'input> Composer<'input> {
                     | EventKind::SequenceEnd
                     | EventKind::MappingEnd
                     | EventKind::BlockEnd
+                    | EventKind::Key
             )
         {
             return Ok(Some(YamlNode::new(YamlNodeKind::Null, dash_span)));
@@ -1002,6 +1009,23 @@ mod tests {
         let r = root("a: 1\nlist:\n  - x\n  - y\n");
         assert!(matches!(r.kind, YamlNodeKind::Mapping(_)));
         assert!(matches!(get(&r, "list").kind, YamlNodeKind::Sequence(_)));
+    }
+
+    #[test]
+    fn empty_indentless_entry_before_a_sibling_key_keeps_its_null() {
+        // The composer shares the fast decoder's empty-entry rule: an empty
+        // indentless `-` whose sibling mapping key dedents to a bare `Key` (no
+        // `BlockEnd`) is a null entry, not a dropped one. Keeping it in the AST is
+        // what lets an unmodified document re-emit byte-for-byte.
+        let src = "9:\n-\nq:\n";
+        let r = root(src);
+        let YamlNodeKind::Sequence(items) = &get(&r, "9").kind else {
+            panic!("expected a sequence under key 9");
+        };
+        assert_eq!(items.len(), 1, "the empty entry survives as one null");
+        assert!(matches!(items[0].kind, YamlNodeKind::Null));
+        let out = crate::roundtrip::emit::emit_roundtrip(&r);
+        assert_eq!(out, src.as_bytes(), "re-emits byte-for-byte");
     }
 
     #[test]

--- a/tests/core/test_loads.py
+++ b/tests/core/test_loads.py
@@ -101,6 +101,18 @@ def test_bare_scalar_document():
     assert yamlrocks.loads(b"hello") == "hello"
 
 
+def test_empty_indentless_sequence_entry_before_a_sibling_key():
+    """An empty indentless `-` entry keeps its null when a sibling key follows.
+
+    The dash sits at the mapping key's column, so dedenting to the sibling key
+    `q` emits a `Key` event with no `BlockEnd` (the sequence shares the mapping's
+    block level). The empty-entry detection missed `Key` and dropped the null, so
+    the sequence came back empty. Pins it to `[None]`, matching the indented form
+    `9:\n  -\nq:`.
+    """
+    assert yamlrocks.loads(b"9:\n-\nq:\n") == {9: [None], "q": None}
+
+
 def test_str_input_accepted():
     """Accept a str input and parse it."""
     assert yamlrocks.loads("key: value") == {"key": "value"}

--- a/tests/core/test_loads.py
+++ b/tests/core/test_loads.py
@@ -110,7 +110,11 @@ def test_empty_indentless_sequence_entry_before_a_sibling_key():
     the sequence came back empty. Pins it to `[None]`, matching the indented form
     `9:\n  -\nq:`.
     """
-    assert yamlrocks.loads(b"9:\n-\nq:\n") == {9: [None], "q": None}
+    src = b"9:\n-\nq:\n"
+    assert yamlrocks.loads(src) == {9: [None], "q": None}
+    # The round-trip composer has the same empty-entry rule and must keep the
+    # entry too, so an unmodified document still re-emits byte-for-byte.
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_yaml() == src
 
 
 def test_str_input_accepted():


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None, other than that affected inputs now decode correctly instead of silently dropping a list element.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

```yaml
9:
-
q:
```

decoded to `{9: [], "q": None}`, silently dropping the list element. It should be `{9: [None], "q": None}`: the indented form `9:\n  -\nq:` already decodes that way, and `9:\n-\n` (no sibling) already keeps the `[None]`. The bug is reachable from plain hand-written YAML; it surfaced through a new emit-options differential fuzzer (separate PR) that emits sequences in the indentless style.

An indentless block sequence shares its parent mapping's block level, so an empty `-` entry whose sibling mapping key sits at the sequence's own column dedents straight to a `Key` event with no `BlockEnd` (the sequence has no level of its own to close). `decode_block_sequence`'s empty-entry detection listed `SequenceEntry | SequenceEnd | MappingEnd | BlockEnd` but not `Key`, so the null entry was not recognized, `decode_node` returned `None` on the `Key`, and the entry was lost.

Add `Key` to the set. A non-empty `- key: val` entry opens with `MappingStart`, never a bare `Key`, so this cannot swallow real content. Verified by the full suite (including the YAML test suite), a Python regression test, and a 1.05M-run differential fuzz pass with no divergence.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
