### PR TITLE
🐛 Reject malformed block structure in the round-trip composer

### DIFF
--- a/src/ffi/errors.rs
+++ b/src/ffi/errors.rs
@@ -112,8 +112,33 @@ pub fn schema_error(
 /// An `!include`/`!secret`/`!env_var` resolution failure, mapped to the precise
 /// subclass and carrying the file plus (for include errors) the include chain.
 pub fn include_error(py: Python<'_>, e: &IncludeError) -> PyErr {
-    let message = format!("{e}");
     let file = e.path.to_string_lossy().into_owned();
+
+    // A malformed included file is a parse error that happens to live behind an
+    // include. Surface it exactly like the same content errors as a root: a
+    // located `YAMLRocksParseError` pointing at the included file, not an opaque
+    // `YAMLRocksIncludeError`. The include chain is still attached for context.
+    if e.kind == IncludeErrorKind::Parse {
+        let span = e.span.unwrap_or_default();
+        let err = YAMLRocksParseError::new_err(located_message(
+            &e.message,
+            span.line,
+            span.column,
+        ));
+        let value = err.value(py);
+        let _ = value.setattr("file", Some(file));
+        let _ = value.setattr("line", Some(span.line + 1));
+        let _ = value.setattr("column", Some(span.column + 1));
+        let stack: Vec<(String, u32)> = e
+            .include_stack
+            .iter()
+            .map(|(path, line)| (path.to_string_lossy().into_owned(), line + 1))
+            .collect();
+        let _ = value.setattr("include_stack", stack);
+        return err;
+    }
+
+    let message = format!("{e}");
     let stack: Vec<(String, u32)> = e
         .include_stack
         .iter()
@@ -128,6 +153,8 @@ pub fn include_error(py: Python<'_>, e: &IncludeError) -> PyErr {
         IncludeErrorKind::SecretNotFound => (YAMLRocksSecretNotFoundError::new_err(message), false),
         IncludeErrorKind::EnvVarUndefined => (YAMLRocksEnvVarError::new_err(message), false),
         IncludeErrorKind::Invalid => (YAMLRocksIncludeError::new_err(message), true),
+        // Handled by the early return above (a located YAMLRocksParseError).
+        IncludeErrorKind::Parse => unreachable!("Parse is handled before this match"),
     };
 
     let value = err.value(py);

--- a/src/ffi/errors.rs
+++ b/src/ffi/errors.rs
@@ -120,11 +120,7 @@ pub fn include_error(py: Python<'_>, e: &IncludeError) -> PyErr {
     // `YAMLRocksIncludeError`. The include chain is still attached for context.
     if e.kind == IncludeErrorKind::Parse {
         let span = e.span.unwrap_or_default();
-        let err = YAMLRocksParseError::new_err(located_message(
-            &e.message,
-            span.line,
-            span.column,
-        ));
+        let err = YAMLRocksParseError::new_err(located_message(&e.message, span.line, span.column));
         let value = err.value(py);
         let _ = value.setattr("file", Some(file));
         let _ = value.setattr("line", Some(span.line + 1));

--- a/src/include/mod.rs
+++ b/src/include/mod.rs
@@ -190,14 +190,14 @@ impl IncludeResolver {
         // (in-memory `loads(bytes)`), fall back to a placeholder *inside* the
         // base directory so includes still resolve relative to `base_dir`.
         let root = root_path.unwrap_or_else(|| self.base_dir.join("<root>"));
-        let file_id = self.register_file(root, Some(content.to_owned()));
+        let file_id = self.register_file(root.clone(), Some(content.to_owned()));
 
         let nodes = compose_with_file_id(content, file_id).map_err(|e| IncludeError {
-            kind: IncludeErrorKind::Invalid,
+            kind: IncludeErrorKind::Parse,
             message: e.message,
-            path: self.base_dir.clone(),
+            path: root.clone(),
             include_stack: Vec::new(),
-            span: None,
+            span: Some(e.span),
         })?;
 
         let mut resolved = Vec::new();
@@ -679,11 +679,11 @@ impl IncludeResolver {
         })?;
         let file_id = self.register_file(path.to_path_buf(), Some(content.clone()));
         let nodes = compose_with_file_id(&content, file_id).map_err(|e| IncludeError {
-            kind: IncludeErrorKind::Invalid,
+            kind: IncludeErrorKind::Parse,
             message: e.message,
             path: path.to_path_buf(),
             include_stack: stack.to_vec(),
-            span: None,
+            span: Some(e.span),
         })?;
         Ok((file_id, nodes))
     }
@@ -792,7 +792,11 @@ pub enum IncludeErrorKind {
     SecretNotFound,
     /// An `!env_var` references an undefined variable with no default.
     EnvVarUndefined,
-    /// A malformed argument or malformed included document. The catch-all.
+    /// An included file is not valid YAML (the composer rejected it). Carries the
+    /// failing span so it surfaces as a located `YAMLRocksParseError` pointing at
+    /// the included file, identical to how the same content errors as a root.
+    Parse,
+    /// A malformed argument or other resolution failure. The catch-all.
     #[default]
     Invalid,
 }

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -630,7 +630,7 @@ impl<'input> Composer<'input> {
                 } else {
                     NodeStyle::Block
                 };
-                let pairs = self.compose_mapping(events)?;
+                let pairs = self.compose_mapping(events, *flow)?;
                 YamlNode::new(YamlNodeKind::Mapping(pairs), span).with_style(style)
             }
 
@@ -729,6 +729,7 @@ impl<'input> Composer<'input> {
     fn compose_mapping(
         &mut self,
         events: &[Event],
+        flow: bool,
     ) -> Result<Vec<(YamlNode, YamlNode)>, ScanError> {
         let mut pairs = Vec::new();
 
@@ -763,6 +764,22 @@ impl<'input> Composer<'input> {
                 }
                 _ => {
                     let start_pos = self.pos;
+                    let key_span = events[self.pos].span;
+                    // A bare plain scalar (no anchor/tag property) in key position
+                    // with no `:` after it is a missing colon; a property-carrying
+                    // key is structured differently and handled as before.
+                    let bare_scalar_key = matches!(events[self.pos].kind, EventKind::Scalar(..));
+                    // Reject a block collection sitting in mapping-key position
+                    // (mis-indented content), using the same shared check as the
+                    // fast decoder so both paths agree on what is valid.
+                    if let Some(span) =
+                        crate::parser::block_collection_key_span(events, self.pos, flow)
+                    {
+                        return Err(ScanError::new(
+                            crate::parser::BLOCK_COLLECTION_KEY_MESSAGE,
+                            span,
+                        ));
+                    }
                     let key = self
                         .compose_node(events)?
                         .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()));
@@ -770,6 +787,14 @@ impl<'input> Composer<'input> {
                         && matches!(events[self.pos].kind, EventKind::Value);
                     if has_value {
                         self.pos += 1;
+                    } else if !flow && bare_scalar_key {
+                        // A bare key in a block mapping must be followed by `:`;
+                        // its absence is mis-indented content, rejected by the fast
+                        // decoder and PyYAML alike.
+                        return Err(ScanError::new(
+                            crate::parser::MISSING_COLON_MESSAGE,
+                            key_span,
+                        ));
                     }
                     // A flow-mapping entry with a key but no `:` (`{a, b}`) has a
                     // null value; composing one here would wrongly absorb the next

--- a/tests/realworld/test_realworld.py
+++ b/tests/realworld/test_realworld.py
@@ -298,6 +298,12 @@ KNOWN_INVALID: dict[str, str] = {
         "a Jinja2-templated Lovelace config (`{% if %}`) that dedents a sequence "
         "into mapping-key position, not standalone YAML (PyYAML rejects it too)"
     ),
+    "dbt/dbt-core/.github/ISSUE_TEMPLATE/bug-report-vsce.yml": (
+        "an unquoted `description:` value contains `: ` (in `Developer: Reload "
+        "Window`), read as a nested mapping that puts a block collection in "
+        "mapping-key position; PyYAML rejects it too (`mapping values are not "
+        "allowed in this context`)"
+    ),
 }
 
 # opentelemetry-collector-contrib ships Go-templated e2e test fixtures: K8s

--- a/tests/realworld/test_realworld.py
+++ b/tests/realworld/test_realworld.py
@@ -272,6 +272,32 @@ KNOWN_INVALID: dict[str, str] = {
         "multi-line single-quoted flow scalar continued at the block indent (QB6E "
         "spec error); yamlrocks rejects, PyYAML is lenient"
     ),
+    # Mis-indented block structure that puts a block collection in mapping-key
+    # position, or a bare key with no `:`. Invalid YAML the fast decoder and
+    # PyYAML both reject; the round-trip composer now rejects them too (it
+    # previously accepted them, producing nonsense complex keys).
+    "argo-workflows/argo-rollouts/test/e2e/expectedfailures/analysis-run-failfast.yaml": (
+        "mis-indented block sequence reaching mapping-key position; a deliberate "
+        "`expectedfailures` negative fixture (PyYAML rejects it too)"
+    ),
+    "helm/helm-tool/pkg/cmd/testdata/testcharts/chart-bad-requirements/Chart.yaml": (
+        "a dependency's `version:`/`repository:` dedented to the `-` column, "
+        "putting a block mapping in key position; a deliberately-bad "
+        "`chart-bad-requirements` fixture (PyYAML rejects it too)"
+    ),
+    "home-assistant/arsaboo/automations/automations_manual.yaml": (
+        "a Jinja2 template body (`{%- ... -%}`) with bare lines and no `:`, not "
+        "standalone YAML (PyYAML rejects it too)"
+    ),
+    "home-assistant/nagyrobi/esphome/ble-sensors-ethernet.yaml": (
+        "an ESPHome `lambda: |-` block scalar broken by a comment at the key's "
+        "own indent, leaving the C++ body as bare mapping keys (PyYAML rejects "
+        "it too)"
+    ),
+    "home-assistant/thomasloven/lovelace/functions/presence.yaml": (
+        "a Jinja2-templated Lovelace config (`{% if %}`) that dedents a sequence "
+        "into mapping-key position, not standalone YAML (PyYAML rejects it too)"
+    ),
 }
 
 # opentelemetry-collector-contrib ships Go-templated e2e test fixtures: K8s

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -232,3 +232,37 @@ def test_set_comment_via_api_uses_single_space():
     doc = yamlrocks.loads(b"a: 1\n", option=RT)
     doc.node["a"].comment = "added"
     assert doc.to_yaml() == b"a: 1 # added\n"
+
+
+# -- The round-trip composer rejects malformed block structure --------------
+# Mis-indented input that puts a block collection in mapping-key position, or a
+# bare key with no `:`, is invalid YAML. The fast decoder (and PyYAML) reject it;
+# the composer must too, rather than silently composing a nonsense complex key.
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        b"deps:\n  - a: 1\n  b: 2\n",  # `b:` dedents to the dash column
+        b"x:\n  - 1\n  k: 2\n",
+    ],
+)
+def test_round_trip_rejects_block_collection_as_key(src):
+    """A block collection reaching mapping-key position is rejected in round-trip
+    mode, matching the fast path."""
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="cannot be a mapping key"):
+        yamlrocks.loads(src, option=RT)
+
+
+def test_round_trip_rejects_missing_colon():
+    """A bare scalar key with no `:` in a block mapping is rejected in round-trip
+    mode, matching the fast path."""
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="expected ':'"):
+        yamlrocks.loads(b"a: 1\nbare\n", option=RT)
+
+
+@pytest.mark.parametrize("src", [b"? [a, b]\n: c\n", b"{a, b}\n", b"[a: b]\n"])
+def test_round_trip_keeps_valid_complex_and_flow_keys(src):
+    """The validity check must not reject legitimate explicit `?` complex keys or
+    flow mappings with bare keys; those still compose and round-trip."""
+    assert yamlrocks.loads(src, option=RT).to_yaml() == src


