### PR TITLE
🐛 Keep %TAG and %YAML directives on a round-trip edit

### DIFF
--- a/src/roundtrip/ast.rs
+++ b/src/roundtrip/ast.rs
@@ -34,6 +34,13 @@ pub struct YamlNode {
     /// re-emission (after an edit, or when writing an included file) keeps the
     /// marker instead of silently dropping it.
     pub explicit_start: bool,
+    /// The `%YAML`/`%TAG` directives that introduced this document, in source
+    /// order and without their leading `%` (`TAG !e! tag:example.com,2020:`).
+    /// Only meaningful on a document root node; empty for nested nodes. Preserved
+    /// so re-emission after an edit keeps a `%TAG` handle in scope (dropping it
+    /// would leave a `!e!foo` node with an undefined handle that no longer
+    /// reloads).
+    pub directives: Vec<String>,
     /// Whether the stream began with a UTF-8 byte order mark. Only meaningful on
     /// the first document root; `false` otherwise. Preserved so re-emission keeps
     /// the mark and a round-trip stays byte-for-byte.
@@ -61,6 +68,7 @@ impl YamlNode {
             style: NodeStyle::Block,
             source: None,
             explicit_start: false,
+            directives: Vec::new(),
             leading_bom: false,
             synthetic: false,
         }

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -539,6 +539,11 @@ impl<'input> Composer<'input> {
                         node.explicit_start = true;
                         node.directives = std::mem::take(&mut pending_directives);
                         documents.push(node);
+                    } else {
+                        // An empty document dropped here still consumed its own
+                        // directives; clear them so a `%TAG` scoped to it cannot
+                        // leak onto the next document.
+                        pending_directives.clear();
                     }
                     if self.pos < events.len()
                         && matches!(events[self.pos].kind, EventKind::DocumentEnd)
@@ -553,7 +558,14 @@ impl<'input> Composer<'input> {
                 _ => {
                     let start_pos = self.pos;
                     if let Some(mut node) = self.compose_node(events)? {
+                        // The parser requires a `---` after any directive, so a
+                        // document reaching this arm normally has none pending.
+                        // Attach and mark explicit defensively: emitting the
+                        // directives without their `---` would be invalid YAML.
                         node.directives = std::mem::take(&mut pending_directives);
+                        if !node.directives.is_empty() {
+                            node.explicit_start = true;
+                        }
                         documents.push(node);
                     }
                     // Force progress past a bare terminator (e.g. a leading

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -513,6 +513,10 @@ impl<'input> Composer<'input> {
         keep_empty: bool,
     ) -> Result<Vec<YamlNode>, ScanError> {
         let mut documents = Vec::new();
+        // Directives (`%YAML`/`%TAG`) appear before the `---` of the document
+        // they introduce; collect them until that document's node exists, then
+        // hand them over so re-emission can replay them.
+        let mut pending_directives: Vec<String> = Vec::new();
 
         while self.pos < events.len() {
             match &events[self.pos].kind {
@@ -526,12 +530,14 @@ impl<'input> Composer<'input> {
                         // An explicit `---` produces this event; record it so the
                         // marker is preserved on re-emission.
                         node.explicit_start = true;
+                        node.directives = std::mem::take(&mut pending_directives);
                         documents.push(node);
                     } else if keep_empty {
                         // A lone/trailing `---` with no body is still a document
                         // (a null one) when the caller counts documents.
                         let mut node = YamlNode::new(YamlNodeKind::Null, marker_span);
                         node.explicit_start = true;
+                        node.directives = std::mem::take(&mut pending_directives);
                         documents.push(node);
                     }
                     if self.pos < events.len()
@@ -540,12 +546,14 @@ impl<'input> Composer<'input> {
                         self.pos += 1;
                     }
                 }
-                EventKind::Directive(_) => {
+                EventKind::Directive(text) => {
+                    pending_directives.push(text.clone());
                     self.pos += 1;
                 }
                 _ => {
                     let start_pos = self.pos;
-                    if let Some(node) = self.compose_node(events)? {
+                    if let Some(mut node) = self.compose_node(events)? {
+                        node.directives = std::mem::take(&mut pending_directives);
                         documents.push(node);
                     }
                     // Force progress past a bare terminator (e.g. a leading

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -443,28 +443,47 @@ impl YAMLRocksDocument {
 /// Prepend a `%YAML 1.2` version directive to `buf` so an upgraded document
 /// declares its version (and is read back as 1.2, not re-upgraded). A leading
 /// byte order mark stays first; an existing `---` document-start marker is
-/// reused, otherwise one is added. The upgrade pass already strips any prior
-/// `%YAML` directive, so there is none to replace.
+/// reused, otherwise one is added. Any `%YAML` directive among the leading
+/// directives is dropped (the canonical 1.2 declaration replaces it); a `%TAG`
+/// directive is kept in place, with `%YAML 1.2` inserted ahead of it.
 fn stamp_yaml_1_2(buf: &mut Vec<u8>) {
     const BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
     let at = if buf.starts_with(&BOM) { BOM.len() } else { 0 };
-    // Drop an existing leading `%YAML ...` directive line; the canonical 1.2
-    // declaration below replaces it. This keeps re-stamping idempotent (a file
-    // declared `%YAML 1.2` stays single) and normalizes any other version to
-    // 1.2. The upgrade pass already strips a `%YAML 1.1`, so this fires only for
-    // a document that read as 1.2 because it already declared a version.
-    if buf[at..].starts_with(b"%YAML") {
-        if let Some(newline) = buf[at..].iter().position(|&b| b == b'\n') {
-            buf.drain(at..at + newline + 1);
+    // Walk the leading directive lines. A `%YAML` line is dropped (the canonical
+    // 1.2 declaration below replaces it; this also keeps re-stamping idempotent);
+    // any other directive (a `%TAG` handle) is kept and skipped over so the
+    // marker is found past it, not before it. Inserting `%YAML 1.2\n---\n` ahead
+    // of a `%TAG` would strand the handle after a document start and fail to
+    // reload.
+    let mut cursor = at;
+    loop {
+        let rest = &buf[cursor..];
+        let line_len = rest.iter().position(|&b| b == b'\n').map(|n| n + 1);
+        if rest.starts_with(b"%YAML") {
+            match line_len {
+                Some(len) => {
+                    buf.drain(cursor..cursor + len);
+                }
+                None => buf.truncate(cursor),
+            }
+        } else if rest.starts_with(b"%") {
+            match line_len {
+                Some(len) => cursor += len,
+                None => break,
+            }
+        } else {
+            break;
         }
     }
-    let body = &buf[at..];
+    let body = &buf[cursor..];
     let has_marker = body.starts_with(b"---")
         && body
             .get(3)
             .map_or(true, |&b| matches!(b, b'\n' | b'\r' | b' '));
     let mut stamp: Vec<u8> = b"%YAML 1.2\n".to_vec();
     if !has_marker {
+        // No directives precede us here (a directive always carries its own
+        // `---`), so the marker can sit right after the version line.
         stamp.extend_from_slice(b"---\n");
     }
     buf.splice(at..at, stamp);
@@ -1505,4 +1524,58 @@ fn leaves_to_list(py: Python<'_>, leaves: Vec<(Vec<Py<PyAny>>, Py<PyAny>)>) -> P
         list.append((tuple, value))?;
     }
     Ok(list.into_any().unbind())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stamp_yaml_1_2;
+
+    fn stamp(input: &[u8]) -> Vec<u8> {
+        let mut buf = input.to_vec();
+        stamp_yaml_1_2(&mut buf);
+        buf
+    }
+
+    #[test]
+    fn prepends_version_to_a_bare_document() {
+        assert_eq!(stamp(b"a: 1\n"), b"%YAML 1.2\n---\na: 1\n");
+    }
+
+    #[test]
+    fn reuses_an_existing_document_marker() {
+        assert_eq!(stamp(b"---\na: 1\n"), b"%YAML 1.2\n---\na: 1\n");
+    }
+
+    #[test]
+    fn replaces_a_declared_version() {
+        assert_eq!(stamp(b"%YAML 1.1\n---\na: 1\n"), b"%YAML 1.2\n---\na: 1\n");
+    }
+
+    #[test]
+    fn keeps_a_tag_directive_after_the_version() {
+        // The `%YAML 1.2` must sit *before* the `%TAG`, never displace it past
+        // the `---` (which would leave the handle undefined).
+        assert_eq!(
+            stamp(b"%TAG !e! tag:x:\n---\nv: !e!foo 1\n"),
+            b"%YAML 1.2\n%TAG !e! tag:x:\n---\nv: !e!foo 1\n",
+        );
+    }
+
+    #[test]
+    fn replaces_version_but_keeps_tag_directive() {
+        assert_eq!(
+            stamp(b"%YAML 1.1\n%TAG !e! tag:x:\n---\nv: !e!foo 1\n"),
+            b"%YAML 1.2\n%TAG !e! tag:x:\n---\nv: !e!foo 1\n",
+        );
+    }
+
+    #[test]
+    fn preserves_a_leading_byte_order_mark() {
+        let bom = [0xEF, 0xBB, 0xBF];
+        let mut input = bom.to_vec();
+        input.extend_from_slice(b"a: 1\n");
+        let mut expected = bom.to_vec();
+        expected.extend_from_slice(b"%YAML 1.2\n---\na: 1\n");
+        assert_eq!(stamp(&input), expected);
+    }
 }

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -36,10 +36,16 @@ pub fn emit_roundtrip_all_with(nodes: &[YamlNode], null_style: NullStyle) -> Vec
         emitter.buf.extend_from_slice(BOM);
     }
     for (i, node) in nodes.iter().enumerate() {
-        // Documents need a `---` separator. A document that carries its own
-        // explicit start marker emits it in `emit_document`, so only add the
-        // separator for one that does not (avoiding a double `---`).
-        if i > 0 && !node.explicit_start {
+        // A directive (`%TAG`/`%YAML`) is only valid at the stream start or right
+        // after a `...` end marker, so a later document carrying directives needs
+        // the previous one closed first. `emit_document` then emits the directives
+        // and the `---`.
+        if i > 0 && !node.directives.is_empty() {
+            emitter.buf.extend_from_slice(b"...\n");
+        } else if i > 0 && !node.explicit_start {
+            // Documents need a `---` separator. A document that carries its own
+            // explicit start marker emits it in `emit_document`, so only add the
+            // separator for one that does not (avoiding a double `---`).
             emitter.buf.extend_from_slice(b"---\n");
         }
         emitter.emit_document(node);
@@ -81,6 +87,14 @@ impl RoundTripEmitter {
     // -- Document entry --
 
     fn emit_document(&mut self, node: &YamlNode) {
+        // Directives precede the `---` that opens their document. A `%TAG` handle
+        // is in scope only for this document, so replaying it keeps a tagged node
+        // (`!e!foo`) resolvable when the edited document reloads.
+        for directive in &node.directives {
+            self.buf.push(b'%');
+            self.buf.extend_from_slice(directive.as_bytes());
+            self.buf.push(b'\n');
+        }
         if node.explicit_start {
             self.buf.extend_from_slice(b"---\n");
         }

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -247,6 +247,18 @@ def test_roundtrip_unmodified_tag_directive_is_byte_identical():
     assert yamlrocks.dumps(doc) == src
 
 
+def test_roundtrip_dropped_empty_document_does_not_leak_its_directive():
+    """A directive scoped to a skipped empty document does not reach the next."""
+    # The `%TAG` belongs to the empty first document; once that document is
+    # dropped, re-emitting the second (modified) one must not carry the handle.
+    src = b"%TAG !e! tag:x:\n---\n---\nb: 2\n"
+    doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
+    doc["b"] = 9
+    out = yamlrocks.dumps(doc)
+    assert b"%TAG" not in out
+    assert out == b"---\nb: 9\n"
+
+
 def test_roundtrip_edit_keeps_yaml_version_directive():
     """Editing a round-trip document re-emits its `%YAML` version directive."""
     src = b"%YAML 1.2\n---\nv: 1\nw: 2\n"

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -226,6 +226,35 @@ def test_tag_directive_resolves_named_handle():
     assert yamlrocks.loads(src) == {"x": "bar"}
 
 
+def test_roundtrip_edit_keeps_tag_directive():
+    """Editing a round-trip document re-emits its `%TAG` directive.
+
+    Dropping the directive would strand the `!e!foo` node on an undefined handle
+    that no longer reloads; the edited document must stay self-contained.
+    """
+    src = b"%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\nw: keep\n"
+    doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
+    doc["w"] = "changed"
+    out = yamlrocks.dumps(doc)
+    assert out == (b"%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\nw: changed\n")
+    assert yamlrocks.loads(out) == {"v": "old", "w": "changed"}
+
+
+def test_roundtrip_unmodified_tag_directive_is_byte_identical():
+    """An unmodified round-trip document with a `%TAG` re-emits verbatim."""
+    src = b"%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\n"
+    doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
+    assert yamlrocks.dumps(doc) == src
+
+
+def test_roundtrip_edit_keeps_yaml_version_directive():
+    """Editing a round-trip document re-emits its `%YAML` version directive."""
+    src = b"%YAML 1.2\n---\nv: 1\nw: 2\n"
+    doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
+    doc["w"] = 9
+    assert yamlrocks.dumps(doc) == b"%YAML 1.2\n---\nv: 1\nw: 9\n"
+
+
 def test_duplicate_tag_directive_is_rejected():
     """A `%TAG` handle declared twice in one document is an error.
 

--- a/tests/features/test_upgrade.py
+++ b/tests/features/test_upgrade.py
@@ -181,3 +181,24 @@ def test_roundtrip_upgrade_save_stamps(tmp_path):
     assert written.startswith(b"%YAML 1.2\n---\n")
     # The inline comment keeps its original two-space alignment padding.
     assert b"enabled: true  # was on" in written
+
+
+def test_upgrade_keeps_tag_directive_in_scope():
+    """upgrade() stamps `%YAML 1.2` ahead of a `%TAG`, keeping the handle valid.
+
+    The version directive must precede the `%TAG`, not displace it after a
+    document start, or the named handle would no longer resolve on reload.
+    """
+    src = b"%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\n"
+    out = yamlrocks.upgrade(src)
+    assert out == (b"%YAML 1.2\n%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\n")
+    # The result reloads: the handle is still defined for the document.
+    assert yamlrocks.loads(out) == {"v": "old"}
+
+
+def test_upgrade_replaces_declared_version_before_tag_directive():
+    """A declared `%YAML 1.1` is replaced by 1.2 while `%TAG` stays in place."""
+    src = b"%YAML 1.1\n%TAG !e! tag:x:\n---\nv: !e!foo 1\n"
+    out = yamlrocks.upgrade(src)
+    assert out == b"%YAML 1.2\n%TAG !e! tag:x:\n---\nv: !e!foo 1\n"
+    assert yamlrocks.loads(out) == {"v": "1"}


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Editing a document loaded with `OPT_ROUND_TRIP` silently dropped the `%YAML`/`%TAG` directives that introduced it. A surviving `!e!foo` node was then stranded on an undefined tag handle and no longer reloaded:

```python
src = b"%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\nw: keep\n"
doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
doc["w"] = "changed"
out = yamlrocks.dumps(doc)
# before: "---\nv: !e!foo old\nw: changed\n"  -> reload fails: undefined tag handle !e!
# after:  "%TAG !e! tag:example.com,2020:\n---\nv: !e!foo old\nw: changed\n"  -> reloads
```

The composer now captures each document's directives on its root node, and the emitter replays them ahead of the `---` when it re-emits from the AST. A later document that carries directives is preceded by a `...` so the directive stays valid. Unmodified documents still replay their source verbatim, so byte-for-byte round-trip is unchanged.

While in the same area I found and fixed a second, pre-existing bug. `upgrade()` (and the upgrade stamp generally) inserted `%YAML 1.2\n---\n` at the very front of a document that led with a `%TAG`, pushing the handle *after* a document start and producing `%YAML 1.2\n---\n%TAG ...\n---\n`, which is invalid and failed to reload. The stamp now walks the leading directive lines, drops any `%YAML` among them, keeps the `%TAG` in place, and inserts `%YAML 1.2` ahead of it.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
