### PR TITLE
🐛 Reject malformed verbatim tags and block scalar headers

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1087,18 +1087,32 @@ impl<'input> Scanner<'input> {
             self.simple_key_allowed = false;
             self.tokens.push_back(Token::new(TokenKind::Tag(tag), span));
         } else if self.reader.peek() == '<' {
-            // Verbatim tag: !<tag>
+            // Verbatim tag: !<tag>. The body is URI text with no whitespace or
+            // line breaks, terminated by `>`. Stopping only at `>`/EOF would let
+            // an unterminated `!<foo` swallow the rest of the document, so a
+            // break or whitespace inside the body ends the scan and (with a
+            // missing `>`) is reported instead of silently consumed.
             self.reader.advance(); // skip '<'
             let inner_start = self.reader.offset();
-            while !self.reader.is_eof() && self.reader.peek() != '>' {
+            while !self.reader.is_eof()
+                && self.reader.peek() != '>'
+                && !is_whitespace_or_break(self.reader.peek())
+            {
                 self.reader.advance();
+            }
+            if self.reader.peek() != '>' {
+                return Err(ScanError::new(
+                    "unterminated verbatim tag: expected '>'",
+                    span,
+                ));
             }
             let tag = self
                 .reader
                 .slice(inner_start, self.reader.offset())
                 .to_owned();
-            if self.reader.peek() == '>' {
-                self.reader.advance();
+            self.reader.advance(); // skip '>'
+            if tag.is_empty() {
+                return Err(ScanError::new("a verbatim tag must not be empty", span));
             }
             self.simple_key_allowed = false;
             self.tokens

--- a/src/scanner/scalar.rs
+++ b/src/scanner/scalar.rs
@@ -358,27 +358,44 @@ pub fn scan_block<'input>(
     let start_span = reader.span();
     reader.advance(); // skip '|' or '>'
 
-    // Parse optional chomping and indentation indicators
+    // Parse the optional chomping (`+`/`-`) and indentation (`1`-`9`) indicators.
+    // They follow the `|`/`>` immediately, in either order, each at most once,
+    // with no whitespace before or between them (YAML 8.1.1). Anything else ends
+    // this phase; a repeated or stray indicator is then caught as unexpected
+    // header content below.
     let mut chomping = Chomping::Clip; // default
+    let mut seen_chomping = false;
     let mut explicit_indent: Option<u32> = None;
 
+    while !reader.is_eof() {
+        match reader.peek() {
+            '-' if !seen_chomping => {
+                chomping = Chomping::Strip;
+                seen_chomping = true;
+                reader.advance();
+            }
+            '+' if !seen_chomping => {
+                chomping = Chomping::Keep;
+                seen_chomping = true;
+                reader.advance();
+            }
+            '1'..='9' if explicit_indent.is_none() => {
+                explicit_indent = Some(reader.peek() as u32 - '0' as u32);
+                reader.advance();
+            }
+            _ => break,
+        }
+    }
+
+    // After the indicators, only whitespace, an optional comment, and the line
+    // break may remain on the header line. A repeated indicator, a second
+    // indentation digit (`|12`), a space-separated indicator (`| 2`), or any
+    // other text lands here and is rejected.
     loop {
         if reader.is_eof() {
             break;
         }
         match reader.peek() {
-            '-' => {
-                chomping = Chomping::Strip;
-                reader.advance();
-            }
-            '+' => {
-                chomping = Chomping::Keep;
-                reader.advance();
-            }
-            '1'..='9' => {
-                explicit_indent = Some(reader.peek() as u32 - '0' as u32);
-                reader.advance();
-            }
             ' ' | '\t' => {
                 reader.advance();
             }
@@ -390,9 +407,6 @@ pub fn scan_block<'input>(
                 break;
             }
             '\n' | '\r' => break,
-            // Only chomping/indent indicators, a space-preceded comment, or a
-            // line break may follow the `|`/`>` header. Anything else (a stray
-            // `#` or arbitrary text on the header line) is invalid.
             other => {
                 let what = if other == '#' {
                     "a comment must be preceded by whitespace"
@@ -931,5 +945,22 @@ mod tests {
     #[test]
     fn invalid_escape_is_an_error() {
         assert!(errors("\"bad \\q escape\"\n"));
+    }
+
+    #[test]
+    fn malformed_block_scalar_header_is_an_error() {
+        // At most one chomping and one indentation indicator, no whitespace
+        // before or between them. The lenient scan accepted all of these.
+        assert!(errors("|+-\n  a\n")); // two chomping indicators
+        assert!(errors("|12\n  a\n")); // two indentation digits
+        assert!(errors("| 2\n  a\n")); // whitespace before the indicator
+    }
+
+    #[test]
+    fn valid_block_scalar_headers_scan() {
+        // Either indicator order, with or without a trailing comment, is fine.
+        assert_eq!(first("|2-\n   a\n").0, " a");
+        assert_eq!(first("|-2\n   a\n").0, " a");
+        assert_eq!(first("| # c\n  a\n").0, "a\n");
     }
 }

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -120,3 +120,66 @@ def test_directive_after_document_end_is_allowed():
         "foo",
         "bar",
     ]
+
+
+def test_unterminated_verbatim_tag_is_rejected():
+    """An unterminated `!<...` is rejected, not swallowed through the rest.
+
+    Stopping only at `>`/EOF let `!<foo` consume the following lines, silently
+    dropping them; the missing `>` must be reported instead.
+    """
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="verbatim tag"):
+        yamlrocks.loads(b"x: !<foo\nbar: 1\n")
+
+
+def test_empty_verbatim_tag_is_rejected():
+    """A `!<>` verbatim tag has no tag text and is invalid."""
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="verbatim tag"):
+        yamlrocks.loads(b"x: !<> v\n")
+
+
+def test_verbatim_tag_with_whitespace_is_rejected():
+    """A verbatim tag body holds URI text only; whitespace ends it unterminated."""
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="verbatim tag"):
+        yamlrocks.loads(b"x: !<a b> v\n")
+
+
+def test_valid_verbatim_tag_still_parses():
+    """A well-formed `!<...>` is unaffected by the stricter scan."""
+    assert yamlrocks.loads(b"x: !<tag:example.com,2024:foo> v\n") == {"x": "v"}
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        b"x: |+-\n  a\n",  # two chomping indicators
+        b"x: |-+\n  a\n",  # two chomping indicators, other order
+        b"x: |12\n  a\n",  # two indentation digits
+        b"x: | 2\n  a\n",  # whitespace before the indentation indicator
+        b"x: |2 3\n  a\n",  # a second indicator after whitespace
+    ],
+)
+def test_invalid_block_scalar_header_is_rejected(src):
+    """A block scalar header allows at most one chomping and one indent indicator.
+
+    No whitespace may precede or separate them; the lenient scan accepted these
+    malformed headers and silently kept whichever indicator came last.
+    """
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError):
+        yamlrocks.loads(src)
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        (b"x: |-\n  a\n", "a"),
+        (b"x: |+\n  a\n", "a\n"),
+        (b"x: |2\n   a\n", " a\n"),
+        (b"x: |2-\n   a\n", " a"),
+        (b"x: |-2\n   a\n", " a"),
+        (b"x: | # c\n  a\n", "a\n"),
+    ],
+)
+def test_valid_block_scalar_header_still_parses(src, expected):
+    """Every well-formed chomping/indent header combination still loads."""
+    assert yamlrocks.loads(src) == {"x": expected}


