### PR TITLE
🐛 Guard the remaining round-trip AST traversals against stack overflow

### DIFF
--- a/src/roundtrip/anchors.rs
+++ b/src/roundtrip/anchors.rs
@@ -72,6 +72,17 @@ pub(crate) fn walk_anchor(
     prefix: &mut Vec<PathSeg>,
     found: &mut Option<Vec<PathSeg>>,
 ) {
+    // Grow the native stack on demand: this recurses once per nesting level over
+    // attacker-controlled AST depth. See [`crate::stack`].
+    crate::stack::guard(|| walk_anchor_inner(node, name, prefix, found))
+}
+
+fn walk_anchor_inner(
+    node: &YamlNode,
+    name: &str,
+    prefix: &mut Vec<PathSeg>,
+    found: &mut Option<Vec<PathSeg>>,
+) {
     if found.is_some() {
         return;
     }

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -68,6 +68,13 @@ pub fn check_duplicate_keys(nodes: &[YamlNode], schema: Schema) -> Result<(), Sc
 }
 
 fn check_node_duplicate_keys(node: &YamlNode, schema: Schema) -> Result<(), ScanError> {
+    // Grow the native stack on demand: this recurses once per nesting level over
+    // attacker-controlled AST depth (bounded by the composer's MAX_DEPTH), so a
+    // small thread stack could otherwise overflow. See [`crate::stack`].
+    crate::stack::guard(|| check_node_duplicate_keys_inner(node, schema))
+}
+
+fn check_node_duplicate_keys_inner(node: &YamlNode, schema: Schema) -> Result<(), ScanError> {
     match &node.kind {
         YamlNodeKind::Mapping(pairs) => {
             // A `HashSet` of key signatures gives O(1) membership; a linear scan
@@ -109,6 +116,12 @@ pub fn collect_duplicate_keys(nodes: &[YamlNode], schema: Schema) -> Vec<String>
 }
 
 fn collect_node_duplicate_keys(node: &YamlNode, schema: Schema, out: &mut Vec<String>) {
+    // Grow the native stack on demand (see `check_node_duplicate_keys`); this
+    // recurses over attacker-controlled AST depth.
+    crate::stack::guard(|| collect_node_duplicate_keys_inner(node, schema, out))
+}
+
+fn collect_node_duplicate_keys_inner(node: &YamlNode, schema: Schema, out: &mut Vec<String>) {
     match &node.kind {
         YamlNodeKind::Mapping(pairs) => {
             // `HashSet` membership is O(1); a linear scan made a large mapping

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -647,6 +647,12 @@ pub fn collect_changed_include_changes(nodes: &[YamlNode]) -> Vec<(u32, Vec<u8>)
 /// `file_id`. Shared by the two write-back collectors above, which differ only
 /// in what they do at each boundary.
 fn walk_boundaries(node: &YamlNode, visit: &mut impl FnMut(&YamlNode, u32)) {
+    // Grow the native stack on demand: this recurses once per nesting level over
+    // attacker-controlled AST depth. See [`crate::stack`].
+    crate::stack::guard(|| walk_boundaries_inner(node, visit))
+}
+
+fn walk_boundaries_inner(node: &YamlNode, visit: &mut impl FnMut(&YamlNode, u32)) {
     if let Some(ref source) = node.source {
         if let Some(file_id) = source.target_file_id {
             visit(node, file_id);


### PR DESCRIPTION
## Breaking change

None. Pure internal robustness change; no behavior difference for any valid input.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Four Python-reachable round-trip traversals recurse over attacker-controlled AST depth (bounded by the composer's `MAX_DEPTH` of 1000) without `crate::stack::guard`, even though their siblings (decode, compose, the value/leaf walks) all use it:

- `check_node_duplicate_keys` and `collect_node_duplicate_keys` — duplicate-key checking and warnings
- `walk_anchor` — `doc.anchors`, `find_anchor_path`, `make_alias`
- `walk_boundaries` — include write-back

On a thread with a small stack, a deeply nested document could overflow the native stack before the depth cap fires (the same class as the known small-stack residual the project already mitigates with `stacker`). This routes each traversal through the guarded wrapper / `_inner` pattern, so every level grows the stack on demand, matching the rest of the codebase. No behavior change.

There is no new unit test: reliably exercising the overflow needs a near-`MAX_DEPTH` document on a deliberately tiny thread stack, which is environment-dependent and would not catch guard removal on a normal test thread. The change is a consistency fix against an established invariant, verified by the full suite passing and deep-nesting paths behaving unchanged.

Found via an independent code review of the round-trip traversals.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
