### PR TITLE
✨ Resolve JSON Schema $ref against local pointers

### DIFF
--- a/docs/src/content/docs/guides/schema-validation.md
+++ b/docs/src/content/docs/guides/schema-validation.md
@@ -265,12 +265,13 @@ full validator. The supported keywords are:
 | Numbers     | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`                 |
 | Strings     | `minLength`, `maxLength`                                                     |
 | Combinators | `allOf`, `anyOf`, `oneOf`, `not`                                             |
+| References  | `$ref` (local `#/...` pointers, including `#/$defs/...`)                     |
 
 :::note[Unknown keywords are ignored]
 This is a deliberately small subset. Keywords YAMLRocks does not implement (such as
-`pattern`, `format`, or `$ref`) are skipped rather than rejected, so a richer
-schema written for another validator still works here; it just validates against
-the keywords listed above. If you need a feature that is missing, validate with a
+`pattern` or `format`) are skipped rather than rejected, so a richer schema
+written for another validator still works here; it just validates against the
+keywords listed above. If you need a feature that is missing, validate with a
 dedicated JSON Schema library after `loads` returns.
 :::
 
@@ -280,10 +281,10 @@ The validator is tuned for the scalar-and-shape constraints configuration files
 actually use. Three boundaries are worth knowing, and all three are reasons to
 reach for a dedicated JSON Schema library when you need them:
 
-- **`enum` and `const` compare scalars.** They are reliable for strings, numbers,
-  booleans, and null. Using them to pin an _array_ or _object_ value is not
-  supported and may reject an otherwise-matching value, so do not rely on
-  structural `const`/`enum`.
+- **`$ref` resolves local pointers only.** A `$ref` into the same schema
+  (`#/$defs/...`, `#/definitions/...`, or any `#/`-path) is resolved and
+  validated. A remote reference (an external URL) is not fetched; it is reported
+  as an unresolvable `$ref` rather than silently passing.
 - **Object rules apply to scalar keys.** `properties`, `required`, and
   `additionalProperties` match string keys. A YAML _collection key_
   (`[a, b]: ...`) is not a JSON object key and is not subject to these rules, so

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -7,8 +7,10 @@
 //! A practical subset of JSON Schema (draft 7-ish) is supported: `type`,
 //! `enum`, `const`, `properties`, `required`, `additionalProperties` (boolean),
 //! `items`, `minimum`/`maximum`, `exclusiveMinimum`/`exclusiveMaximum`,
-//! `minLength`/`maxLength`, `minItems`/`maxItems`, and the `allOf`/`anyOf`/
-//! `oneOf`/`not` combinators. Unknown keywords are ignored.
+//! `minLength`/`maxLength`, `minItems`/`maxItems`, the `allOf`/`anyOf`/`oneOf`/
+//! `not` combinators, and `$ref` to local `#/...` pointers (including
+//! `#/$defs/...`). Other keywords are ignored; an unresolvable `$ref` is an
+//! error rather than silently permissive.
 
 mod directive;
 
@@ -32,6 +34,34 @@ const MAX_ALIAS_DEPTH: usize = 100;
 /// validator cannot be turned into an uncatchable process abort.
 const MAX_ALIAS_NODES: usize = 1_000_000;
 