### PR DESCRIPTION
## Breaking change

Round-trip mode (`OPT_ROUND_TRIP`) now rejects two kinds of malformed block structure it previously accepted: a block collection sitting in mapping-key position (mis-indented content), and a bare block-mapping key with no `:`. Both are invalid YAML that the fast `loads` path and PyYAML already reject; the composer used to accept them and produce nonsense (a mapping with a tuple key). Anyone who fed such malformed input through the round-trip path and relied on it not raising will now get a `YAMLRocksParseError`. Separately, a malformed *included* file now raises a located `YAMLRocksParseError` pointing at that file instead of a location-less `YAMLRocksIncludeError`.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The fast decoder and the round-trip composer share the same parser but enforced different validity rules. The fast decoder rejects a block collection in mapping-key position (`block_collection_key_span`) and a bare block-mapping key with no `:` (`MISSING_COLON_MESSAGE`); the composer did neither, so the two paths disagreed on what is valid YAML. On the malformed Helm `chart-bad-requirements` fixture, for example, the composer happily produced a mapping keyed by a `(version, repository)` tuple.

This applies the same shared checks in the composer's bare-key arm, so round-trip mode rejects exactly what the fast path does. The explicit `?`-key arm is untouched, so legitimate complex keys (`? [a, b]`) and flow bare keys (`{a, b}`, `[a: b]`) still compose and round-trip byte-for-byte.

That fix had one necessary ripple. A malformed included file used to surface as a location-less `YAMLRocksIncludeError`, because the include resolver wrapped the composer's error and dropped its span. A new `IncludeErrorKind::Parse` carries the failing span, and the FFI maps it to a located `YAMLRocksParseError` pointing at the included file, identical to how the same content errors as a root document. That is both an error-quality improvement and what the existing include tests assert.

Surfaced by auditing the real-world corpus: five files (mis-indented configs, Jinja2 and ESPHome templates) that the fast path and PyYAML reject were silently accepted by the composer. They are added to the real-world suite's `KNOWN_INVALID` set as strict xfails.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
