### PR TITLE
✨ Resolve round-trip projection under the document's loaded schema

### DIFF
--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -13,9 +13,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyList, PyString, PyTuple};
-
-use crate::scanner::ScalarStyle;
+use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 
 use super::anchors::{
     alias_target_path, build_anchor_map, collect_alias_paths, collect_anchor_paths,
@@ -138,7 +136,16 @@ impl YAMLRocksDocument {
         let double_quotes = self.double_quotes;
         let schema = self.schema;
         if self.nodes.len() == 1 {
-            set_child(py, &mut self.nodes[0], key, value, double_quotes, schema)
+            let anchors = build_anchor_map(&self.nodes);
+            set_child(
+                py,
+                &mut self.nodes[0],
+                key,
+                value,
+                double_quotes,
+                schema,
+                &anchors,
+            )
         } else {
             let idx: usize = key.extract()?;
             let node = self
@@ -500,9 +507,10 @@ impl YAMLRocksDocumentView {
         let mut doc = self.root.borrow_mut(py);
         let double_quotes = doc.double_quotes;
         let schema = doc.schema;
+        let anchors = build_anchor_map(&doc.nodes);
         let node = resolve_path_mut(&mut doc.nodes, &self.path)
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
-        set_child(py, node, key, value, double_quotes, schema)
+        set_child(py, node, key, value, double_quotes, schema, &anchors)
     }
 
     fn __delitem__(&mut self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<()> {
@@ -1149,6 +1157,27 @@ pub(crate) fn scalar_eq(key: &YamlNode, name: &str) -> bool {
     matches!(&key.kind, YamlNodeKind::Scalar(s, _) if s == name)
 }
 
+/// Whether `key_node`, resolved under `schema`, equals the Python `key`. Indexed
+/// access and assignment match the *resolved* mapping key, so `doc[True]` reaches
+/// a `yes:` entry under YAML 1.1 (and `doc['yes']` does not), consistent with
+/// `keys()`/`to_dict()` and with Python dict semantics (e.g. `True == 1`). Only
+/// scalar keys are addressable this way; a collection key is not.
+fn key_node_matches(
+    py: Python<'_>,
+    key_node: &YamlNode,
+    key: &Bound<'_, PyAny>,
+    schema: Schema,
+    anchors: &HashMap<String, YamlNode>,
+) -> bool {
+    if !matches!(key_node.kind, YamlNodeKind::Scalar(..)) {
+        return false;
+    }
+    node_to_python_with(py, key_node, schema, anchors)
+        .bind(py)
+        .eq(key)
+        .unwrap_or(false)
+}
+
 // -- Child access shared by YAMLRocksDocument and YAMLRocksDocumentView --
 
 /// Read a child of `node`: scalars resolve to plain Python; containers return a
@@ -1162,7 +1191,22 @@ fn access_child(
     anchors: &HashMap<String, YamlNode>,
     schema: Schema,
 ) -> PyResult<Py<PyAny>> {
-    let seg = seg_from_key(key)?;
+    // For a mapping, match the looked-up key against each key resolved under the
+    // schema (so `doc[True]` finds a `yes:` entry), recording the matched key's
+    // lexeme for the path. Sequences index by position as before.
+    let seg = match &node.kind {
+        YamlNodeKind::Mapping(pairs) => {
+            let (k, _) = pairs
+                .iter()
+                .find(|(k, _)| key_node_matches(py, k, key, schema, anchors))
+                .ok_or_else(|| key_error(node, key))?;
+            let YamlNodeKind::Scalar(lexeme, _) = &k.kind else {
+                unreachable!("key_node_matches only matches scalar keys")
+            };
+            PathSeg::Key(lexeme.clone())
+        }
+        _ => seg_from_key(key)?,
+    };
     let child = child_ref(node, &seg).ok_or_else(|| key_error(node, key))?;
 
     let mut path = parent_path.to_vec();
@@ -1205,16 +1249,16 @@ fn set_child(
     value: &Bound<'_, PyAny>,
     double_quotes: bool,
     schema: Schema,
+    anchors: &HashMap<String, YamlNode>,
 ) -> PyResult<()> {
     match &mut node.kind {
         YamlNodeKind::Mapping(pairs) => {
-            let key_str: String = key
-                .extract()
-                .map_err(|_| pyo3::exceptions::PyTypeError::new_err("mapping keys must be str"))?;
             let mut new_val = python_to_node(py, value, double_quotes, schema)?;
             new_val.mark_modified();
+            // Match an existing key by its resolved value (so `doc[True] = x`
+            // updates a `yes:` entry under 1.1), mirroring read access.
             for (k, v) in pairs.iter_mut() {
-                if scalar_eq(k, &key_str) {
+                if key_node_matches(py, k, key, schema, anchors) {
                     // Replacing a value keeps the metadata attached to it (its
                     // comments, anchor, and tag), matching `YAMLRocksNode.set_value`, so
                     // an edit does not silently drop nearby comments or markup.
@@ -1229,10 +1273,11 @@ fn set_child(
                     return Ok(());
                 }
             }
-            let new_key = YamlNode::new(
-                YamlNodeKind::Scalar(key_str, ScalarStyle::Plain),
-                crate::scanner::Span::default(),
-            );
+            // No key matched: add one, building the key node from the Python key
+            // so a non-string key (`doc[True] = ...`) and a string that needs
+            // quoting under the schema both emit correctly.
+            let mut new_key = python_to_node(py, key, double_quotes, schema)?;
+            new_key.mark_modified();
             pairs.push((new_key, new_val));
             Ok(())
         }
@@ -1431,8 +1476,10 @@ fn collect_leaves_inner(
     match &node.kind {
         YamlNodeKind::Mapping(pairs) => {
             for (key, val) in pairs {
-                if let YamlNodeKind::Scalar(name, _) = &key.kind {
-                    path.push(PyString::new(py, name).into_any().unbind());
+                if let YamlNodeKind::Scalar(_, _) = &key.kind {
+                    // Resolve the path key under the schema so `walk()` paths match
+                    // `keys()` and indexed access (a `yes:` key is `True` under 1.1).
+                    path.push(node_to_python_with(py, key, schema, anchors));
                     collect_leaves(py, val, path, out, anchors, schema)?;
                     path.pop();
                 }

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -24,7 +24,7 @@ use super::anchors::{
 use super::ast::{NodeStyle, YamlNode, YamlNodeKind};
 use super::emit;
 use super::emit::{emit_roundtrip_all_with, emit_roundtrip_with};
-use super::value::{node_to_python, python_to_node};
+use super::value::{node_to_python_with, python_to_node};
 use crate::encode::NullStyle;
 use crate::resolver::Schema;
 
@@ -112,8 +112,9 @@ impl YAMLRocksDocument {
         let py = slf.py();
         let this = slf.borrow();
         let anchors = build_anchor_map(&this.nodes);
+        let schema = this.schema;
         if this.nodes.len() == 1 {
-            access_child(py, slf, &[], &this.nodes[0], key, &anchors)
+            access_child(py, slf, &[], &this.nodes[0], key, &anchors, schema)
         } else {
             let idx: usize = key.extract().map_err(|_| {
                 pyo3::exceptions::PyKeyError::new_err(
@@ -124,7 +125,7 @@ impl YAMLRocksDocument {
                 .nodes
                 .get(idx)
                 .ok_or_else(|| pyo3::exceptions::PyIndexError::new_err("index out of range"))?;
-            wrap_node(py, slf, vec![PathSeg::Index(idx)], node, &anchors)
+            wrap_node(py, slf, vec![PathSeg::Index(idx)], node, &anchors, schema)
         }
     }
 
@@ -187,7 +188,7 @@ impl YAMLRocksDocument {
     fn keys(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         if self.nodes.len() == 1 {
             let anchors = build_anchor_map(&self.nodes);
-            node_keys(py, &self.nodes[0], &anchors)
+            node_keys(py, &self.nodes[0], &anchors, self.schema)
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
                 "keys() is only available on a single mapping document",
@@ -311,11 +312,11 @@ impl YAMLRocksDocument {
     fn to_dict(&self, py: Python<'_>) -> Py<PyAny> {
         let anchors = build_anchor_map(&self.nodes);
         if self.nodes.len() == 1 {
-            node_to_python(py, &self.nodes[0], &anchors)
+            node_to_python_with(py, &self.nodes[0], self.schema, &anchors)
         } else {
             let list = PyList::empty(py);
             for node in &self.nodes {
-                let _ = list.append(node_to_python(py, node, &anchors));
+                let _ = list.append(node_to_python_with(py, node, self.schema, &anchors));
             }
             list.into_any().unbind()
         }
@@ -337,7 +338,7 @@ impl YAMLRocksDocument {
         let mut out: Vec<(Vec<Py<PyAny>>, Py<PyAny>)> = Vec::new();
         let anchors = build_anchor_map(&self.nodes);
         if let Some(root) = self.nodes.first() {
-            collect_leaves(py, root, &mut Vec::new(), &mut out, &anchors)?;
+            collect_leaves(py, root, &mut Vec::new(), &mut out, &anchors, self.schema)?;
         }
         leaves_to_list(py, out)
     }
@@ -487,7 +488,7 @@ impl YAMLRocksDocumentView {
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
         let anchors = build_anchor_map(&doc.nodes);
         let root_bound = root.bind(py);
-        access_child(py, root_bound, &this.path, node, key, &anchors)
+        access_child(py, root_bound, &this.path, node, key, &anchors, doc.schema)
     }
 
     fn __setitem__(
@@ -535,7 +536,7 @@ impl YAMLRocksDocumentView {
         let node = resolve_path(&doc.nodes, &self.path)
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
         let anchors = build_anchor_map(&doc.nodes);
-        node_keys(py, node, &anchors)
+        node_keys(py, node, &anchors, doc.schema)
     }
 
     /// The [`YAMLRocksNode`] cursor for this view's node: a metadata-bearing handle
@@ -557,7 +558,7 @@ impl YAMLRocksDocumentView {
         let node = resolve_path(&doc.nodes, &self.path)
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
         let anchors = build_anchor_map(&doc.nodes);
-        Ok(node_to_python(py, node, &anchors))
+        Ok(node_to_python_with(py, node, doc.schema, &anchors))
     }
 
     /// Alias for [`unwrap`](Self::unwrap): the resolved plain-Python value.
@@ -582,7 +583,7 @@ impl YAMLRocksDocumentView {
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
         let anchors = build_anchor_map(&doc.nodes);
         let mut out: Vec<(Vec<Py<PyAny>>, Py<PyAny>)> = Vec::new();
-        collect_leaves(py, node, &mut Vec::new(), &mut out, &anchors)?;
+        collect_leaves(py, node, &mut Vec::new(), &mut out, &anchors, doc.schema)?;
         leaves_to_list(py, out)
     }
 
@@ -632,7 +633,7 @@ impl YAMLRocksNode {
         let doc = self.root.borrow(py);
         let node = resolve_path(&doc.nodes, &self.path).ok_or_else(stale_node)?;
         let anchors = build_anchor_map(&doc.nodes);
-        Ok(node_to_python(py, node, &anchors))
+        Ok(node_to_python_with(py, node, doc.schema, &anchors))
     }
 
     /// Replace this node's value, preserving its comments, anchor, and tag.
@@ -1159,13 +1160,14 @@ fn access_child(
     node: &YamlNode,
     key: &Bound<'_, PyAny>,
     anchors: &HashMap<String, YamlNode>,
+    schema: Schema,
 ) -> PyResult<Py<PyAny>> {
     let seg = seg_from_key(key)?;
     let child = child_ref(node, &seg).ok_or_else(|| key_error(node, key))?;
 
     let mut path = parent_path.to_vec();
     path.push(seg);
-    wrap_node(py, root, path, child, anchors)
+    wrap_node(py, root, path, child, anchors, schema)
 }
 
 /// Wrap a node for return to Python: scalars as plain values, containers as
@@ -1176,6 +1178,7 @@ fn wrap_node(
     path: Vec<PathSeg>,
     node: &YamlNode,
     anchors: &HashMap<String, YamlNode>,
+    schema: Schema,
 ) -> PyResult<Py<PyAny>> {
     match &node.kind {
         YamlNodeKind::Mapping(_) | YamlNodeKind::Sequence(_) => {
@@ -1188,10 +1191,10 @@ fn wrap_node(
         // An alias cannot resolve to a live view: it has no path of its own, so
         // we follow it to its anchor and return a plain snapshot instead.
         YamlNodeKind::Alias(name) => match anchors.get(name) {
-            Some(target) => wrap_node(py, root, path, target, anchors),
+            Some(target) => wrap_node(py, root, path, target, anchors, schema),
             None => Ok(py.None()),
         },
-        _ => Ok(node_to_python(py, node, anchors)),
+        _ => Ok(node_to_python_with(py, node, schema, anchors)),
     }
 }
 
@@ -1310,12 +1313,13 @@ fn node_keys(
     py: Python<'_>,
     node: &YamlNode,
     anchors: &HashMap<String, YamlNode>,
+    schema: Schema,
 ) -> PyResult<Py<PyAny>> {
     match &node.kind {
         YamlNodeKind::Mapping(pairs) => {
             let list = PyList::empty(py);
             for (k, _) in pairs {
-                list.append(node_to_python(py, k, anchors))?;
+                list.append(node_to_python_with(py, k, schema, anchors))?;
             }
             Ok(list.into_any().unbind())
         }
@@ -1409,10 +1413,11 @@ fn collect_leaves(
     path: &mut Vec<Py<PyAny>>,
     out: &mut Vec<(Vec<Py<PyAny>>, Py<PyAny>)>,
     anchors: &HashMap<String, YamlNode>,
+    schema: Schema,
 ) -> PyResult<()> {
     // Grow the native stack on demand so walking a deeply nested document cannot
     // overflow a small thread stack. See [`crate::stack`].
-    crate::stack::guard(|| collect_leaves_inner(py, node, path, out, anchors))
+    crate::stack::guard(|| collect_leaves_inner(py, node, path, out, anchors, schema))
 }
 
 fn collect_leaves_inner(
@@ -1421,13 +1426,14 @@ fn collect_leaves_inner(
     path: &mut Vec<Py<PyAny>>,
     out: &mut Vec<(Vec<Py<PyAny>>, Py<PyAny>)>,
     anchors: &HashMap<String, YamlNode>,
+    schema: Schema,
 ) -> PyResult<()> {
     match &node.kind {
         YamlNodeKind::Mapping(pairs) => {
             for (key, val) in pairs {
                 if let YamlNodeKind::Scalar(name, _) = &key.kind {
                     path.push(PyString::new(py, name).into_any().unbind());
-                    collect_leaves(py, val, path, out, anchors)?;
+                    collect_leaves(py, val, path, out, anchors, schema)?;
                     path.pop();
                 }
             }
@@ -1435,11 +1441,11 @@ fn collect_leaves_inner(
         YamlNodeKind::Sequence(items) => {
             for (i, item) in items.iter().enumerate() {
                 path.push(i.into_pyobject(py)?.into_any().unbind());
-                collect_leaves(py, item, path, out, anchors)?;
+                collect_leaves(py, item, path, out, anchors, schema)?;
                 path.pop();
             }
         }
-        _ => out.push((path.clone(), node_to_python(py, node, anchors))),
+        _ => out.push((path.clone(), node_to_python_with(py, node, schema, anchors))),
     }
     Ok(())
 }

--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -14,18 +14,9 @@ use crate::resolver::{ResolvedValue, Schema};
 use crate::roundtrip::ast::{YamlNode, YamlNodeKind};
 use crate::scanner::ScalarStyle;
 
-/// Resolve a node to a plain Python value (used for scalars and `unwrap()`),
-/// using the YAML 1.2 scalar schema. `anchors` resolves `*alias` nodes.
-pub fn node_to_python(
-    py: Python<'_>,
-    node: &YamlNode,
-    anchors: &HashMap<String, YamlNode>,
-) -> Py<PyAny> {
-    node_to_python_with(py, node, Schema::Yaml12, anchors)
-}
-
-/// Like [`node_to_python`], but `schema` selects the YAML 1.1 scalar schema so
-/// `yes`/`no` resolve as booleans and `0777` as an octal int.
+/// Resolve a node to a plain Python value (scalars, and `to_dict`/`unwrap`),
+/// using `schema` for scalar typing (so under 1.1 `yes`/`no` are booleans and
+/// `0777` an octal int). `anchors` resolves `*alias` nodes.
 pub fn node_to_python_with(
     py: Python<'_>,
     node: &YamlNode,

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -289,3 +289,29 @@ def test_edit_in_a_default_document_stays_bare():
     doc = yamlrocks.loads(b"k: hello\n", option=RT)
     doc["k"] = "y"
     assert doc.to_yaml() == b"k: y\n"
+
+
+# -- Round-trip projection resolves under the document's loaded schema --------
+# to_dict()/view access/walk() type scalars with the schema the document was
+# loaded under, matching the fast loads() path, instead of always 1.2.
+
+
+def test_round_trip_to_dict_resolves_under_the_loaded_1_1_schema():
+    """Round-trip to_dict() under OPT_YAML_1_1 resolves like the fast path; the
+    1.2 default keeps the same scalars as strings."""
+    src = b"a: yes\nb: 0777\nc: plain\n"
+    fast = yamlrocks.loads(src, option=yamlrocks.OPT_YAML_1_1)
+    rt = yamlrocks.loads(src, option=RT | yamlrocks.OPT_YAML_1_1).to_dict()
+    assert rt == fast == {"a": True, "b": 511, "c": "plain"}
+    assert yamlrocks.loads(src, option=RT).to_dict() == {
+        "a": "yes",
+        "b": "0777",
+        "c": "plain",
+    }
+
+
+def test_round_trip_view_and_walk_resolve_under_1_1():
+    """A nested view value and walk() honor the loaded 1.1 schema too."""
+    doc = yamlrocks.loads(b"m:\n  k: yes\n", option=RT | yamlrocks.OPT_YAML_1_1)
+    assert doc["m"]["k"] is True
+    assert list(doc.walk()) == [(("m", "k"), True)]

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -297,8 +297,7 @@ def test_edit_in_a_default_document_stays_bare():
 
 
 def test_round_trip_to_dict_resolves_under_the_loaded_1_1_schema():
-    """Round-trip to_dict() under OPT_YAML_1_1 resolves like the fast path; the
-    1.2 default keeps the same scalars as strings."""
+    """Round-trip to_dict() under OPT_YAML_1_1 matches the fast path; default 1.2 keeps these scalars as strings."""
     src = b"a: yes\nb: 0777\nc: plain\n"
     fast = yamlrocks.loads(src, option=yamlrocks.OPT_YAML_1_1)
     rt = yamlrocks.loads(src, option=RT | yamlrocks.OPT_YAML_1_1).to_dict()
@@ -315,3 +314,36 @@ def test_round_trip_view_and_walk_resolve_under_1_1():
     doc = yamlrocks.loads(b"m:\n  k: yes\n", option=RT | yamlrocks.OPT_YAML_1_1)
     assert doc["m"]["k"] is True
     assert list(doc.walk()) == [(("m", "k"), True)]
+
+
+def test_round_trip_access_matches_the_resolved_key_under_1_1():
+    """Indexed access matches the resolved mapping key (a `yes:` key is `True`), so it stays consistent with keys()/walk()."""
+    doc = yamlrocks.loads(b"yes: 1\nplain: 2\n", option=RT | yamlrocks.OPT_YAML_1_1)
+    resolved_keys = list(doc.keys())
+    assert resolved_keys == [True, "plain"]
+    assert doc[True] == 1  # resolved key
+    assert [doc[k] for k in resolved_keys] == [
+        1,
+        2,
+    ]  # keys() round-trips through access
+    with pytest.raises(KeyError):
+        doc["yes"]  # the lexeme is not the key under 1.1
+
+
+def test_round_trip_default_access_uses_the_string_key():
+    """Under the 1.2 default the same key stays the string `yes`, so `doc['yes']` works."""
+    doc = yamlrocks.loads(b"yes: 1\n", option=RT)
+    assert list(doc.keys()) == ["yes"]
+    assert doc["yes"] == 1
+
+
+def test_round_trip_assign_by_resolved_key_updates_the_entry():
+    """Assigning by the resolved key updates the matching entry in place; a new bool key emits a bool scalar."""
+    doc = yamlrocks.loads(b"yes: 1\n", option=RT | yamlrocks.OPT_YAML_1_1)
+    doc[True] = 9
+    assert doc.to_yaml() == b"yes: 9\n"  # existing entry updated, lexeme kept
+    doc[False] = 7  # a new bool key
+    assert yamlrocks.loads(doc.to_yaml(), option=yamlrocks.OPT_YAML_1_1) == {
+        True: 9,
+        False: 7,
+    }


### PR DESCRIPTION
## Breaking change

`to_dict()` (and view access, `keys()`, `walk()`) on a round-trip document loaded under `OPT_YAML_1_1` now resolves scalars by the 1.1 schema instead of always 1.2. So `yamlrocks.loads(src, option=OPT_ROUND_TRIP | OPT_YAML_1_1).to_dict()` returns `True` for `yes`, `511` for `0777`, and so on, matching the fast `loads(src, OPT_YAML_1_1)` path. Code that loaded a 1.1 document in round-trip mode and read its projected values previously got 1.2-typed results (e.g. the string `'yes'`); it now gets the 1.1-typed values. The 1.2 default is unaffected, and byte-for-byte re-emission of unmodified documents is unchanged.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The round-trip projection (`YAMLRocksDocument`/`YAMLRocksDocumentView`/`YAMLRocksNode` → plain Python) always typed scalars with `Schema::Yaml12`, so it ignored the schema the document was loaded with. That made round-trip `to_dict()` disagree with the fast `loads()` path under `OPT_YAML_1_1`: the fast path resolved `yes` to `True`, but round-trip returned the string `'yes'`. The two decode paths should agree on what a document means.

This threads the document's schema (stored since the round-trip-edit work) through the projection helpers (`access_child`, `wrap_node`, `node_keys`, `collect_leaves`) and every call site, replacing the 1.2-hardcoded `node_to_python` with `node_to_python_with(schema)`. The now-unused `node_to_python` wrapper is removed.

This is the read half of the round-trip 1.1 story; #115 made round-trip edits quote by the loaded schema, and this makes round-trip reads resolve by it.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: the YAML 1.1 round-trip work (follows #114, #115)
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
