### PR TITLE
🐛 Report a missing relative include as not-found, not confinement

### DIFF
--- a/src/include/mod.rs
+++ b/src/include/mod.rs
@@ -624,7 +624,22 @@ impl IncludeResolver {
                 Ok(resolved)
             }
             Err(_) => {
-                let lexical = lexical_normalize(&candidate);
+                // The path does not canonicalize (it is missing, or a dangling
+                // symlink), so it is checked lexically. `canonical_base` is
+                // absolute, so a relative candidate must be anchored to the
+                // current directory first (the same directory `canonical_base`
+                // was resolved against). Otherwise a relative `include_dir` like
+                // "." leaves the candidate relative, and a missing in-tree file
+                // (`missing.yaml`) fails `starts_with` and is misreported as a
+                // confinement escape instead of a plain not-found.
+                let absolute = if candidate.is_absolute() {
+                    candidate.clone()
+                } else {
+                    std::env::current_dir()
+                        .map(|cwd| cwd.join(&candidate))
+                        .unwrap_or_else(|_| candidate.clone())
+                };
+                let lexical = lexical_normalize(&absolute);
                 if !lexical.starts_with(&self.canonical_base) {
                     return Err(confinement());
                 }

--- a/tests/features/test_includes.py
+++ b/tests/features/test_includes.py
@@ -265,6 +265,27 @@ def test_missing_include_raises(tmp_path):
         )
 
 
+def test_missing_relative_include_is_not_found_not_confinement(tmp_path, monkeypatch):
+    """A missing in-tree file with a relative include_dir is not-found, not a
+    confinement escape. Regression: a relative dir left the candidate path
+    relative, so it failed the absolute-base check and was misreported as an
+    attempt to escape the include directory."""
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(yamlrocks.YAMLRocksIncludeNotFoundError):
+        yamlrocks.loads(
+            b"x: !include missing.yaml\n",
+            option=yamlrocks.OPT_INCLUDES,
+            include_dir=".",
+        )
+    # A genuine escape is still a confinement error, even with a relative dir.
+    with pytest.raises(yamlrocks.YAMLRocksIncludeConfinementError):
+        yamlrocks.loads(
+            b"x: !include ../escape.yaml\n",
+            option=yamlrocks.OPT_INCLUDES,
+            include_dir=".",
+        )
+
+
 def test_include_resolver_composes_tag_families(tmp_path, monkeypatch):
     """The include resolver expands !include, !secret, and !env_var together.
 


### PR DESCRIPTION
## Breaking change

None. The fix changes only the *error class* for a missing included file when `include_dir` is relative: it now raises `YAMLRocksIncludeNotFoundError` instead of `YAMLRocksIncludeConfinementError`. Successful loads, genuine confinement escapes, and absolute `include_dir` are all unchanged.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

When an included path does not canonicalize (typically a missing file), `confine()` falls back to a lexical check against the absolute confinement base. With a relative `include_dir` such as `"."`, the candidate path stays relative (e.g. `missing.yaml`), so `starts_with(absolute_base)` fails and a simple missing in-tree file is misreported as `YAMLRocksIncludeConfinementError`, an escape attempt, rather than not-found. That is both wrong and alarming (it signals a security violation for an ordinary typo).

The fix anchors a relative candidate to the current directory (the same directory `canonical_base` was resolved against with `dunce::canonicalize`) before the lexical comparison. A missing in-tree file then resolves to not-found, while a genuine `../escape` still normalizes outside the base and trips confinement. Absolute `include_dir` paths were already absolute, so their behavior is unchanged.

Found via an independent code review of the include resolver.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
