### PR TITLE
✨ Quote round-trip edits by the document's loaded schema

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1037,11 +1037,17 @@ fn loads_roundtrip(
         }
     }
     validate_schema_root(py, &nodes, schema, yaml_schema.is_yaml_11())?;
+    // The schema governs how an edited-in scalar is quoted, so it must match what
+    // the document re-emits as. An upgraded document is rewritten to canonical
+    // YAML 1.2 (and stamped `%YAML 1.2`), so its edits quote by 1.2 rules even
+    // though it was read as 1.1; otherwise edits follow the loaded schema.
+    let emit_schema = if upgrade { Schema::Yaml12 } else { yaml_schema };
     let doc = YAMLRocksDocument::with_file_map(nodes, file_map, file_sources)
         .with_source(input.to_owned())
         .with_null_style(null_style)
         .with_double_quotes(double_quotes)
-        .with_upgraded(upgrade);
+        .with_upgraded(upgrade)
+        .with_schema(emit_schema);
     Ok(Py::new(py, doc)?.into_any())
 }
 

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -26,6 +26,7 @@ use super::emit;
 use super::emit::{emit_roundtrip_all_with, emit_roundtrip_with};
 use super::value::{node_to_python, python_to_node};
 use crate::encode::NullStyle;
+use crate::resolver::Schema;
 
 /// A single step along a path into the AST: a mapping key or sequence index.
 #[derive(Debug, Clone, PartialEq)]
@@ -73,6 +74,11 @@ pub struct YAMLRocksDocument {
     /// re-emission stamps a `%YAML 1.2` directive so the written-back file
     /// declares its version and is read back as 1.2 (not re-upgraded).
     pub upgraded: bool,
+    /// The schema the document was loaded under. A freshly assigned scalar is
+    /// quoted by this schema's rules so an edit stays the type it reads as (e.g.
+    /// a string `y` keeps quotes under strict 1.1); loaded scalars keep their
+    /// original text. Defaults to 1.2.
+    pub schema: Schema,
 }
 
 /// Free the document's AST without unbounded native recursion. The derived drop
@@ -129,15 +135,16 @@ impl YAMLRocksDocument {
         value: &Bound<'_, PyAny>,
     ) -> PyResult<()> {
         let double_quotes = self.double_quotes;
+        let schema = self.schema;
         if self.nodes.len() == 1 {
-            set_child(py, &mut self.nodes[0], key, value, double_quotes)
+            set_child(py, &mut self.nodes[0], key, value, double_quotes, schema)
         } else {
             let idx: usize = key.extract()?;
             let node = self
                 .nodes
                 .get_mut(idx)
                 .ok_or_else(|| pyo3::exceptions::PyIndexError::new_err("index out of range"))?;
-            *node = python_to_node(py, value, double_quotes)?;
+            *node = python_to_node(py, value, double_quotes, schema)?;
             node.mark_modified();
             Ok(())
         }
@@ -347,6 +354,7 @@ impl YAMLRocksDocument {
             null_style: NullStyle::Empty,
             double_quotes: true,
             upgraded: false,
+            schema: Schema::Yaml12,
         }
     }
 
@@ -366,6 +374,7 @@ impl YAMLRocksDocument {
             null_style: NullStyle::Empty,
             double_quotes: true,
             upgraded: false,
+            schema: Schema::Yaml12,
         }
     }
 
