### PR TITLE
👷 Build Python 3.15 wheels (GIL and free-threaded) on native legs

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -54,7 +54,7 @@ jobs:
         # 0.29 dropped it), and it exists only on 64-bit plus Windows x86, which
         # is exactly these native targets. The emulated/musl legs do not build
         # it yet.
-        python: ["3.12", "3.13", "3.14", "3.14t"]
+        python: ["3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -66,6 +66,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
+          # 3.15 is still a prerelease (beta); without this, setup-python
+          # cannot resolve it. Stable versions are unaffected.
+          allow-prereleases: true
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: 🏗 Set package version from release tag
         if: inputs.release-tag != ''
@@ -102,7 +105,7 @@ jobs:
         # 0.29 dropped it), and it exists only on 64-bit plus Windows x86, which
         # is exactly these native targets. The emulated/musl legs do not build
         # it yet.
-        python: ["3.12", "3.13", "3.14", "3.14t"]
+        python: ["3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -117,6 +120,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
+          # 3.15 is still a prerelease (beta); without this, setup-python
+          # cannot resolve it. Stable versions are unaffected.
+          allow-prereleases: true
           architecture: ${{ matrix.platform.arch }}
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: 🏗 Set package version from release tag
@@ -155,7 +161,7 @@ jobs:
         # 0.29 dropped it), and it exists only on 64-bit plus Windows x86, which
         # is exactly these native targets. The emulated/musl legs do not build
         # it yet.
-        python: ["3.12", "3.13", "3.14", "3.14t"]
+        python: ["3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -167,6 +173,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
+          # 3.15 is still a prerelease (beta); without this, setup-python
+          # cannot resolve it. Stable versions are unaffected.
+          allow-prereleases: true
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: 🏗 Set package version from release tag
         if: inputs.release-tag != ''

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ SOFTWARE.
 [prek]: https://prek.j178.dev
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
 [pypi]: https://pypi.org/project/yamlrocks/
-[python-versions-shield]: https://img.shields.io/badge/python-3.12_%7C_3.13_%7C_3.14-blue?logo=python&logoColor=white
+[python-versions-shield]: https://img.shields.io/badge/python-3.12_%7C_3.13_%7C_3.14_%7C_3.15-blue?logo=python&logoColor=white
 [realworld-verification]: https://yaml.rocks/verification/real-world-corpus/
 [releases-shield]: https://img.shields.io/github/release/frenck/yamlrocks.svg
 [releases]: https://github.com/frenck/yamlrocks/releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
+  "Programming Language :: Python :: Free Threading :: 3 - Stable",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Rust",
   "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Adds new wheel targets.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Add CPython 3.15 wheels, both the GIL build (cp3.15) and the free-threaded build (cp3.15t), to the native wheel matrices (Linux x86_64, Windows, macOS), and set `allow-prereleases: true` on `setup-python` so it resolves 3.15 while it is still a beta (stable versions are unaffected).

No dependency bump is needed: PyO3 0.29 already supports 3.15 (`STABLE_ABI_MAX_MINOR = 15`, with free-threaded stable-ABI code from 3.15). Verified locally against 3.15.0b1: both a `cp315` and a `cp315t` wheel build with the current toolchain, import cleanly, and round-trip loads/dumps, with the free-threaded build confirmed running GIL-disabled.

Scoped to the native legs for now. The emulated/musllinux legs stay at 3.12-3.14 until 3.15 is available in those container images (it is a beta); adding it there is a follow-up once it is stable.

One thing to watch in CI: the native Linux x86_64 leg builds inside a manylinux container, so its 3.15 legs depend on that image shipping 3.15.0b1. Windows and macOS build against the host `setup-python`, so those are unaffected. If the manylinux image does not have 3.15 yet, I will gate just that leg until it does.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