### PR DESCRIPTION
## Breaking change

Two inputs that previously loaded now raise `YAMLRocksDecodeError`. Both were malformed YAML that should never have been accepted, so this tightens correctness rather than removing a feature:

- An unterminated verbatim tag such as `!<foo` (no closing `>`).
- A block scalar header with more than one chomping or indentation indicator, or whitespace before/between them (`|+-`, `|12`, `| 2`).

## Proposed change

Two scanner-level cases accepted invalid YAML instead of rejecting it (found in a review pass).

A verbatim tag scanned its body until `>` or end of input, so an unterminated `!<foo` swallowed the following lines and silently dropped them:

```python
yamlrocks.loads(b"x: !<foo\nbar: 1\n")
# before: {"x": ""}   (bar: 1 was consumed into the tag and lost)
# after:  raises YAMLRocksDecodeError (unterminated verbatim tag)
```

The body is now bounded by whitespace and line breaks, a missing `>` is reported, and an empty `!<>` is rejected.

A block scalar header looped over chomping/indent indicators, whitespace, and digits in any order, keeping whichever indicator came last, so `|+-`, `|12`, and `| 2` all loaded. The header now parses at most one chomping (`+`/`-`) and one indentation (`1`-`9`) indicator, in either order, with no whitespace before or between them (YAML 8.1.1). Every valid combination (`|-`, `|2`, `|2-`, `|-2`, `| # comment`) still parses identically.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
