### PR TITLE
✅ Add an emit-options differential fuzz target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -45,6 +45,13 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "differential_options"
+path = "fuzz_targets/differential_options.rs"
+test = false
+doc = false
+bench = false
+
 [profile.release]
 # Keep line-level debug info so libFuzzer/ASan crash reports are legible.
 debug = 1

--- a/fuzz/fuzz_targets/differential_options.rs
+++ b/fuzz/fuzz_targets/differential_options.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+// Differential target over non-default emit options. Like `differential`, it
+// decodes arbitrary text and asserts that emitting then re-decoding preserves
+// the data, but it emits each document under a matrix of `EmitOptions` (flow
+// style, indentation, null styles, quote style, explicit markers, indentless
+// sequences, and several line widths) instead of only the defaults. `dumps` must
+// never produce YAML that `loads` reads back as different values under *any*
+// presentation choice; width-driven line breaking and the indentless layout are
+// the prime suspects. See `_yamlrocks::fuzz::differential_options`.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        _yamlrocks::fuzz::differential_options(text);
+    }
+});

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -243,7 +243,18 @@ impl<'a> Emitter<'a> {
             Value::Tagged(tag, inner) => {
                 self.buf.push(b' ');
                 self.buf.extend_from_slice(tag.as_bytes());
-                self.emit_value_after_colon(inner, indent);
+                match inner.as_ref() {
+                    // A tagged block sequence always indents under the tag, even
+                    // in indentless mode: the tag sits on the line above, so the
+                    // indentless style (dashes at the key's column) would not bind
+                    // the tag to the sequence and it would be lost on reload. The
+                    // indented layout is what the default mode already produces.
+                    Value::Sequence(s) if self.is_block(inner) => {
+                        self.buf.push(b'\n');
+                        self.emit_block_sequence(s, indent + self.step());
+                    }
+                    _ => self.emit_value_after_colon(inner, indent),
+                }
             }
             _ => {
                 self.buf.push(b' ');
@@ -956,6 +967,28 @@ mod tests {
             ..EmitOptions::default()
         };
         assert_eq!(emit(&v, &opts), "key:\n- 1\n- 2\n");
+    }
+
+    #[test]
+    fn tagged_sequence_value_keeps_its_tag_in_indentless_mode() {
+        // A tagged sequence value must indent under the tag even in indentless
+        // mode: dashes at the key's column would sit below the tag's line without
+        // binding to it, so the tag would be lost on reload. The tagged sequence
+        // therefore emits indented, and the document round-trips.
+        let v = Value::Mapping(vec![(
+            s("k"),
+            Value::Tagged(
+                "!t".to_owned(),
+                Box::new(Value::Sequence(vec![s("a"), s("b")])),
+            ),
+        )]);
+        let opts = EmitOptions {
+            indentless_sequences: true,
+            ..EmitOptions::default()
+        };
+        let out = emit(&v, &opts);
+        assert_eq!(out, "k: !t\n  - a\n  - b\n");
+        assert_eq!(reparse(&out), v, "tag survives the round-trip: {out:?}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,22 +87,106 @@ pub mod fuzz {
         };
         let options = EmitOptions::default();
         for document in &documents {
-            let emitted = encode(document, &options);
-            let Ok(text) = std::str::from_utf8(&emitted) else {
-                continue;
-            };
-            let Ok(reparsed) = decode_with(text, Schema::Yaml12, false, false) else {
-                continue;
-            };
-            if reparsed.len() != 1 {
-                continue;
-            }
-            assert!(
-                values_equiv(document, &reparsed[0]),
-                "dumps/loads diverged on data\n  input:    {input:?}\n  emitted:  {text:?}\n  original: {document:?}\n  reparsed: {:?}",
-                reparsed[0]
-            );
+            check_emit_roundtrip(input, document, &options);
         }
+    }
+
+    /// Like [`differential`], but emits each document under a matrix of
+    /// *non-default* [`EmitOptions`]: flow style, wider indentation, indentless
+    /// sequences, the alternate null styles, single-quote preference, explicit
+    /// document markers, and several line widths. The emitter must preserve the
+    /// decoded data under every presentation choice; width-driven line breaking
+    /// (scalar folding, flow-separator breaks) and the indentless layout are the
+    /// prime suspects, since each may only break where it cannot change the value.
+    ///
+    /// `sort_keys` is left out on purpose: it reorders mapping pairs, and the data
+    /// comparison is order-sensitive (a YAML mapping is unordered, but the decoded
+    /// `Value` keeps source order), so a sort would diverge by design, not by bug.
+    pub fn differential_options(input: &str) {
+        let Ok(documents) = decode_with(input, Schema::Yaml12, false, false) else {
+            return;
+        };
+        let base = EmitOptions::default();
+        let configs = [
+            EmitOptions {
+                flow_style: true,
+                ..base.clone()
+            },
+            EmitOptions {
+                indent: 4,
+                ..base.clone()
+            },
+            EmitOptions {
+                indentless_sequences: true,
+                ..base.clone()
+            },
+            EmitOptions {
+                null_style: NullStyle::Tilde,
+                ..base.clone()
+            },
+            EmitOptions {
+                null_style: NullStyle::Null,
+                ..base.clone()
+            },
+            EmitOptions {
+                double_quotes: false,
+                ..base.clone()
+            },
+            EmitOptions {
+                explicit_start: true,
+                explicit_end: true,
+                ..base.clone()
+            },
+            EmitOptions {
+                width: 1,
+                ..base.clone()
+            },
+            EmitOptions {
+                width: 20,
+                ..base.clone()
+            },
+            EmitOptions {
+                width: 80,
+                ..base.clone()
+            },
+            EmitOptions {
+                flow_style: true,
+                width: 20,
+                ..base.clone()
+            },
+        ];
+        for document in &documents {
+            for options in &configs {
+                check_emit_roundtrip(input, document, options);
+            }
+        }
+    }
+
+    /// Emit `document` with `options`, re-decode the output, and assert the data
+    /// survived unchanged. Shared by both differential targets so a divergence is
+    /// reported identically (the panic message names the options that triggered
+    /// it). Re-decode failures and multi-document output are skipped, not
+    /// asserted, for the reasons [`roundtrip`] documents.
+    fn check_emit_roundtrip(
+        input: &str,
+        document: &crate::decode::Value<'_>,
+        options: &EmitOptions,
+    ) {
+        let emitted = encode(document, options);
+        let Ok(text) = std::str::from_utf8(&emitted) else {
+            return;
+        };
+        let Ok(reparsed) = decode_with(text, Schema::Yaml12, false, false) else {
+            return;
+        };
+        if reparsed.len() != 1 {
+            return;
+        }
+        assert!(
+            values_equiv(document, &reparsed[0]),
+            "dumps/loads diverged on data\n  options:  {options:?}\n  input:    {input:?}\n  emitted:  {text:?}\n  original: {document:?}\n  reparsed: {:?}",
+            reparsed[0]
+        );
     }
 
     /// Structural equality of two decoded `Value` trees, identical to the


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Test infrastructure only (a new fuzz target).

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The existing `differential` fuzz target (decode then emit then re-decode, assert the data is unchanged) only ever emits with the default `EmitOptions`. The emit-shaping options were unfuzzed, and that is exactly where silent dumps/loads corruption hides.

This adds a sibling target, `differential_options`, that emits each decoded document under a matrix of non-default options: flow style, wider indentation, indentless sequences, the alternate null styles, single-quote preference, explicit document markers, and several line widths (including a pathological `width: 1`). `sort_keys` is excluded on purpose, it reorders mapping pairs and the order-sensitive comparison would flag that by design, not by bug.

This target found a string of pre-existing silent-corruption / invalid-output bugs in the width-folding and indentless emit paths (all fixed in their own PRs: #95, #96, and the tagged-indentless fix this PR is stacked on). With those fixes in, it runs clean over a 1,000,000-run sweep and now guards those paths against regression.

Stacked on the tagged-indentless-sequence fix, since this target finds that bug on `main`; it will retarget to `main` once that fix merges.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: #95, #96, and the tagged-indentless-sequence fix it is stacked on

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
