### PR TITLE
🐛 Reject invalid anchor names and tags before emitting them

### DIFF
--- a/src/ffi/convert/encode.rs
+++ b/src/ffi/convert/encode.rs
@@ -157,6 +157,25 @@ fn python_to_value_inner(
     )))
 }
 
+/// Reject a tag that cannot be emitted as a single tag token. A tag is written
+/// verbatim before its value (`!tag value`), so a tag containing whitespace or a
+/// control character (or one not starting with `!`) would split on re-parse and
+/// silently corrupt the document: `YAMLRocksTag("!bad tag", "v")` would emit
+/// `!bad tag v`, reloading as the tag `!bad` on the value `"tag v"`.
+fn validate_tag(tag: &str) -> PyResult<()> {
+    if tag.is_empty() || !tag.starts_with('!') {
+        return Err(errors::encode_error(format!(
+            "invalid tag {tag:?}: a tag must start with '!'"
+        )));
+    }
+    if let Some(bad) = tag.chars().find(|c| c.is_whitespace() || c.is_control()) {
+        return Err(errors::encode_error(format!(
+            "invalid tag {tag:?}: a tag cannot contain whitespace or control characters (found {bad:?})"
+        )));
+    }
+    Ok(())
+}
+
 /// Convert a [`YAMLRocksTag`] into a [`Value::Tagged`], serializing its inner
 /// value with the normal rules. The tag and value are read out first so the
 /// borrow is released before the (Python-running) recursive conversion.
@@ -169,6 +188,7 @@ fn tagged_to_value(
         let borrowed = tag_obj.borrow();
         (borrowed.tag.clone(), borrowed.value.clone_ref(py))
     };
+    validate_tag(&tag)?;
     let inner = python_to_value(py, value.bind(py), ctx)?;
     Ok(Value::Tagged(tag, Box::new(inner)))
 }