+/// Maximum chain of `$ref` follows before validation gives up, fast-failing a
+/// cyclic reference (`#/$defs/a` whose schema is `{"$ref": "#/$defs/a"}`).
+/// Counts only consecutive `$ref` hops at one node; descending into a child node
+/// resets it, so a legitimately deep document with many refs is not truncated.
+const MAX_REF_DEPTH: usize = 128;
+
+/// Validation context threaded through the recursive walk: the root schema (for
+/// resolving `#/...` `$ref` pointers, which are document-relative), the scalar
+/// schema to resolve leaves with, and the current `$ref` follow depth. Cheap to
+/// copy (a reference plus two scalars).
+#[derive(Clone, Copy)]
+struct Ctx<'a, 'v> {
+    root: &'a Value<'v>,
+    yaml_11: bool,
+    ref_depth: usize,
+}
+
+impl<'a, 'v> Ctx<'a, 'v> {
+    /// Context for validating a child node: the `$ref` depth resets because
+    /// descending the document is finite progress, not a reference cycle.
+    fn child(self) -> Self {
+        Self {
+            ref_depth: 0,
+            ..self
+        }
+    }
+}
+
 /// A single schema validation failure.
 pub struct SchemaError {
     pub message: String,
@@ -54,7 +84,12 @@ pub fn validate(node: &YamlNode, schema: &Value, yaml_11: bool) -> Vec<SchemaErr
     let resolved = expand_aliases(node, &anchors, 0, &mut budget);
 
     let mut errors = Vec::new();
-    validate_node(&resolved, schema, "$", yaml_11, &mut errors);
+    let ctx = Ctx {
+        root: schema,
+        yaml_11,
+        ref_depth: 0,
+    };
+    validate_node(&resolved, schema, "$", ctx, &mut errors);
     errors
 }
 
