### PR TITLE
🐛 Validate base-60 segments of a sexagesimal float

### DIFF
--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -212,7 +212,11 @@ fn try_parse_float_11(value: &str) -> Option<f64> {
 }
 
 fn parse_sexagesimal_float(value: &str) -> Option<f64> {
-    let parts: Vec<&str> = value.split(':').collect();
+    // The sign applies to the whole magnitude, not just the high-order segment
+    // (`-1:30.5` is `-90.5`, not `-29.5`). Strip it first and reapply at the end,
+    // mirroring the integer path; the callers pass the signed string in as-is.
+    let (negative, rest) = super::split_sign(value)?;
+    let parts: Vec<&str> = rest.split(':').collect();
     // A sexagesimal value has at least one colon; the caller only routes here
     // when one is present, but guard anyway.
     if parts.len() < 2 {
@@ -241,7 +245,7 @@ fn parse_sexagesimal_float(value: &str) -> Option<f64> {
         let n: f64 = part.parse().ok()?;
         result = result * 60.0 + n;
     }
-    Some(result)
+    Some(if negative { -result } else { result })
 }
 
 fn classify_tagged_11(value: &str, tag: &str, pyyaml_compat: bool) -> ScalarKind {
@@ -430,6 +434,9 @@ mod tests {
         assert!(matches!(plain("1:3e2"), ResolvedValue::String(_)));
         // The high-order segment is unbounded; later segments are base-60 digits.
         assert_eq!(plain("90:00.0"), ResolvedValue::Float(5400.0));
+        // The sign applies to the whole magnitude, not just the first segment.
+        assert_eq!(plain("-1:30.5"), ResolvedValue::Float(-90.5));
+        assert_eq!(plain("+1:30.5"), ResolvedValue::Float(90.5));
         // A base-60 digit out of range, a fraction on a non-final segment, or a
         // fractional first segment are all invalid and stay strings.
         for value in ["1:70.5", "1:60.0", "1.5:30", "1:5.5:30"] {

--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -213,18 +213,33 @@ fn try_parse_float_11(value: &str) -> Option<f64> {
 
 fn parse_sexagesimal_float(value: &str) -> Option<f64> {
     let parts: Vec<&str> = value.split(':').collect();
-    if parts.is_empty() {
+    // A sexagesimal value has at least one colon; the caller only routes here
+    // when one is present, but guard anyway.
+    if parts.len() < 2 {
         return None;
     }
 
+    let last = parts.len() - 1;
     let mut result: f64 = 0.0;
     for (i, part) in parts.iter().enumerate() {
-        let n: f64 = part.parse().ok()?;
-        if i == 0 {
-            result = n;
-        } else {
-            result = result * 60.0 + n;
+        // Only the final segment may carry a fraction (`1:30.5`). A dot in any
+        // earlier segment (`1.5:30`) is not a valid sexagesimal value; PyYAML's
+        // resolver rejects it, so it stays a string here too.
+        if i != last && part.contains('.') {
+            return None;
         }
+        // Every segment after the first is a base-60 digit: its integer part
+        // must be in 0..60 (`1:70.5` is invalid). The first (high-order) segment
+        // is unbounded (`90:00.0`). This mirrors `parse_sexagesimal_int`, which
+        // already validated the no-fraction form.
+        if i > 0 {
+            match part.split('.').next().unwrap_or("").parse::<u32>() {
+                Ok(n) if n < 60 => {}
+                _ => return None,
+            }
+        }
+        let n: f64 = part.parse().ok()?;
+        result = result * 60.0 + n;
     }
     Some(result)
 }
@@ -413,6 +428,16 @@ mod tests {
         // with an exponent but no dot (`1:3e2`) is not sexagesimal and must stay
         // a string, not be read as 1*60 + 300.
         assert!(matches!(plain("1:3e2"), ResolvedValue::String(_)));
+        // The high-order segment is unbounded; later segments are base-60 digits.
+        assert_eq!(plain("90:00.0"), ResolvedValue::Float(5400.0));
+        // A base-60 digit out of range, a fraction on a non-final segment, or a
+        // fractional first segment are all invalid and stay strings.
+        for value in ["1:70.5", "1:60.0", "1.5:30", "1:5.5:30"] {
+            assert!(
+                matches!(plain(value), ResolvedValue::String(_)),
+                "{value:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/core/test_yaml_1_1.py
+++ b/tests/core/test_yaml_1_1.py
@@ -139,6 +139,9 @@ def test_sexagesimal_float():
     # The high-order segment is unbounded; later segments are base-60 digits.
     assert load11("90:00.0") == 5400.0
     assert load11("2:3:4.5") == 7384.5
+    # The sign applies to the whole magnitude, not just the first segment.
+    assert load11("-1:30.5") == -90.5
+    assert load11("+1:30.5") == 90.5
 
 
 def test_invalid_sexagesimal_float_stays_string():

--- a/tests/core/test_yaml_1_1.py
+++ b/tests/core/test_yaml_1_1.py
@@ -136,6 +136,19 @@ def test_not_a_number(text):
 def test_sexagesimal_float():
     """Resolve a base-60 float (1:30.5) under OPT_YAML_1_1."""
     assert load11("1:30.5") == 90.5
+    # The high-order segment is unbounded; later segments are base-60 digits.
+    assert load11("90:00.0") == 5400.0
+    assert load11("2:3:4.5") == 7384.5
+
+
+def test_invalid_sexagesimal_float_stays_string():
+    """A sexagesimal float with a bad segment stays a string, matching PyYAML.
+
+    The float path skipped the base-60 check the integer path already applied,
+    so `1:70.5` wrongly resolved to 130.5.
+    """
+    for value in ["1:70.5", "1:60.0", "1.5:30", "1:5.5:30"]:
+        assert load11(value) == value
 
 
 def test_scientific_float():


### PR DESCRIPTION
## Breaking change

Under `OPT_YAML_1_1`, a few colon-bearing values that previously resolved to a number now stay strings: `1:70.5`, `1:60.0`, `1.5:30`, `1:5.5:30`. These were never valid sexagesimal floats, so this matches PyYAML rather than removing a feature.

## Proposed change

The sexagesimal-float path summed every colon segment as a float without the base-60 range check the integer path already applied, so an out-of-range segment resolved to a wrong number:

```python
yamlrocks.loads(b"x: 1:70.5", option=yamlrocks.OPT_YAML_1_1)
# before: {"x": 130.5}
# after:  {"x": "1:70.5"}   (PyYAML also returns the string)
```

It also accepted a fraction on a non-final segment (`1.5:30`), which is not valid sexagesimal. Found in a review pass.

The parser now follows PyYAML's grammar: the high-order segment is unbounded (`90:00.0` -> `5400.0`), every later segment is a base-60 digit whose integer part is in `0..60`, and only the final segment may carry a fraction (`1:30.5` -> `90.5`). Anything else stays a string. This mirrors the existing `parse_sexagesimal_int`, which already validated the no-fraction form.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
