### PR TITLE
🐛 Discover and navigate an anchor on a mapping key

### DIFF
--- a/src/roundtrip/anchors.rs
+++ b/src/roundtrip/anchors.rs
@@ -49,7 +49,11 @@ pub(crate) fn path_precedes(roots: &[YamlNode], a: &[PathSeg], b: &[PathSeg]) ->
 /// element index for a sequence). Missing entries sort last.
 pub(crate) fn seg_order(node: Option<&YamlNode>, seg: &PathSeg) -> usize {
     match (node.map(|n| &n.kind), seg) {
-        (Some(YamlNodeKind::Mapping(pairs)), PathSeg::Key(k)) => pairs
+        // A key node and its value share the entry's position. Comparing the two
+        // (only reachable for a same-entry self-reference like `&a k: *a`) yields
+        // "neither precedes", which is acceptable: the order matters only when
+        // creating a new alias via the edit API, never on load.
+        (Some(YamlNodeKind::Mapping(pairs)), PathSeg::Key(k) | PathSeg::KeyNode(k)) => pairs
             .iter()
             .position(|(key, _)| scalar_eq(key, k))
             .unwrap_or(usize::MAX),
@@ -127,9 +131,12 @@ pub(crate) fn collect_alias_paths(
     });
 }
 
-/// Visit each addressable child of `node` (mapping values by key, sequence items
-/// by index), pushing the corresponding `PathSeg` onto `prefix` for the call.
-/// Mapping keys are not addressable, so anchors on keys are not visited.
+/// Visit each child of `node` that anchor/alias traversal can address: a mapping
+/// key node (`PathSeg::KeyNode`), its value (`PathSeg::Key`), and a sequence
+/// element (`PathSeg::Index`), pushing the segment onto `prefix` for the call.
+/// The key is visited before its value, matching document order. Only scalar
+/// keys are addressable; a complex (mapping/sequence) key and its value are
+/// skipped, as the path model has no segment for them.
 pub(crate) fn for_each_child(
     node: &YamlNode,
     prefix: &mut Vec<PathSeg>,
@@ -139,6 +146,10 @@ pub(crate) fn for_each_child(
         YamlNodeKind::Mapping(pairs) => {
             for (key, val) in pairs {
                 if let YamlNodeKind::Scalar(name, _) = &key.kind {
+                    // The key node first: an anchor may sit on it (`&a foo: bar`).
+                    prefix.push(PathSeg::KeyNode(name.clone()));
+                    visit(key, prefix);
+                    prefix.pop();
                     prefix.push(PathSeg::Key(name.clone()));
                     visit(val, prefix);
                     prefix.pop();
@@ -367,6 +378,20 @@ mod tests {
         let mut aliases = Vec::new();
         collect_alias_paths(&r[0], "x", &mut Vec::new(), &mut aliases);
         assert_eq!(aliases.len(), 2); // `use` and `also`
+    }
+
+    #[test]
+    fn collects_an_anchor_on_a_mapping_key() {
+        // An anchor on a key (`&k key: value`) is discovered and addressable,
+        // mirroring `collect_anchor_refs`, which already sees key anchors.
+        let r = roots("&kanchor key: value\nother: &vanchor 1\n");
+        let mut anchors = Vec::new();
+        collect_anchor_paths(&r[0], &mut Vec::new(), &mut anchors);
+        let names: Vec<&str> = anchors.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"kanchor"));
+        assert!(names.contains(&"vanchor"));
+        // The key anchor's path resolves to the key node (the `key` scalar).
+        assert!(find_anchor_path(&r, "kanchor").is_some());
     }
 
     #[test]

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -26,11 +26,19 @@ use super::value::{node_to_python_with, python_to_node};
 use crate::encode::NullStyle;
 use crate::resolver::Schema;
 
-/// A single step along a path into the AST: a mapping key or sequence index.
+/// A single step along a path into the AST: a mapping value (by key), a sequence
+/// element (by index), or a mapping *key node* itself.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PathSeg {
+    /// The value of the mapping entry whose key resolves to this string.
     Key(String),
+    /// The element at this index of a sequence.
     Index(usize),
+    /// The key node of the mapping entry whose key resolves to this string.
+    /// Only the anchor/alias traversal produces this (an anchor may sit on a
+    /// key, `&a foo: bar`); indexed access from Python never does, so a key
+    /// node is reachable for discovery but not addressed by `doc["foo"]`.
+    KeyNode(String),
 }
 
 fn seg_from_key(key: &Bound<'_, PyAny>) -> PyResult<PathSeg> {
@@ -1083,7 +1091,8 @@ fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<&'a YamlN
                 _ => None,
             }
         }
-        Some((PathSeg::Index(_), _)) => resolve_path(roots, path),
+        // A sequence element or a key node holds its own head comment.
+        Some((PathSeg::Index(_) | PathSeg::KeyNode(_), _)) => resolve_path(roots, path),
     }
 }
 
