### PR TITLE
🐛 Keep a non-conforming explicit core tag as a string, not a wrong value

### DIFF
--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -230,15 +230,35 @@ fn parse_sexagesimal_float(value: &str) -> Option<f64> {
 }
 
 fn classify_tagged_11(value: &str, tag: &str, pyyaml_compat: bool) -> ScalarKind {
+    // An explicit core tag whose content does not match the type (`!!int nope`,
+    // `!!bool maybe`) is kept as a string rather than coerced to a wrong-but-valid
+    // value (which silently turned `!!int nope` into `0`). A conforming value
+    // still resolves to its type, including an integer too large for i64.
     match tag {
-        "!!null" | "tag:yaml.org,2002:null" => ScalarKind::Null,
-        "!!bool" | "tag:yaml.org,2002:bool" => {
-            ScalarKind::Bool(try_parse_bool_11(value, pyyaml_compat).unwrap_or(false))
+        "!!null" | "tag:yaml.org,2002:null" => {
+            if super::is_null(value) {
+                ScalarKind::Null
+            } else {
+                ScalarKind::Str
+            }
         }
-        "!!int" | "tag:yaml.org,2002:int" => ScalarKind::Int(try_parse_int_11(value).unwrap_or(0)),
-        "!!float" | "tag:yaml.org,2002:float" => {
-            ScalarKind::Float(try_parse_float_11(value).unwrap_or(0.0))
+        "!!bool" | "tag:yaml.org,2002:bool" => match try_parse_bool_11(value, pyyaml_compat) {
+            Some(b) => ScalarKind::Bool(b),
+            None => ScalarKind::Str,
+        },
+        "!!int" | "tag:yaml.org,2002:int" => {
+            if let Some(int) = try_parse_int_11(value) {
+                ScalarKind::Int(int)
+            } else if is_big_decimal_int_11(value) {
+                ScalarKind::BigInt
+            } else {
+                ScalarKind::Str
+            }
         }
+        "!!float" | "tag:yaml.org,2002:float" => match try_parse_float_11(value) {
+            Some(float) => ScalarKind::Float(float),
+            None => ScalarKind::Str,
+        },
         "!!merge" | "tag:yaml.org,2002:merge" => ScalarKind::Merge,
         _ => ScalarKind::Str,
     }
@@ -378,9 +398,9 @@ mod tests {
     #[test]
     fn tagged_scalars_classify_by_tag() {
         let r = Yaml11Resolver::default();
-        // Each explicit core-schema tag drives its own classification arm.
+        // A conforming value resolves to the tagged type.
         assert_eq!(
-            r.resolve("anything", ScalarStyle::Plain, Some("!!null")),
+            r.resolve("~", ScalarStyle::Plain, Some("!!null")),
             ResolvedValue::Null
         );
         assert_eq!(
@@ -395,6 +415,25 @@ mod tests {
             r.resolve("1.5", ScalarStyle::Plain, Some("!!float")),
             ResolvedValue::Float(1.5)
         );
+    }
+
+    #[test]
+    fn explicit_tag_with_nonconforming_content_stays_a_string() {
+        // An explicit core tag whose content does not match the type is kept as a
+        // string, not coerced to a wrong-but-valid value (`!!int nope` was `0`).
+        let r = Yaml11Resolver::default();
+        for (value, tag) in [
+            ("nope", "!!int"),
+            ("x", "!!float"),
+            ("maybe", "!!bool"),
+            ("text", "!!null"),
+        ] {
+            assert_eq!(
+                r.resolve(value, ScalarStyle::Plain, Some(tag)),
+                ResolvedValue::String(value.to_owned()),
+                "{tag} {value:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -255,13 +255,33 @@ fn classify_tagged_11(value: &str, tag: &str, pyyaml_compat: bool) -> ScalarKind
                 ScalarKind::Str
             }
         }
-        "!!float" | "tag:yaml.org,2002:float" => match try_parse_float_11(value) {
+        "!!float" | "tag:yaml.org,2002:float" => match try_parse_float_11_tagged(value) {
             Some(float) => ScalarKind::Float(float),
             None => ScalarKind::Str,
         },
         "!!merge" | "tag:yaml.org,2002:merge" => ScalarKind::Merge,
         _ => ScalarKind::Str,
     }
+}
+
+/// Parse a value carrying an explicit `!!float` tag under YAML 1.1. Unlike the
+/// plain-scalar [`try_parse_float_11`] (which requires a `.`/`e`/`E` so a bare
+/// integer stays an int), an integer-form value is a conforming float here:
+/// `42` resolves to `42.0` and the sexagesimal `1:30` to `90.0`, matching
+/// PyYAML. Hexadecimal and octal forms are not part of the float production, so
+/// they fall through to a string rather than being coerced.
+fn try_parse_float_11_tagged(value: &str) -> Option<f64> {
+    if let Some(f) = super::parse_special_float(value) {
+        return Some(f);
+    }
+    // Strip underscores (allocation-free unless any are present).
+    let cleaned = strip_underscores(value);
+    let clean: &str = &cleaned;
+    if clean.contains(':') {
+        // Sexagesimal, integer (`1:30`) or fractional (`1:30.5`).
+        return parse_sexagesimal_float(clean);
+    }
+    clean.parse::<f64>().ok()
 }
 
 #[cfg(test)]
@@ -414,6 +434,16 @@ mod tests {
         assert_eq!(
             r.resolve("1.5", ScalarStyle::Plain, Some("!!float")),
             ResolvedValue::Float(1.5)
+        );
+        // Integer-form and sexagesimal values are conforming floats under an
+        // explicit tag (`42` -> `42.0`, `1:30` -> `90.0`), matching PyYAML.
+        assert_eq!(
+            r.resolve("42", ScalarStyle::Plain, Some("!!float")),
+            ResolvedValue::Float(42.0)
+        );
+        assert_eq!(
+            r.resolve("1:30", ScalarStyle::Plain, Some("!!float")),
+            ResolvedValue::Float(90.0)
         );
     }
 

--- a/src/resolver/yaml12.rs
+++ b/src/resolver/yaml12.rs
@@ -149,12 +149,25 @@ fn classify_tagged(value: &str, tag: &str) -> ScalarKind {
                 ScalarKind::Str
             }
         }
-        "!!float" | "tag:yaml.org,2002:float" => match try_parse_float_12(value) {
+        "!!float" | "tag:yaml.org,2002:float" => match try_parse_float_12_tagged(value) {
             Some(float) => ScalarKind::Float(float),
             None => ScalarKind::Str,
         },
         _ => ScalarKind::Str,
     }
+}
+
+/// Parse a value carrying an explicit `!!float` tag. Unlike the plain-scalar
+/// [`try_parse_float_12`] (which requires a `.`/`e`/`E` so a bare integer stays
+/// an int), an integer-form decimal like `42` is a *conforming* float under the
+/// core schema and resolves to `42.0`. Hexadecimal and octal forms are not part
+/// of the float production, so they fall through to a string (Rust's `f64` parse
+/// rejects them), matching the schema rather than coercing `0x10` to `16.0`.
+fn try_parse_float_12_tagged(value: &str) -> Option<f64> {
+    if let Some(f) = super::parse_special_float(value) {
+        return Some(f);
+    }
+    value.parse::<f64>().ok()
 }
 
 #[cfg(test)]
@@ -290,6 +303,18 @@ mod tests {
         assert_eq!(
             r.resolve("1.5", ScalarStyle::Plain, Some("!!float")),
             ResolvedValue::Float(1.5)
+        );
+        // An integer-form value is a conforming float under an explicit tag
+        // (`42` -> `42.0`), unlike in plain resolution where it stays an int.
+        assert_eq!(
+            r.resolve("42", ScalarStyle::Plain, Some("!!float")),
+            ResolvedValue::Float(42.0)
+        );
+        // Hex/octal forms are not part of the float production, so they stay a
+        // string rather than being coerced to their integer value.
+        assert_eq!(
+            r.resolve("0x10", ScalarStyle::Plain, Some("!!float")),
+            ResolvedValue::String("0x10".to_owned())
         );
         // A non-conforming value under an explicit core tag is kept as a string,
         // not coerced to a wrong-but-valid 0/0.0/false/null.

--- a/src/resolver/yaml12.rs
+++ b/src/resolver/yaml12.rs
@@ -123,15 +123,36 @@ fn try_parse_float_12(value: &str) -> Option<f64> {
 }
 
 fn classify_tagged(value: &str, tag: &str) -> ScalarKind {
+    // An explicit core tag whose content does not match the type (`!!int nope`,
+    // `!!bool maybe`) is kept as a string rather than coerced to a wrong-but-valid
+    // value (which silently turned `!!int nope` into `0`). A conforming value
+    // still resolves to its type, including an integer too large for i64.
     match tag {
-        "!!null" | "tag:yaml.org,2002:null" => ScalarKind::Null,
-        "!!bool" | "tag:yaml.org,2002:bool" => {
-            ScalarKind::Bool(matches!(value, "true" | "True" | "TRUE"))
+        "!!null" | "tag:yaml.org,2002:null" => {
+            if super::is_null(value) {
+                ScalarKind::Null
+            } else {
+                ScalarKind::Str
+            }
         }
-        "!!int" | "tag:yaml.org,2002:int" => ScalarKind::Int(try_parse_int_12(value).unwrap_or(0)),
-        "!!float" | "tag:yaml.org,2002:float" => {
-            ScalarKind::Float(try_parse_float_12(value).unwrap_or(0.0))
+        "!!bool" | "tag:yaml.org,2002:bool" => match value {
+            "true" | "True" | "TRUE" => ScalarKind::Bool(true),
+            "false" | "False" | "FALSE" => ScalarKind::Bool(false),
+            _ => ScalarKind::Str,
+        },
+        "!!int" | "tag:yaml.org,2002:int" => {
+            if let Some(int) = try_parse_int_12(value) {
+                ScalarKind::Int(int)
+            } else if super::is_big_decimal_int(value) {
+                ScalarKind::BigInt
+            } else {
+                ScalarKind::Str
+            }
         }
+        "!!float" | "tag:yaml.org,2002:float" => match try_parse_float_12(value) {
+            Some(float) => ScalarKind::Float(float),
+            None => ScalarKind::Str,
+        },
         _ => ScalarKind::Str,
     }
 }
@@ -262,7 +283,7 @@ mod tests {
             ResolvedValue::Bool(true)
         );
         assert_eq!(
-            r.resolve("anything", ScalarStyle::Plain, Some("!!null")),
+            r.resolve("null", ScalarStyle::Plain, Some("!!null")),
             ResolvedValue::Null
         );
         // The float tag drives its own classification arm.
@@ -270,15 +291,24 @@ mod tests {
             r.resolve("1.5", ScalarStyle::Plain, Some("!!float")),
             ResolvedValue::Float(1.5)
         );
-        // A non-float text under !!float falls back to 0.0 rather than erroring.
+        // A non-conforming value under an explicit core tag is kept as a string,
+        // not coerced to a wrong-but-valid 0/0.0/false/null.
+        for (value, tag) in [
+            ("nope", "!!int"),
+            ("nope", "!!float"),
+            ("maybe", "!!bool"),
+            ("anything", "!!null"),
+        ] {
+            assert_eq!(
+                r.resolve(value, ScalarStyle::Plain, Some(tag)),
+                ResolvedValue::String(value.to_owned()),
+                "{tag} {value:?}"
+            );
+        }
+        // A conforming integer too large for i64 still resolves as an integer.
         assert_eq!(
-            r.resolve("nope", ScalarStyle::Plain, Some("!!float")),
-            ResolvedValue::Float(0.0)
-        );
-        // A non-int text under !!int falls back to 0.
-        assert_eq!(
-            r.resolve("nope", ScalarStyle::Plain, Some("!!int")),
-            ResolvedValue::Int(0)
+            r.resolve("99999999999999999999", ScalarStyle::Plain, Some("!!int")),
+            ResolvedValue::BigInt("99999999999999999999".to_owned())
         );
     }
 }

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -56,6 +56,21 @@ def test_standard_tags_not_treated_as_custom():
     assert yamlrocks.loads(b"x: !!str 42") == {"x": "42"}
 
 
+def test_explicit_core_tag_with_nonconforming_content_stays_a_string():
+    """A core tag whose content does not match the type is kept as a string, not
+    coerced to a wrong-but-valid value (`!!int nope` used to become 0)."""
+    assert yamlrocks.loads(b"x: !!int nope") == {"x": "nope"}
+    assert yamlrocks.loads(b"x: !!float nope") == {"x": "nope"}
+    assert yamlrocks.loads(b"x: !!bool maybe") == {"x": "maybe"}
+    assert yamlrocks.loads(b"x: !!null text") == {"x": "text"}
+    # A conforming value still resolves to its type (including a big int).
+    assert yamlrocks.loads(b"x: !!int 42") == {"x": 42}
+    assert yamlrocks.loads(b"x: !!null") == {"x": None}
+    assert yamlrocks.loads(b"x: !!int 99999999999999999999") == {
+        "x": 99999999999999999999
+    }
+
+
 def test_nested_custom_tags():
     """tag_handler is applied to custom tags nested within other custom tags."""
     result = yamlrocks.loads(

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -57,8 +57,8 @@ def test_standard_tags_not_treated_as_custom():
 
 
 def test_explicit_core_tag_with_nonconforming_content_stays_a_string():
-    """A core tag whose content does not match the type is kept as a string, not
-    coerced to a wrong-but-valid value (`!!int nope` used to become 0)."""
+    """A core tag whose content does not match its type is kept as a string."""
+    # Not coerced to a wrong-but-valid value (`!!int nope` used to become 0).
     assert yamlrocks.loads(b"x: !!int nope") == {"x": "nope"}
     assert yamlrocks.loads(b"x: !!float nope") == {"x": "nope"}
     assert yamlrocks.loads(b"x: !!bool maybe") == {"x": "maybe"}
@@ -69,6 +69,8 @@ def test_explicit_core_tag_with_nonconforming_content_stays_a_string():
     assert yamlrocks.loads(b"x: !!int 99999999999999999999") == {
         "x": 99999999999999999999
     }
+    # An integer-form value under `!!float` is a conforming float, not a string.
+    assert yamlrocks.loads(b"x: !!float 42") == {"x": 42.0}
 
 
 def test_nested_custom_tags():


### PR DESCRIPTION
## Breaking change

The parse result changes for the narrow, previously-corrupted case of an explicit core tag whose content does not match the type. `!!int nope` was `0`, `!!float nope` was `0.0`, `!!bool maybe` was `False`, and `!!null anything` was `None`; each is now the original string (`"nope"`, `"maybe"`, ...). Conforming values are unchanged (`!!int 42` is still `42`). Anyone who relied on the old silent coercion would now get a string.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

An explicit core-schema tag whose content did not match its type was coerced to a wrong-but-valid value rather than kept faithfully: `!!int nope` resolved to `0`, `!!float nope` to `0.0`, `!!bool maybe` to `False`, and `!!null anything` to `None`. That is silent data corruption on explicitly typed scalars (PyYAML raises instead).

Both resolvers (`yaml11.rs`, `yaml12.rs`) now keep a non-conforming value as a string, reusing each schema's own int/float/bool/null parsers and falling back to `Str` only on a genuine mismatch. A conforming value still resolves to its type, including an integer too large for `i64` (`BigInt`). This also fixes a latent `!!bool` bug: the old `!!bool` arm matched only the `true` spellings, so any non-`true` text (not just `false`) became `False`.

The behavior is consistent across the fast and round-trip paths (both resolve through the same code). It is more lenient than PyYAML (which raises), but it never fabricates a wrong value; raising consistently would require threading a `Result` through the infallible resolver and the infallible round-trip `to_dict` projection, which was judged not worth the churn for this case.

Found via an independent code review of the resolver.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