@@ -390,6 +399,13 @@ impl YAMLRocksDocument {
     /// Set whether freshly assigned strings that need quoting use double quotes.
     pub fn with_double_quotes(mut self, double_quotes: bool) -> Self {
         self.double_quotes = double_quotes;
+        self
+    }
+
+    /// Set the schema whose rules govern quoting of freshly assigned scalars, so
+    /// an edit to a document loaded under YAML 1.1 stays 1.1-safe.
+    pub fn with_schema(mut self, schema: Schema) -> Self {
+        self.schema = schema;
         self
     }
 
@@ -482,9 +498,10 @@ impl YAMLRocksDocumentView {
     ) -> PyResult<()> {
         let mut doc = self.root.borrow_mut(py);
         let double_quotes = doc.double_quotes;
+        let schema = doc.schema;
         let node = resolve_path_mut(&mut doc.nodes, &self.path)
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
-        set_child(py, node, key, value, double_quotes)
+        set_child(py, node, key, value, double_quotes, schema)
     }
 
     fn __delitem__(&mut self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<()> {
@@ -623,8 +640,9 @@ impl YAMLRocksNode {
     fn set_value(&self, py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<()> {
         let mut doc = self.root.borrow_mut(py);
         let double_quotes = doc.double_quotes;
+        let schema = doc.schema;
         let node = resolve_path_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
-        let mut new_val = python_to_node(py, value, double_quotes)?;
+        let mut new_val = python_to_node(py, value, double_quotes, schema)?;
         new_val.comments.head = std::mem::take(&mut node.comments.head);
         new_val.comments.inline = node.comments.inline.take();
         // Keep the alignment padding around the value so an edit preserves the
@@ -1183,13 +1201,14 @@ fn set_child(
     key: &Bound<'_, PyAny>,
     value: &Bound<'_, PyAny>,
     double_quotes: bool,
+    schema: Schema,
 ) -> PyResult<()> {
     match &mut node.kind {
         YamlNodeKind::Mapping(pairs) => {
             let key_str: String = key
                 .extract()
                 .map_err(|_| pyo3::exceptions::PyTypeError::new_err("mapping keys must be str"))?;
-            let mut new_val = python_to_node(py, value, double_quotes)?;
+            let mut new_val = python_to_node(py, value, double_quotes, schema)?;
             new_val.mark_modified();
             for (k, v) in pairs.iter_mut() {
                 if scalar_eq(k, &key_str) {
@@ -1219,7 +1238,7 @@ fn set_child(
             let target = items
                 .get_mut(idx)
                 .ok_or_else(|| pyo3::exceptions::PyIndexError::new_err("index out of range"))?;
-            let mut new_val = python_to_node(py, value, double_quotes)?;
+            let mut new_val = python_to_node(py, value, double_quotes, schema)?;
             new_val.mark_modified();
             // Carry the replaced item's metadata (comments, anchor, tag) onto
             // the new value so editing a list entry preserves the markup around

--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -197,8 +197,9 @@ pub(crate) fn python_to_node(
     py: Python<'_>,
     obj: &Bound<'_, PyAny>,
     double_quotes: bool,
+    schema: Schema,
 ) -> PyResult<YamlNode> {
-    python_to_node_depth(py, obj, double_quotes, 0)
+    python_to_node_depth(py, obj, double_quotes, schema, 0)
 }
 
 #[allow(clippy::only_used_in_recursion)]
@@ -206,12 +207,13 @@ fn python_to_node_depth(
     py: Python<'_>,
     obj: &Bound<'_, PyAny>,
     double_quotes: bool,
+    schema: Schema,
     depth: u32,
 ) -> PyResult<YamlNode> {
     // Grow the native stack on demand so assigning a deeply nested object
     // (bounded by `MAX_ASSIGN_DEPTH`) cannot overflow a small thread stack; the
     // recursion re-enters here per level. See [`crate::stack`].
-    crate::stack::guard(|| python_to_node_depth_inner(py, obj, double_quotes, depth))
+    crate::stack::guard(|| python_to_node_depth_inner(py, obj, double_quotes, schema, depth))
 }
 
 #[allow(clippy::only_used_in_recursion)]
@@ -219,6 +221,7 @@ fn python_to_node_depth_inner(
     py: Python<'_>,
     obj: &Bound<'_, PyAny>,
     double_quotes: bool,
+    schema: Schema,
     depth: u32,
 ) -> PyResult<YamlNode> {
     use crate::scanner::Span;
@@ -267,13 +270,19 @@ fn python_to_node_depth_inner(
         ));
     }
     if let Ok(s) = obj.extract::<String>() {
-        let style = assigned_string_style(&s, double_quotes);
+        let style = assigned_string_style(&s, double_quotes, schema);
         return Ok(YamlNode::new(YamlNodeKind::Scalar(s, style), span));
     }
     if let Ok(list) = obj.cast::<PyList>() {
         let mut items = Vec::new();
         for item in list.iter() {
-            items.push(python_to_node_depth(py, &item, double_quotes, depth + 1)?);
+            items.push(python_to_node_depth(
+                py,
+                &item,
+                double_quotes,
+                schema,
+                depth + 1,
+            )?);
         }
         return Ok(YamlNode::new(YamlNodeKind::Sequence(items), span));
     }
@@ -281,8 +290,8 @@ fn python_to_node_depth_inner(
         let mut pairs = Vec::new();
         for (k, v) in dict.iter() {
             pairs.push((
-                python_to_node_depth(py, &k, double_quotes, depth + 1)?,
-                python_to_node_depth(py, &v, double_quotes, depth + 1)?,
+                python_to_node_depth(py, &k, double_quotes, schema, depth + 1)?,
+                python_to_node_depth(py, &v, double_quotes, schema, depth + 1)?,
             ));
         }
         return Ok(YamlNode::new(YamlNodeKind::Mapping(pairs), span));
@@ -298,15 +307,14 @@ fn python_to_node_depth_inner(
 /// plain; otherwise the document's quote preference (double by default). A
 /// single-quoted scalar cannot hold a line break or a literal quote, so those
 /// fall back to double even in single-quote mode, mirroring the fast encoder.
-fn assigned_string_style(value: &str, double_quotes: bool) -> ScalarStyle {
+fn assigned_string_style(value: &str, double_quotes: bool, schema: Schema) -> ScalarStyle {
     // Use the fast encoder's quoting rules verbatim rather than a second,
     // weaker check: a divergent copy let edited values (newlines, `...`, number
     // and bool/null look-alikes, leading indicators) emit unquoted and reparse
-    // as a different value or as broken YAML, defeating round-trip fidelity.
-    // Quote by the default (1.2) rules here; round-trip assignment is not yet
-    // schema-aware (a follow-up threads the document's schema through). This keeps
-    // edited-scalar quoting exactly as before.
-    if !crate::encode::needs_quoting(value, Schema::Yaml12) {
+    // as a different value or as broken YAML, defeating round-trip fidelity. The
+    // document's schema governs, so an edit to a 1.1 document quotes a `y`/`1:30`
+    // that only 1.1 would re-read as a non-string.
+    if !crate::encode::needs_quoting(value, schema) {
         ScalarStyle::Plain
     } else if double_quotes || value.contains('\'') || value.contains('\n') || value.contains('\r')
     {

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -266,3 +266,26 @@ def test_round_trip_keeps_valid_complex_and_flow_keys(src):
     """The validity check must not reject legitimate explicit `?` complex keys or
     flow mappings with bare keys; those still compose and round-trip."""
     assert yamlrocks.loads(src, option=RT).to_yaml() == src
+
+
+# -- Editing a document quotes the edit by the document's schema --------------
+# A scalar assigned into a round-trip document loaded under YAML 1.1 is quoted by
+# 1.1's rules, so it stays the type it reads as. (Unmodified nodes keep their
+# original text; only the edited value is re-quoted.)
+
+
+@pytest.mark.parametrize("value", ["y", "01:02:03", "_5"])
+def test_edit_in_a_1_1_document_is_quoted_1_1_safely(value):
+    """An edit into a 1.1-loaded document is quoted so it re-reads as a string under 1.1."""
+    doc = yamlrocks.loads(b"k: hello\n", option=RT | yamlrocks.OPT_YAML_1_1)
+    doc["k"] = value
+    out = doc.to_yaml()
+    assert b'"' in out
+    assert yamlrocks.loads(out, option=yamlrocks.OPT_YAML_1_1) == {"k": value}
+
+
+def test_edit_in_a_default_document_stays_bare():
+    """The same edit in a 1.2 document stays unquoted (1.2 reads `y` as a string)."""
+    doc = yamlrocks.loads(b"k: hello\n", option=RT)
+    doc["k"] = "y"
+    assert doc.to_yaml() == b"k: y\n"


### PR DESCRIPTION
## Breaking change

None for unmodified documents (they re-emit byte-for-byte) or for documents loaded under YAML 1.2 (edits quote exactly as before). The only behavior change: editing a value in a document loaded under YAML 1.1 now quotes the new scalar by 1.1's rules. Previously such an edit could emit a bare `y`/`1:30` that re-read as a boolean/number instead of the string that was assigned; now it is quoted (`k: "y"`).

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

This is the round-trip half of YAML 1.1 dump support (the fast `dumps` path landed in #114). A scalar assigned into a `YAMLRocksDocument` was always quoted by the 1.2 rules, so "read in 1.1, edit, write back" was not 1.1-safe: assigning the string `y` to a document loaded as 1.1 emitted a bare `y`, which a 1.1 reader turns back into the boolean `True`.

The document now records the schema it was loaded under (via `with_schema`, set at load; an upgraded document gets 1.2 because it re-emits canonical 1.2 with a `%YAML 1.2` directive). That schema is threaded through the assignment path (`python_to_node` → `assigned_string_style` → the shared `needs_quoting`), so a freshly assigned scalar is quoted by the same rules the fast `dumps` path uses for that schema. Unmodified nodes keep their original text, so an untouched document still re-emits byte-for-byte.

Scope: the edit/assignment path only. Round-trip `to_dict` projection still resolves scalars under the 1.2 schema regardless of `OPT_YAML_1_1` (so `to_dict()` on a 1.1 document does not yet match the fast path's 1.1 resolution). That fix needs the schema threaded through every `node_to_python` caller and is coupled to a pending decision on whether bare `y`/`n` should resolve as booleans under 1.1, so it is left for a separate follow-up.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: the YAML 1.1 dump-mode work (follows #114)
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