@@ -153,20 +188,20 @@ fn validate_node(
     node: &YamlNode,
     schema: &Value,
     path: &str,
-    yaml_11: bool,
+    ctx: Ctx<'_, '_>,
     errors: &mut Vec<SchemaError>,
 ) {
     // Grow the native stack on demand so validating a deeply nested document
     // cannot overflow a small thread stack; the recursion re-enters here per
     // level. See [`crate::stack`].
-    crate::stack::guard(|| validate_node_inner(node, schema, path, yaml_11, errors))
+    crate::stack::guard(|| validate_node_inner(node, schema, path, ctx, errors))
 }
 
 fn validate_node_inner(
     node: &YamlNode,
     schema: &Value,
     path: &str,
-    yaml_11: bool,
+    ctx: Ctx<'_, '_>,
     errors: &mut Vec<SchemaError>,
 ) {
     // A boolean schema: `true` accepts anything, `false` rejects everything.
@@ -181,7 +216,37 @@ fn validate_node_inner(
         return; // non-object schemas other than booleans are treated as permissive
     };
 
-    let resolved = resolve(node, yaml_11);
+    // `$ref`: resolve the `#/...` pointer against the root schema and validate
+    // against the target. Draft-07 semantics: a `$ref` ignores any sibling
+    // keywords, so this returns afterward. An unresolvable reference is an error
+    // (not silently permissive), and a `$ref` cycle is cut by the depth bound.
+    if let Some(Value::String(reference)) = get(schema, "$ref") {
+        if ctx.ref_depth >= MAX_REF_DEPTH {
+            errors.push(err(
+                node,
+                path,
+                "schema $ref nesting too deep (cyclic reference?)",
+            ));
+            return;
+        }
+        match resolve_ref(ctx.root, reference) {
+            Some(target) => {
+                let next = Ctx {
+                    ref_depth: ctx.ref_depth + 1,
+                    ..ctx
+                };
+                validate_node(node, target, path, next, errors);
+            }
+            None => errors.push(err(
+                node,
+                path,
+                &format!("unresolvable schema $ref '{reference}'"),
+            )),
+        }
+        return;
+    }
+
+    let resolved = resolve(node, ctx.yaml_11);
 
     if let Some(type_schema) = get(schema, "type") {
         check_type(node, &resolved, type_schema, path, errors);
@@ -194,7 +259,7 @@ fn validate_node_inner(
     // only by `MAX_DEPTH` over untrusted input, so a recursive teardown could
     // overflow a small thread stack and, under `panic = "abort"`, abort.
     if let Some(Value::Sequence(options)) = get(schema, "enum") {
-        let value = resolve_deep(node, yaml_11);
+        let value = resolve_deep(node, ctx.yaml_11);
         if !options.iter().any(|opt| value_eq(opt, &value)) {
             errors.push(err(
                 node,
@@ -205,7 +270,7 @@ fn validate_node_inner(
         crate::stack::drop_value_tree(value);
     }
     if let Some(const_schema) = get(schema, "const") {
-        let value = resolve_deep(node, yaml_11);
+        let value = resolve_deep(node, ctx.yaml_11);
         if !value_eq(const_schema, &value) {
             errors.push(err(node, path, "value does not equal the required const"));
         }
@@ -214,9 +279,9 @@ fn validate_node_inner(
 
     check_numeric(node, &resolved, schema, path, errors);
     check_string(node, &resolved, schema, path, errors);
-    check_object(node, schema, path, yaml_11, errors);
-    check_array(node, schema, path, yaml_11, errors);
-    check_combinators(node, schema, path, yaml_11, errors);
+    check_object(node, schema, path, ctx, errors);
+    check_array(node, schema, path, ctx, errors);
+    check_combinators(node, schema, path, ctx, errors);
 }
 
 fn check_type(
@@ -365,7 +430,7 @@ fn check_object(
     node: &YamlNode,
     schema: &Value,
     path: &str,
-    yaml_11: bool,
+    ctx: Ctx<'_, '_>,
     errors: &mut Vec<SchemaError>,
 ) {
     let YamlNodeKind::Mapping(pairs) = &node.kind else {
@@ -400,7 +465,7 @@ fn check_object(
         if let Some(props) = properties {
             if let Some(subschema) = get(props, &key_name) {
                 matched = true;
-                validate_node(val, subschema, &child_path, yaml_11, errors);
+                validate_node(val, subschema, &child_path, ctx.child(), errors);
             }
         }
         if !matched {
@@ -411,7 +476,7 @@ fn check_object(
                     &format!("additional property '{key_name}' is not allowed"),
                 )),
                 Some(sub @ Value::Mapping(_)) => {
-                    validate_node(val, sub, &child_path, yaml_11, errors)
+                    validate_node(val, sub, &child_path, ctx.child(), errors)
                 }
                 _ => {}
             }
@@ -423,7 +488,7 @@ fn check_array(
     node: &YamlNode,
     schema: &Value,
     path: &str,
-    yaml_11: bool,
+    ctx: Ctx<'_, '_>,
     errors: &mut Vec<SchemaError>,
 ) {
     let YamlNodeKind::Sequence(items) = &node.kind else {
@@ -452,7 +517,7 @@ fn check_array(
     if let Some(items_schema) = get(schema, "items") {
         for (i, item) in items.iter().enumerate() {
             let child_path = format!("{path}[{i}]");
-            validate_node(item, items_schema, &child_path, yaml_11, errors);
+            validate_node(item, items_schema, &child_path, ctx.child(), errors);
         }
     }
 }
@@ -461,18 +526,23 @@ fn check_combinators(
     node: &YamlNode,
     schema: &Value,
     path: &str,
-    yaml_11: bool,
+    ctx: Ctx<'_, '_>,
     errors: &mut Vec<SchemaError>,
 ) {
+    // Combinator sub-schemas apply to the *same* node, so `ctx` passes through
+    // unchanged: the `$ref` depth is not reset (a sub-schema that is itself a
+    // `$ref` still counts toward the cycle bound) and not incremented here (the
+    // increment happens in `validate_node_inner` when a `$ref` is actually
+    // followed).
     if let Some(Value::Sequence(subs)) = get(schema, "allOf") {
         for sub in subs {
-            validate_node(node, sub, path, yaml_11, errors);
+            validate_node(node, sub, path, ctx, errors);
         }
     }
     if let Some(Value::Sequence(subs)) = get(schema, "anyOf") {
         let any = subs.iter().any(|sub| {
             let mut tmp = Vec::new();
-            validate_node(node, sub, path, yaml_11, &mut tmp);
+            validate_node(node, sub, path, ctx, &mut tmp);
             tmp.is_empty()
         });
         if !any {
@@ -488,7 +558,7 @@ fn check_combinators(
             .iter()
             .filter(|sub| {
                 let mut tmp = Vec::new();
-                validate_node(node, sub, path, yaml_11, &mut tmp);
+                validate_node(node, sub, path, ctx, &mut tmp);
                 tmp.is_empty()
             })
             .count();
@@ -502,7 +572,7 @@ fn check_combinators(
     }
     if let Some(sub) = get(schema, "not") {
         let mut tmp = Vec::new();
-        validate_node(node, sub, path, yaml_11, &mut tmp);
+        validate_node(node, sub, path, ctx, &mut tmp);
         if tmp.is_empty() {
             errors.push(err(node, path, "value must not match the 'not' schema"));
         }
@@ -557,6 +627,33 @@ fn resolve_deep(node: &YamlNode, yaml_11: bool) -> Value<'static> {
         ),
         _ => resolve(node, yaml_11),
     })
+}
+
+/// Resolve a JSON Schema `$ref` against the root schema. Only local pointers are
+/// supported: a `#` fragment naming a path within the same document (the common
+/// `#/$defs/name` / `#/definitions/name` form, or any deeper path). Returns the
+/// referenced subschema, or `None` for a remote reference (one not starting with
+/// `#`, which would need a network or external resolver) or a pointer that does
+/// not exist. `None` is reported by the caller as an error, never silently
+/// treated as a permissive schema.
+fn resolve_ref<'a, 'v>(root: &'a Value<'v>, reference: &str) -> Option<&'a Value<'v>> {
+    let pointer = reference.strip_prefix('#')?;
+    if pointer.is_empty() {
+        return Some(root); // `#` is the whole schema
+    }
+    // A non-empty fragment must be a JSON Pointer (`#/...`).
+    let pointer = pointer.strip_prefix('/')?;
+    let mut current = root;
+    for raw in pointer.split('/') {
+        // JSON Pointer unescaping: `~1` -> `/`, then `~0` -> `~` (RFC 6901).
+        let token = raw.replace("~1", "/").replace("~0", "~");
+        current = match current {
+            Value::Mapping(_) => get(current, &token)?,
+            Value::Sequence(items) => items.get(token.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(current)
 }
 
 /// Look up a key in an object schema.

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -35,25 +35,35 @@ const MAX_ALIAS_DEPTH: usize = 100;
 const MAX_ALIAS_NODES: usize = 1_000_000;
 
 /// Maximum chain of `$ref` follows before validation gives up, fast-failing a
-/// cyclic reference (`#/$defs/a` whose schema is `{"$ref": "#/$defs/a"}`).
+/// straight cyclic reference (`#/$defs/a` whose schema is `{"$ref": "#/$defs/a"}`).
 /// Counts only consecutive `$ref` hops at one node; descending into a child node
 /// resets it, so a legitimately deep document with many refs is not truncated.
 const MAX_REF_DEPTH: usize = 128;
 
+/// Total `$ref` follows allowed across the whole validation, shared through the
+/// walk. The per-chain [`MAX_REF_DEPTH`] cannot catch a *branching* cycle (a
+/// `$ref` reached twice from one node through `allOf`, which doubles the work at
+/// every level for `2^depth` total calls); this budget does, mirroring the
+/// alias-expansion [`MAX_ALIAS_NODES`] bound. Set far above any real schema.
+const MAX_REF_FOLLOWS: usize = 100_000;
+
 /// Validation context threaded through the recursive walk: the root schema (for
 /// resolving `#/...` `$ref` pointers, which are document-relative), the scalar
-/// schema to resolve leaves with, and the current `$ref` follow depth. Cheap to
-/// copy (a reference plus two scalars).
+/// schema to resolve leaves with, the current `$ref` chain depth, and a shared
+/// total-follow budget. Cheap to copy (references plus two scalars); the budget
+/// is a shared cell so every branch of the walk draws from one pool.
 #[derive(Clone, Copy)]
 struct Ctx<'a, 'v> {
     root: &'a Value<'v>,
     yaml_11: bool,
     ref_depth: usize,
+    ref_budget: &'a std::cell::Cell<usize>,
 }
 
 impl<'a, 'v> Ctx<'a, 'v> {
-    /// Context for validating a child node: the `$ref` depth resets because
-    /// descending the document is finite progress, not a reference cycle.
+    /// Context for validating a child node: the `$ref` chain depth resets because
+    /// descending the document is finite progress, not a reference cycle. The
+    /// shared follow budget carries over (it bounds total work, not depth).
     fn child(self) -> Self {
         Self {
             ref_depth: 0,
@@ -84,10 +94,12 @@ pub fn validate(node: &YamlNode, schema: &Value, yaml_11: bool) -> Vec<SchemaErr
     let resolved = expand_aliases(node, &anchors, 0, &mut budget);
 
     let mut errors = Vec::new();
+    let ref_budget = std::cell::Cell::new(MAX_REF_FOLLOWS);
     let ctx = Ctx {
         root: schema,
         yaml_11,
         ref_depth: 0,
+        ref_budget: &ref_budget,
     };
     validate_node(&resolved, schema, "$", ctx, &mut errors);
     errors
@@ -219,9 +231,11 @@ fn validate_node_inner(
     // `$ref`: resolve the `#/...` pointer against the root schema and validate
     // against the target. Draft-07 semantics: a `$ref` ignores any sibling
     // keywords, so this returns afterward. An unresolvable reference is an error
-    // (not silently permissive), and a `$ref` cycle is cut by the depth bound.
+    // (not silently permissive). A straight `$ref` cycle is cut by the per-chain
+    // depth bound; a cycle that branches through a combinator is cut by the
+    // shared total-follow budget, which a depth cap alone cannot bound.
     if let Some(Value::String(reference)) = get(schema, "$ref") {
-        if ctx.ref_depth >= MAX_REF_DEPTH {
+        if ctx.ref_depth >= MAX_REF_DEPTH || ctx.ref_budget.get() == 0 {
             errors.push(err(
                 node,
                 path,
@@ -229,6 +243,7 @@ fn validate_node_inner(
             ));
             return;
         }
+        ctx.ref_budget.set(ctx.ref_budget.get() - 1);
         match resolve_ref(ctx.root, reference) {
             Some(target) => {
                 let next = Ctx {

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -157,6 +157,19 @@ def test_cyclic_ref_is_bounded():
         yamlrocks.loads(b"1", schema=schema)
 
 
+def test_branching_ref_cycle_is_bounded():
+    """A `$ref` cycle that branches through a combinator is bounded by a budget.
+
+    `allOf` reaches the same `$ref` twice, doubling the work at each level; a
+    per-chain depth cap alone would allow ~2^depth calls (an effective hang). A
+    shared total-follow budget cuts it.
+    """
+    inner = {"allOf": [{"$ref": "#/$defs/a"}, {"$ref": "#/$defs/a"}]}
+    schema = {"$ref": "#/$defs/a", "$defs": {"a": inner}}
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="nesting too deep"):
+        yamlrocks.loads(b"1", schema=schema)
+
+
 def test_deeply_nested_value_under_enum_does_not_overflow():
     """A deep document under a container enum/const tears down without crashing.
 

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -94,6 +94,69 @@ def test_enum_array_compares_full_structure():
         yamlrocks.loads(b"a: [1]\n", schema={"properties": {"a": {"enum": [[]]}}})
 
 
+def test_ref_resolves_against_defs():
+    """A `$ref` to `#/$defs/...` validates against the referenced subschema."""
+    schema = {"$ref": "#/$defs/port", "$defs": {"port": {"type": "integer"}}}
+    assert yamlrocks.loads(b"42", schema=schema) == 42
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="integer"):
+        yamlrocks.loads(b"not_int", schema=schema)
+
+
+def test_ref_resolves_against_definitions():
+    """A `$ref` to the draft-7 `#/definitions/...` location works too."""
+    schema = {
+        "properties": {"p": {"$ref": "#/definitions/p"}},
+        "definitions": {"p": {"type": "string"}},
+    }
+    assert yamlrocks.loads(b"p: hello\n", schema=schema) == {"p": "hello"}
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="string"):
+        yamlrocks.loads(b"p: 5\n", schema=schema)
+
+
+def test_ref_resolves_a_deep_json_pointer():
+    """A `$ref` may point at any path within the schema, not just $defs."""
+    schema = {
+        "$ref": "#/$defs/a/properties/b",
+        "$defs": {"a": {"properties": {"b": {"type": "boolean"}}}},
+    }
+    assert yamlrocks.loads(b"true", schema=schema) is True
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="boolean"):
+        yamlrocks.loads(b"5", schema=schema)
+
+
+def test_ref_recurses_over_a_finite_document():
+    """A recursive schema validates a finite nested document (no false cycle)."""
+    schema = {
+        "$ref": "#/$defs/node",
+        "$defs": {
+            "node": {
+                "type": "object",
+                "properties": {"child": {"$ref": "#/$defs/node"}},
+            }
+        },
+    }
+    assert yamlrocks.loads(b"child:\n  child:\n    x: 1\n", schema=schema) == {
+        "child": {"child": {"x": 1}}
+    }
+
+
+def test_unresolvable_ref_is_an_error():
+    """An unresolvable `$ref` is reported, never silently treated as permissive."""
+    # A missing local pointer.
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="unresolvable schema"):
+        yamlrocks.loads(b"1", schema={"$ref": "#/$defs/nope", "$defs": {}})
+    # A remote reference, which would need an external resolver.
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="unresolvable schema"):
+        yamlrocks.loads(b"1", schema={"$ref": "https://example.com/s.json"})
+
+
+def test_cyclic_ref_is_bounded():
+    """A `$ref` cycle is cut by the depth bound rather than looping forever."""
+    schema = {"$ref": "#/$defs/a", "$defs": {"a": {"$ref": "#/$defs/a"}}}
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError, match="nesting too deep"):
+        yamlrocks.loads(b"1", schema=schema)
+
+
 def test_deeply_nested_value_under_enum_does_not_overflow():
     """A deep document under a container enum/const tears down without crashing.
 


### PR DESCRIPTION
## Breaking change

A schema that uses `$ref` now actually validates. Previously `$ref` was ignored, so such a schema silently accepted any document; documents that only "passed" because validation was a no-op may now be correctly rejected. No other schema behavior changes.

## Proposed change

The schema validator ignored the JSON-Schema `$ref` keyword (it fell into the "unknown keywords are ignored" bucket), so a schema built around `$ref` (the common `#/$defs/...` form) validated nothing and silently accepted any document. Found in a review pass.

`$ref` is now resolved:

```python
schema = {"$ref": "#/$defs/port", "$defs": {"port": {"type": "integer"}}}
yamlrocks.loads(b"42", schema=schema)        # 42
yamlrocks.loads(b"not_int", schema=schema)   # raises: expected type integer
```

Implementation:

- A small `Ctx` (root schema + `yaml_11` + `$ref` depth) is threaded through the recursive walk, so a `#/...` pointer resolves document-relative against the root schema.
- `resolve_ref` walks a local JSON Pointer (`#/$defs/...`, `#/definitions/...`, or any `#/`-path, with `~0`/`~1` unescaping). Draft-07 semantics: a `$ref` ignores sibling keywords.
- An **unresolvable** reference (a missing pointer, or a remote URL that would need an external resolver) is reported as an error rather than silently passing.
- A `$ref` **cycle** is cut by a depth bound (`MAX_REF_DEPTH`) that resets when descending into a child node, so a recursive schema over a finite document still validates correctly.

The schema guide is updated: `$ref` is added to the supported-keywords table and removed from the "ignored" list, and the stale note that structural `const`/`enum` is unsupported is dropped (that was fixed in #130).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #130
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
