### PR TITLE
🐛 Indent a tagged sequence under its tag in indentless mode

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -243,7 +243,18 @@ impl<'a> Emitter<'a> {
             Value::Tagged(tag, inner) => {
                 self.buf.push(b' ');
                 self.buf.extend_from_slice(tag.as_bytes());
-                self.emit_value_after_colon(inner, indent);
+                match inner.as_ref() {
+                    // A tagged block sequence always indents under the tag, even
+                    // in indentless mode: the tag sits on the line above, so the
+                    // indentless style (dashes at the key's column) would not bind
+                    // the tag to the sequence and it would be lost on reload. The
+                    // indented layout is what the default mode already produces.
+                    Value::Sequence(s) if self.is_block(inner) => {
+                        self.buf.push(b'\n');
+                        self.emit_block_sequence(s, indent + self.step());
+                    }
+                    _ => self.emit_value_after_colon(inner, indent),
+                }
             }
             _ => {
                 self.buf.push(b' ');
@@ -956,6 +967,28 @@ mod tests {
             ..EmitOptions::default()
         };
         assert_eq!(emit(&v, &opts), "key:\n- 1\n- 2\n");
+    }
+
+    #[test]
+    fn tagged_sequence_value_keeps_its_tag_in_indentless_mode() {
+        // A tagged sequence value must indent under the tag even in indentless
+        // mode: dashes at the key's column would sit below the tag's line without
+        // binding to it, so the tag would be lost on reload. The tagged sequence
+        // therefore emits indented, and the document round-trips.
+        let v = Value::Mapping(vec![(
+            s("k"),
+            Value::Tagged(
+                "!t".to_owned(),
+                Box::new(Value::Sequence(vec![s("a"), s("b")])),
+            ),
+        )]);
+        let opts = EmitOptions {
+            indentless_sequences: true,
+            ..EmitOptions::default()
+        };
+        let out = emit(&v, &opts);
+        assert_eq!(out, "k: !t\n  - a\n  - b\n");
+        assert_eq!(reparse(&out), v, "tag survives the round-trip: {out:?}");
     }
 
     #[test]


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None, other than that a tagged sequence value emitted with `indentless_sequences` is now indented under its tag (so the tag survives) instead of producing output that drops the tag on reload.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

A sequence value carrying a tag, emitted with the `indentless_sequences` option, lost its tag on reload:

```yaml
k: !t
- a
- b
```

The tag `!t` sits on the key's line and the indentless dashes drop to the key's column, so the tag has nothing indented beneath it to bind to. `loads` reads back a plain (untagged) sequence. Silent data loss.

A tagged block sequence now always indents under the tag (`k: !t\n  - a\n  - b`), which is exactly the layout the default mode already produces, so the tag binds and the document round-trips. Only the indentless path changes.

Found by the emit-options differential fuzzer (separate PR); pinned by a Rust regression test. Verified by the full suite and a 1M-run differential fuzz pass with no divergence.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
