### PR TITLE
👷 Give the coverage job more address-space headroom

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -63,6 +63,17 @@ jobs:
       - name: 🏗 Build and install yamlrocks (instrumented)
         run: uv run --no-sync maturin develop
       - name: 🚀 Run pytest to exercise the Rust core
+        # The llvm-cov-instrumented build carries far more baseline memory than
+        # the normal extension (per-region counters, larger code, profile
+        # buffers), so the default address-space guard in `tests/conftest.py`
+        # (1536 MiB, tuned for the uninstrumented suite) is too tight here: the
+        # process high-water creeps up across the full run and a large
+        # real-world round-trip then fails to allocate, which under
+        # `panic = "abort"` shows up as `Fatal Python error: Aborted`. Give the
+        # instrumented run generous headroom; the guard still catches a true
+        # runaway well below the 16 GiB runner.
+        env:
+          YAMLROCKS_AS_LIMIT_MIB: "8192"
         run: uv run --no-sync python -m pytest
       - name: 📊 Generate Cobertura coverage report
         run: cargo llvm-cov report --cobertura --output-path coverage.xml


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. CI workflow only.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The Coverage workflow ("Rust coverage via pytest") intermittently failed with `Fatal Python error: Aborted` (SIGABRT, exit 134) partway through `tests/realworld/test_realworld.py::test_parses_and_round_trips`. The normal test and real-world jobs pass everywhere; only the instrumented coverage build trips, and it does so flakily.

Cause: the coverage job runs an llvm-cov-instrumented build, which carries far more baseline memory than the normal extension (per-region counters, larger code, profile buffers). The pytest step inherited the default 1536 MiB address-space guard from `tests/conftest.py`, which is tuned for the uninstrumented suite. Across the full run the process high-water creeps up, and a large real-world round-trip then fails to allocate; under `panic = "abort"` that aborts the process.

`conftest` already exposes `YAMLROCKS_AS_LIMIT_MIB` for exactly this. This sets it to 8192 MiB for the instrumented pytest step. The guard still catches a true runaway well below the 16 GiB runner; it just stops tripping on the instrumented build's legitimately higher footprint.

Transparency: this is a borderline CI-runner flake that did not reproduce locally even when running the full instrumented suite under the default cap, so the verification is that the coverage check stays green from here rather than a local before/after. The fix is low-risk (a CI-only env var) and principled.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