@@ -1106,7 +1115,7 @@ fn resolve_head_mut<'a>(roots: &'a mut [YamlNode], path: &[PathSeg]) -> Option<&
                 None
             }
         }
-        Some((PathSeg::Index(_), _)) => resolve_path_mut(roots, path),
+        Some((PathSeg::Index(_) | PathSeg::KeyNode(_), _)) => resolve_path_mut(roots, path),
     }
 }
 
@@ -1137,6 +1146,10 @@ pub(crate) fn child_ref<'a>(node: &'a YamlNode, seg: &PathSeg) -> Option<&'a Yam
             .iter()
             .find(|(key, _)| scalar_eq(key, k))
             .map(|(_, v)| v),
+        (YamlNodeKind::Mapping(pairs), PathSeg::KeyNode(k)) => pairs
+            .iter()
+            .find(|(key, _)| scalar_eq(key, k))
+            .map(|(key, _)| key),
         (YamlNodeKind::Sequence(items), PathSeg::Index(i)) => items.get(*i),
         _ => None,
     }
@@ -1148,6 +1161,10 @@ fn child_ref_mut<'a>(node: &'a mut YamlNode, seg: &PathSeg) -> Option<&'a mut Ya
             .iter_mut()
             .find(|(key, _)| scalar_eq(key, k))
             .map(|(_, v)| v),
+        (YamlNodeKind::Mapping(pairs), PathSeg::KeyNode(k)) => pairs
+            .iter_mut()
+            .find(|(key, _)| scalar_eq(key, k))
+            .map(|(key, _)| key),
         (YamlNodeKind::Sequence(items), PathSeg::Index(i)) => items.get_mut(*i),
         _ => None,
     }

--- a/tests/roundtrip/test_node.py
+++ b/tests/roundtrip/test_node.py
@@ -283,6 +283,29 @@ def test_anchors_is_empty_without_anchors():
     assert load(b"a: 1\n").anchors == {}
 
 
+def test_anchors_includes_one_on_a_mapping_key():
+    """An anchor on a mapping key is discoverable, like one on a value."""
+    doc = load(b"&kanchor key: value\nother: &vanchor 1\n")
+    assert set(doc.anchors) == {"kanchor", "vanchor"}
+    # The key anchor's node is the key scalar itself.
+    assert doc.anchors["kanchor"].value == "key"
+    assert doc.anchors["kanchor"].anchor == "kanchor"
+
+
+def test_aliases_of_a_key_anchor_are_found():
+    """A key anchor's ``aliases`` list the ``*name`` nodes referencing it."""
+    doc = load(b"&kanchor key: value\nuse: *kanchor\nalso: *kanchor\n")
+    assert len(doc.anchors["kanchor"].aliases) == 2
+
+
+def test_alias_to_a_key_anchor_resolves():
+    """An alias pointing at a key anchor resolves to that key's value."""
+    assert yamlrocks.loads(b"&kanchor key: value\nuse: *kanchor\n") == {
+        "key": "value",
+        "use": "key",
+    }
+
+
 def test_is_alias_detects_aliases():
     """``is_alias`` is True only for ``*name`` nodes."""
     doc = load(ANCHORED)


### PR DESCRIPTION
## Breaking change

None. This only adds discovery of anchors that were previously invisible; existing anchor and navigation behavior is unchanged.

## Proposed change

Alias resolution (`build_anchor_map`) already saw anchors on mapping keys, so `*kanchor` resolved correctly. But the path-based traversal (`for_each_child`, used by `collect_anchor_paths`, `find_anchor_path`, and `collect_alias_paths`) skipped keys entirely. The result was an inconsistency: an anchor on a mapping key was invisible to `doc.anchors`, could not be located by `find_anchor_path`, and its aliases were not found.

```python
src = b"&kanchor key: value\nother: &vanchor 1\n"
doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
# before: {'vanchor'}      (the key anchor was dropped)
# after:  {'kanchor', 'vanchor'}
set(doc.anchors)
```

The path model addressed only mapping values (by key) and sequence elements (by index), with no way to point at a key node. This adds a `PathSeg::KeyNode` variant for exactly that, and has the anchor/alias traversal visit the key node before its value (document order), so all three traversals discover key anchors consistently. The Rust compiler's exhaustiveness check confirmed every match site is handled (`child_ref`, `seg_order`, `resolve_head`).

A `KeyNode` segment is internal-only: it is produced by anchor discovery, never by `doc["foo"]` indexing, so item-access semantics are unchanged. Complex (non-scalar) keys stay skipped, matching the existing value-side behavior.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