@@ -186,6 +206,7 @@ fn tag_callback_result(
     if let Ok(tuple) = result.cast::<PyTuple>() {
         if tuple.len() == 2 {
             let tag: String = tuple.get_item(0)?.extract()?;
+            validate_tag(&tag)?;
             let inner = python_to_value(py, &tuple.get_item(1)?, ctx)?;
             return Ok(Value::Tagged(tag, Box::new(inner)));
         }

--- a/src/ffi/convert/encode.rs
+++ b/src/ffi/convert/encode.rs
@@ -158,10 +158,15 @@ fn python_to_value_inner(
 }
 
 /// Reject a tag that cannot be emitted as a single tag token. A tag is written
-/// verbatim before its value (`!tag value`), so a tag containing whitespace or a
-/// control character (or one not starting with `!`) would split on re-parse and
-/// silently corrupt the document: `YAMLRocksTag("!bad tag", "v")` would emit
-/// `!bad tag v`, reloading as the tag `!bad` on the value `"tag v"`.
+/// verbatim before its value (`!tag value`), so one that the scanner would read
+/// only part of splits on re-parse and silently corrupts the document.
+///
+/// Whitespace and control characters are invalid in any tag. For a shorthand tag
+/// (`!foo`, `!!foo`, `!handle!foo`) a flow indicator `,`/`]`/`}` also terminates
+/// the scan, so `YAMLRocksTag("!foo,bar", "v")` would emit `!foo,bar v` and
+/// reload as the tag `!foo` on a (broken) value `,bar v`. A verbatim tag
+/// (`!<...>`) is delimited by its closing `>` and may carry such characters
+/// (URI commas), so it is exempt from the flow-indicator check but must close.
 fn validate_tag(tag: &str) -> PyResult<()> {
     if tag.is_empty() || !tag.starts_with('!') {
         return Err(errors::encode_error(format!(
@@ -171,6 +176,19 @@ fn validate_tag(tag: &str) -> PyResult<()> {
     if let Some(bad) = tag.chars().find(|c| c.is_whitespace() || c.is_control()) {
         return Err(errors::encode_error(format!(
             "invalid tag {tag:?}: a tag cannot contain whitespace or control characters (found {bad:?})"
+        )));
+    }
+    if let Some(verbatim) = tag.strip_prefix("!<") {
+        // A verbatim tag is `!<` + non-empty URI + `>`; the scanner rejects an
+        // unterminated or empty one on read, so refuse to emit one here too.
+        if verbatim.strip_suffix('>').map_or(true, str::is_empty) {
+            return Err(errors::encode_error(format!(
+                "invalid tag {tag:?}: a verbatim tag must be '!<...>' with non-empty content"
+            )));
+        }
+    } else if let Some(bad) = tag.chars().find(|c| matches!(c, ',' | ']' | '}')) {
+        return Err(errors::encode_error(format!(
+            "invalid tag {tag:?}: a shorthand tag cannot contain a flow indicator (found {bad:?})"
         )));
     }
     Ok(())

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -819,6 +819,16 @@ impl YAMLRocksNode {
                     "anchor name cannot be empty",
                 ));
             }
+            // The name must be a single anchor token: an emitted `&name` is read
+            // back by the same rule, so whitespace, a line break, or a flow
+            // indicator (`,[]{}`) would split it and corrupt the document
+            // (`anchor = "a b"` -> `&a b value`, reloading as the value `b value`).
+            if let Some(bad) = name.chars().find(|&c| !crate::scanner::is_anchor_char(c)) {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid anchor name {name:?}: cannot contain whitespace, line breaks, \
+                     or flow indicators (found {bad:?})"
+                )));
+            }
             if let Some(existing) = find_anchor_path(&doc.nodes, name) {
                 if existing != self.path {
                     return Err(pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/scanner/char_traits.rs
+++ b/src/scanner/char_traits.rs
@@ -39,7 +39,7 @@ pub(super) fn is_whitespace_or_flow(ch: char) -> bool {
 /// A character that may appear in an anchor or alias name: anything that is not a
 /// blank, a line break, a flow indicator, or a NUL.
 #[inline]
-pub(super) fn is_anchor_char(ch: char) -> bool {
+pub(crate) fn is_anchor_char(ch: char) -> bool {
     !(is_whitespace_or_flow(ch) || ch == '\0')
 }
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -23,9 +23,10 @@ use std::collections::VecDeque;
 pub use comment::Comment;
 pub use token::{Span, Token, TokenKind};
 
-use char_traits::{
-    is_anchor_char, is_break, is_flow_indicator, is_whitespace_or_break, is_whitespace_or_flow,
-};
+use char_traits::{is_break, is_flow_indicator, is_whitespace_or_break, is_whitespace_or_flow};
+// Re-exported for the round-trip anchor setter, which validates an edited anchor
+// name against the same rule the scanner uses to read one.
+pub(crate) use char_traits::is_anchor_char;
 use reader::Reader;
 
 /// Maximum flow-collection nesting the scanner will open before rejecting the

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -229,6 +229,44 @@ def test_dumps_tags_callback_bad_return_raises():
         yamlrocks.dumps({"x": Marker()}, tags={Marker: lambda o: 123})
 
 
+def test_dumps_tag_with_whitespace_is_rejected():
+    """A tag containing whitespace would split on reload, so it is rejected.
+
+    `YAMLRocksTag("!bad tag", "v")` would emit `!bad tag v`, reloading as the tag
+    `!bad` on the value `"tag v"`; the emitter refuses rather than corrupt.
+    """
+    import pytest
+
+    for bad in ["!bad tag", "!x\ny: 1", "!t\tx"]:
+        with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="invalid tag"):
+            yamlrocks.dumps(yamlrocks.YAMLRocksTag(bad, "v"))
+
+
+def test_dumps_tag_without_leading_bang_is_rejected():
+    """A tag must start with `!`; otherwise it is not a tag at all."""
+    import pytest
+
+    with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="must start with"):
+        yamlrocks.dumps(yamlrocks.YAMLRocksTag("noexcl", "v"))
+
+
+def test_dumps_tuple_tag_with_whitespace_is_rejected():
+    """A `(tag, value)` callback return is validated the same as a YAMLRocksTag."""
+    import pytest
+
+    class Marker:
+        pass
+
+    with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="invalid tag"):
+        yamlrocks.dumps({"x": Marker()}, tags={Marker: lambda o: ("!bad tag", "v")})
+
+
+def test_dumps_verbatim_tag_with_commas_is_allowed():
+    """A verbatim tag carrying URI commas has no whitespace and is allowed."""
+    out = yamlrocks.dumps(yamlrocks.YAMLRocksTag("!<tag:example.com,2024:foo>", "v"))
+    assert out == b"!<tag:example.com,2024:foo> v\n"
+
+
 def test_to_json_drops_tag():
     """to_json emits the inner value and drops the tag."""
     data = yamlrocks.loads(b"x: !input foo\n", option=yamlrocks.OPT_PASSTHROUGH_TAG)

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -267,6 +267,33 @@ def test_dumps_verbatim_tag_with_commas_is_allowed():
     assert out == b"!<tag:example.com,2024:foo> v\n"
 
 
+def test_dumps_shorthand_tag_with_flow_indicator_is_rejected():
+    """A flow indicator terminates a shorthand tag scan, so it would corrupt.
+
+    `YAMLRocksTag("!foo,bar", "v")` would emit `!foo,bar v`, reloading as the
+    tag `!foo` on the value `,bar v` (which is itself malformed).
+    """
+    import pytest
+
+    for bad in ["!foo,bar", "!foo]bar", "!foo}bar", "!!str,x"]:
+        with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="flow indicator"):
+            yamlrocks.dumps(yamlrocks.YAMLRocksTag(bad, "v"))
+
+
+def test_dumps_shorthand_tag_with_bracket_or_brace_is_allowed():
+    """`[`/`{` do not terminate a tag scan, so they stay part of the tag."""
+    assert yamlrocks.dumps(yamlrocks.YAMLRocksTag("!foo[bar", "v")) == b"!foo[bar v\n"
+
+
+def test_dumps_malformed_verbatim_tag_is_rejected():
+    """A verbatim tag must be `!<...>` with non-empty content and a closing `>`."""
+    import pytest
+
+    for bad in ["!<>", "!<unterminated", "!<tag:foo"]:
+        with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="verbatim tag"):
+            yamlrocks.dumps(yamlrocks.YAMLRocksTag(bad, "v"))
+
+
 def test_to_json_drops_tag():
     """to_json emits the inner value and drops the tag."""
     data = yamlrocks.loads(b"x: !input foo\n", option=yamlrocks.OPT_PASSTHROUGH_TAG)

--- a/tests/roundtrip/test_node.py
+++ b/tests/roundtrip/test_node.py
@@ -442,6 +442,18 @@ def test_empty_anchor_name_rejected():
         doc.node["a"].anchor = ""
 
 
+@pytest.mark.parametrize("name", ["a b", "a\nb", "[x]", "tag,s", "{m}"])
+def test_invalid_anchor_name_rejected(name):
+    """An anchor name with whitespace, a break, or a flow indicator is rejected.
+
+    Such a name would split when the `&name` is emitted and read back, corrupting
+    the document (`anchor = "a b"` -> `&a b value`, reloading as `b value`).
+    """
+    doc = load(b"a: 1\n")
+    with pytest.raises(ValueError, match="invalid anchor name"):
+        doc.node["a"].anchor = name
+
+
 def test_alias_to_undefined_anchor_rejected():
     """An alias needs an existing anchor to point at."""
     doc = load(b"a: 1\nb: 2\n")


### PR DESCRIPTION
## Breaking change

Two write-side inputs that previously produced corrupt output now raise instead. Both were invalid and would not survive a round-trip, so this is a correctness tightening:

- Setting a round-trip `node.anchor` to a name containing whitespace, a line break, or a flow indicator (`,[]{}`) raises `ValueError`.
- `dumps` of a `YAMLRocksTag` (or a `(tag, value)` callback tuple) whose tag contains whitespace/control characters, or does not start with `!`, raises `YAMLRocksEncodeError`.

## Proposed change

Two write paths accepted values that corrupt the document on reload (found in a review pass).

The round-trip `anchor` setter checked only emptiness and uniqueness:

```python
doc = yamlrocks.loads(b"x: 1\n", option=yamlrocks.OPT_ROUND_TRIP)
doc.node["x"].anchor = "a b"
yamlrocks.dumps(doc)
# before: b"x: &a b 1\n"  -> reloads as {"x": "b 1"}
# after:  ValueError: invalid anchor name "a b"
```

The setter now validates the name with the scanner's own `is_anchor_char` (exposed as `pub(crate)`), so it accepts exactly what the parser can read back as a single anchor token.

A `YAMLRocksTag`'s tag text was emitted verbatim:

```python
yamlrocks.dumps(yamlrocks.YAMLRocksTag("!bad tag", "v"))
# before: b"!bad tag v\n"  -> reloads as tag "!bad" on value "tag v"
# after:  YAMLRocksEncodeError: invalid tag "!bad tag"
```

Tag construction now validates the tag (must start with `!`, no whitespace or control characters) for both a `YAMLRocksTag` object and a `(tag, value)` callback tuple. A verbatim tag carrying URI commas (`!<tag:example.com,2024:foo>`) still passes.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
