### PR TITLE
📝 Frame the three scalar schemas and the strict-1.1 y/n sharp edge

### DIFF
--- a/docs/src/content/docs/guides/yaml-11-vs-12.md
+++ b/docs/src/content/docs/guides/yaml-11-vs-12.md
@@ -136,15 +136,23 @@ flag.
 
 ### PyYAML-compatible booleans
 
-`OPT_YAML_1_1` follows the literal YAML 1.1 spec, where bare `y`/`Y`/`n`/`N` are
-booleans alongside `yes`/`no`/`on`/`off`. PyYAML deliberately drops the
-single-letter forms (its resolver lists `y`/`n` as candidates but its regex does
-not match them), so a `y:` key, common for coordinates, stays a string there. The
-PyYAML-based ecosystem (Home Assistant, ESPHome, Ansible) relies on that quirk.
+There are three scalar schemas in play: **YAML 1.2** (the default), **strict YAML
+1.1** (`OPT_YAML_1_1`), and **PyYAML-compat** (`OPT_PYYAML_COMPAT`). The third is
+not a fourth set of rules to learn: it is strict YAML 1.1 with exactly one
+exception.
 
-`OPT_PYYAML_COMPAT` selects PyYAML's set instead: `yes`/`no`/`on`/`off`/`true`/
-`false` (and their case variants) resolve as booleans, but bare `y`/`n` stay
-strings. It implies the 1.1 schema, so it works on its own, and it carries
+`OPT_YAML_1_1` follows the literal YAML 1.1 spec, where bare `y`/`Y`/`n`/`N` are
+booleans alongside `yes`/`no`/`on`/`off`. That is spec-correct, but it is a sharp
+edge: a `y:` key, common for coordinates, becomes the boolean key `True`, and a
+value `n` becomes `False`. PyYAML deliberately drops the single-letter forms (its
+resolver lists `y`/`n` as candidates but its regex does not match them), and the
+PyYAML-based ecosystem (Home Assistant, ESPHome, Ansible) relies on that.
+
+`OPT_PYYAML_COMPAT` is that one exception: identical to strict 1.1 in every way
+(`yes`/`no`/`on`/`off`/`true`/`false` and their case variants are booleans,
+`0777` is octal, `1:30` is sexagesimal), **except** bare `y`/`Y`/`n`/`N` stay
+strings. If you are reading configs written for the PyYAML ecosystem, this is the
+flag you want. It implies the 1.1 schema, so it works on its own, and it carries
 through the migration paths above, `OPT_UPGRADE_1_1` and `OPT_YAML_1_1_WARN` both
 treat `y`/`n` as strings under it.
 


### PR DESCRIPTION
## Breaking change

None. Documentation only; no code or behavior changes.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Sharpens the YAML 1.1-vs-1.2 guide to make the three scalar schemas explicit and easy to reason about: **YAML 1.2** (the default), **strict YAML 1.1** (`OPT_YAML_1_1`), and **PyYAML-compat** (`OPT_PYYAML_COMPAT`). The key reframing is that PyYAML-compat is not a fourth rule set to learn, it is strict YAML 1.1 with exactly one exception: bare `y`/`Y`/`n`/`N` stay strings.

It also names the strict-1.1 sharp edge plainly (a `y:` key becomes the boolean key `True`, a value `n` becomes `False`) and points readers of PyYAML-ecosystem configs (Home Assistant, ESPHome, Ansible) at `OPT_PYYAML_COMPAT`.

This came out of auditing the real-world corpus, where strict 1.1's `y`/`n`-as-boolean behavior surfaced as a divergence from PyYAML. The behavior is intentional and correct (spec-compliant, opt-in), so the resolution is to document the model clearly rather than change it.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: the YAML 1.1 work (#114, #115, #116)
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
