### PR TITLE
🐛 Treat an indented `---`/`...` as a plain scalar, not a document marker

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -403,7 +403,11 @@ impl<'input> Scanner<'input> {
         // open and `...` reopens it (handled in their fetchers); anything else
         // here, document content or a `---` start, closes it.
         let is_directive = ch == '%' && self.reader.column() == 0;
+        // A document-end marker is only one at column 0; an indented `...` is a
+        // plain scalar (`key: ...`, `- ...`), so it must not reopen the directive
+        // window any more than it ends the document below.
         let is_doc_end = ch == '.'
+            && self.reader.column() == 0
             && self.reader.check_ahead("...")
             && self.reader.peek_at(3).map_or(true, is_whitespace_or_break);
         if !is_directive && !is_doc_end {
@@ -415,12 +419,18 @@ impl<'input> Scanner<'input> {
             {
                 self.fetch_block_entry(after_entry)
             }
-            '-' if self.reader.check_ahead("---")
+            // `---`/`...` are document markers only at the start of a line
+            // (column 0). Indented, they are ordinary plain-scalar content in a
+            // mapping value or sequence item (`key: ...`, `- ---`), which the spec
+            // and PyYAML both read as the literal string, not a marker.
+            '-' if self.reader.column() == 0
+                && self.reader.check_ahead("---")
                 && self.reader.peek_at(3).map_or(true, is_whitespace_or_break) =>
             {
                 self.fetch_document_start()
             }
-            '.' if self.reader.check_ahead("...")
+            '.' if self.reader.column() == 0
+                && self.reader.check_ahead("...")
                 && self.reader.peek_at(3).map_or(true, is_whitespace_or_break) =>
             {
                 self.fetch_document_end()

--- a/tests/core/test_loads.py
+++ b/tests/core/test_loads.py
@@ -388,8 +388,14 @@ def test_loads_all_rejects_unsupported_options(option):
 
 @pytest.mark.parametrize("marker", ["...", "---"])
 def test_indented_marker_is_a_plain_scalar_value(marker):
-    """An indented `---`/`...` as a mapping value is the literal string."""
-    assert yamlrocks.loads(f"top: {marker}\n".encode()) == {"top": marker}
+    """An indented `---`/`...` as a mapping value is the literal string.
+
+    The scanner is shared with the round-trip path, so pin both: the fast path
+    decodes the string, and round-trip re-emits byte-for-byte.
+    """
+    src = f"top: {marker}\n".encode()
+    assert yamlrocks.loads(src) == {"top": marker}
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_yaml() == src
 
 
 @pytest.mark.parametrize("marker", ["...", "---"])
@@ -397,6 +403,7 @@ def test_indented_marker_does_not_swallow_following_keys(marker):
     """A `...`/`---` value must not end the document and drop later keys."""
     src = f"m:\n  n: {marker}\n  o: 2\n".encode()
     assert yamlrocks.loads(src) == {"m": {"n": marker, "o": 2}}
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_yaml() == src
 
 
 @pytest.mark.parametrize("marker", ["...", "---"])
@@ -404,6 +411,7 @@ def test_indented_marker_as_sequence_item(marker):
     """An indented `---`/`...` sequence item is the literal string, not a marker."""
     src = f"a:\n  - {marker}\n  - b\n".encode()
     assert yamlrocks.loads(src) == {"a": [marker, "b"]}
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_yaml() == src
 
 
 def test_column_zero_markers_still_delimit_documents():

--- a/tests/core/test_loads.py
+++ b/tests/core/test_loads.py
@@ -377,3 +377,35 @@ def test_loads_all_rejects_unsupported_options(option):
     """
     with pytest.raises(ValueError, match="loads_all"):
         yamlrocks.loads_all(b"a: 1\n", option=option)
+
+
+# -- `---`/`...` are document markers only at column 0 -------------------------
+# An indented `---`/`...` is ordinary plain-scalar content (a mapping value or a
+# sequence item), not a document marker. Treating it as a marker silently turned
+# the value into None and could swallow following keys; the spec and PyYAML both
+# read it as the literal string. Regression test for that fast-path bug.
+
+
+@pytest.mark.parametrize("marker", ["...", "---"])
+def test_indented_marker_is_a_plain_scalar_value(marker):
+    """An indented `---`/`...` as a mapping value is the literal string."""
+    assert yamlrocks.loads(f"top: {marker}\n".encode()) == {"top": marker}
+
+
+@pytest.mark.parametrize("marker", ["...", "---"])
+def test_indented_marker_does_not_swallow_following_keys(marker):
+    """A `...`/`---` value must not end the document and drop later keys."""
+    src = f"m:\n  n: {marker}\n  o: 2\n".encode()
+    assert yamlrocks.loads(src) == {"m": {"n": marker, "o": 2}}
+
+
+@pytest.mark.parametrize("marker", ["...", "---"])
+def test_indented_marker_as_sequence_item(marker):
+    """An indented `---`/`...` sequence item is the literal string, not a marker."""
+    src = f"a:\n  - {marker}\n  - b\n".encode()
+    assert yamlrocks.loads(src) == {"a": [marker, "b"]}
+
+
+def test_column_zero_markers_still_delimit_documents():
+    """The fix must not stop real column-0 markers from delimiting documents."""
+    assert yamlrocks.loads_all(b"---\nx\n...\n---\ny\n") == ["x", "y"]


### PR DESCRIPTION
## Breaking change

This changes the parse result for a narrow, previously-mishandled input: an indented `---`/`...` used as a block mapping value or sequence item. Before, the fast path silently decoded it to `null` (and could drop the keys that followed) or raised a spurious "trailing content after document" error. After, it decodes to the literal string `"---"`/`"..."`, matching the YAML spec and PyYAML. Anyone who happened to rely on the old `null` would see the correct string instead.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The fast-path scanner recognized `---`/`...` as document markers wherever they appeared, not only at the start of a line. A document marker is only a marker at column 0; indented, `---`/`...` is ordinary plain-scalar content. The quoted-scalar scanner already enforced this (`at_document_marker` checks `column() == 0`) and so does the `%` directive arm, but the block-token dispatch for `---`/`...` did not.

The result was silent data corruption on the default `loads` path:

- `top: ...` decoded to `{"top": None}` instead of `{"top": "..."}`
- `m:\n  n: ...\n  o: 2` decoded to `{"m": {"n": None}}`, silently dropping `o`
- the same for `---`

This gates the document-start/document-end dispatch (and the directive-window reopen) on `column() == 0`, so an indented marker falls through to plain-scalar scanning. Real column-0 markers and multi-document streams are unaffected.

Surfaced by auditing the real-world config corpus: the fast path rejected three valid Stripe OpenAPI fixtures (`fixtures3*.yaml`, which use `- ...` list items) that PyYAML accepts.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
