### PR TITLE
🐛 Compare full structure for schema const/enum on containers

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -189,7 +189,10 @@ fn validate_node_inner(
     // `enum`/`const` compare the *whole* value, nested containers included, so
     // they need the fully resolved structure. The shallow `resolved` above keeps
     // every sequence/mapping empty (enough for `type`/numeric/string checks but
-    // not for equality), so resolve deeply here, only when one is present.
+    // not for equality), so resolve deeply here, only when one is present. The
+    // deep tree is dropped iteratively (`drop_value_tree`): its depth is bounded
+    // only by `MAX_DEPTH` over untrusted input, so a recursive teardown could
+    // overflow a small thread stack and, under `panic = "abort"`, abort.
     if let Some(Value::Sequence(options)) = get(schema, "enum") {
         let value = resolve_deep(node, yaml_11);
         if !options.iter().any(|opt| value_eq(opt, &value)) {
@@ -199,12 +202,14 @@ fn validate_node_inner(
                 "value is not one of the allowed enum values",
             ));
         }
+        crate::stack::drop_value_tree(value);
     }
     if let Some(const_schema) = get(schema, "const") {
         let value = resolve_deep(node, yaml_11);
         if !value_eq(const_schema, &value) {
             errors.push(err(node, path, "value does not equal the required const"));
         }
+        crate::stack::drop_value_tree(value);
     }
 
     check_numeric(node, &resolved, schema, path, errors);

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -186,8 +186,13 @@ fn validate_node_inner(
     if let Some(type_schema) = get(schema, "type") {
         check_type(node, &resolved, type_schema, path, errors);
     }
+    // `enum`/`const` compare the *whole* value, nested containers included, so
+    // they need the fully resolved structure. The shallow `resolved` above keeps
+    // every sequence/mapping empty (enough for `type`/numeric/string checks but
+    // not for equality), so resolve deeply here, only when one is present.
     if let Some(Value::Sequence(options)) = get(schema, "enum") {
-        if !options.iter().any(|opt| value_eq(opt, &resolved)) {
+        let value = resolve_deep(node, yaml_11);
+        if !options.iter().any(|opt| value_eq(opt, &value)) {
             errors.push(err(
                 node,
                 path,
@@ -196,7 +201,8 @@ fn validate_node_inner(
         }
     }
     if let Some(const_schema) = get(schema, "const") {
-        if !value_eq(const_schema, &resolved) {
+        let value = resolve_deep(node, yaml_11);
+        if !value_eq(const_schema, &value) {
             errors.push(err(node, path, "value does not equal the required const"));
         }
     }
@@ -527,6 +533,27 @@ fn resolve(node: &YamlNode, yaml_11: bool) -> Value<'static> {
     }
 }
 
+/// Like [`resolve`], but recurses into sequences and mappings so the full nested
+/// structure is materialized. Used only by `enum`/`const`, which compare the
+/// whole value; the shallow [`resolve`] leaves containers empty, which would make
+/// `const {}` match any mapping and a non-empty `const`/`enum` match nothing.
+fn resolve_deep(node: &YamlNode, yaml_11: bool) -> Value<'static> {
+    // Grow the native stack on demand: this recurses once per nesting level over
+    // the (depth-bounded) AST, matching `validate_node`. See [`crate::stack`].
+    crate::stack::guard(|| match &node.kind {
+        YamlNodeKind::Sequence(items) => {
+            Value::Sequence(items.iter().map(|it| resolve_deep(it, yaml_11)).collect())
+        }
+        YamlNodeKind::Mapping(pairs) => Value::Mapping(
+            pairs
+                .iter()
+                .map(|(k, v)| (resolve_deep(k, yaml_11), resolve_deep(v, yaml_11)))
+                .collect(),
+        ),
+        _ => resolve(node, yaml_11),
+    })
+}
+
 /// Look up a key in an object schema.
 fn get<'a, 'v>(schema: &'a Value<'v>, key: &str) -> Option<&'a Value<'v>> {
     match schema {
@@ -562,6 +589,20 @@ fn as_count_bound(value: &Value) -> Option<i64> {
 fn value_eq(a: &Value, b: &Value) -> bool {
     match (a, b) {
         (Value::Int(i), Value::Float(f)) | (Value::Float(f), Value::Int(i)) => *i as f64 == *f,
+        // Arrays are equal element-wise, in order.
+        (Value::Sequence(xs), Value::Sequence(ys)) => {
+            xs.len() == ys.len() && xs.iter().zip(ys).all(|(x, y)| value_eq(x, y))
+        }
+        // Objects are equal as sets of pairs: order does not matter, but every
+        // pair on one side must have an equal pair on the other (sizes match, and
+        // a loaded mapping has no duplicate keys, so this is true set equality).
+        (Value::Mapping(xs), Value::Mapping(ys)) => {
+            xs.len() == ys.len()
+                && xs.iter().all(|(xk, xv)| {
+                    ys.iter()
+                        .any(|(yk, yv)| value_eq(xk, yk) && value_eq(xv, yv))
+                })
+        }
         _ => a == b,
     }
 }

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -94,6 +94,22 @@ def test_enum_array_compares_full_structure():
         yamlrocks.loads(b"a: [1]\n", schema={"properties": {"a": {"enum": [[]]}}})
 
 
+def test_deeply_nested_value_under_enum_does_not_overflow():
+    """A deep document under a container enum/const tears down without crashing.
+
+    `enum`/`const` build a fully resolved copy of the value; that deep tree must
+    be dropped iteratively, or a near-MAX_DEPTH document could overflow the stack
+    on teardown (and abort under `panic = "abort"`).
+    """
+    depth = 900
+    doc = (b"[" * depth) + b"1" + (b"]" * depth)
+    # The exact verdict does not matter; the point is no crash on teardown.
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError):
+        yamlrocks.loads(doc, schema={"enum": [[]]})
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError):
+        yamlrocks.loads(doc, schema={"const": []})
+
+
 def test_additional_property_rejected():
     """An undeclared property is rejected when additionalProperties is false."""
     with pytest.raises(

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -63,6 +63,37 @@ def test_enum_violation():
         yamlrocks.loads(b"name: app\nport: 80\nmode: staging\n", schema=SCHEMA)
 
 
+def test_const_object_compares_full_structure():
+    """`const` on an object matches by full contents, not as an empty mapping.
+
+    The resolver previously collapsed every mapping to empty, so `const {}`
+    accepted any mapping and a non-empty `const` accepted none.
+    """
+    schema = {"properties": {"a": {"const": {"k": 1}}}}
+    # An equal object passes; order does not matter.
+    assert yamlrocks.loads(b"a:\n  k: 1\n", schema=schema) == {"a": {"k": 1}}
+    assert yamlrocks.loads(
+        b"a:\n  k: 1\n  j: 2\n",
+        schema={"properties": {"a": {"const": {"j": 2, "k": 1}}}},
+    ) == {"a": {"k": 1, "j": 2}}
+    # A different value, and a non-empty object against `const {}`, both fail.
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="const"):
+        yamlrocks.loads(b"a:\n  k: 2\n", schema=schema)
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="const"):
+        yamlrocks.loads(b"a:\n  k: 1\n", schema={"properties": {"a": {"const": {}}}})
+
+
+def test_enum_array_compares_full_structure():
+    """`enum` options that are arrays match by full contents."""
+    schema = {"properties": {"a": {"enum": [[1, 2], [3, 4]]}}}
+    assert yamlrocks.loads(b"a: [3, 4]\n", schema=schema) == {"a": [3, 4]}
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="enum"):
+        yamlrocks.loads(b"a: [1, 3]\n", schema=schema)
+    # An empty-array enum option must not match a non-empty array.
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="enum"):
+        yamlrocks.loads(b"a: [1]\n", schema={"properties": {"a": {"enum": [[]]}}})
+
+
 def test_additional_property_rejected():
     """An undeclared property is rejected when additionalProperties is false."""
     with pytest.raises(


### PR DESCRIPTION
## Breaking change

None for valid usage. Schema `const`/`enum` with array or object values now validate correctly; documents that previously passed (or failed) by accident may now be judged correctly. No valid schema behavior is removed.

## Proposed change

Schema validation resolved a node's value with a shallow pass that collapsed every sequence and mapping to an empty container. So equality-based keywords on containers were broken both ways:

```python
# const {} matched ANY mapping (should match only an empty one)
yamlrocks.loads(b"admin:\n  x: 1\n", schema={"properties": {"admin": {"const": {}}}})
# before: accepted   after: rejected

# a non-empty const matched NOTHING (an equal object was rejected)
yamlrocks.loads(b"a:\n  k: 1\n", schema={"properties": {"a": {"const": {"k": 1}}}})
# before: rejected   after: accepted

# enum [[]] matched any array; enum [[1,2]] never matched [1,2]
```

Found in a review pass. The fix resolves the value deeply (recursing into sequences and mappings) only when an `enum` or `const` is present, and compares structurally: arrays element-wise in order, objects as order-independent sets of pairs (so `{a: 1, b: 2}` equals `{b: 2, a: 1}`). The shallow resolve still serves the `type`/numeric/string checks, so the common validation path keeps its cost.

The unsupported `$ref` keyword (internal `#/$defs/...`) is tracked separately and will be implemented in a follow-up.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
