### PR TITLE
📝 Fix documentation that did not match the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Options compose with `|`, the integer bit-flag pattern:
 | `OPT_INDENT_2` / `OPT_INDENT_4`           | Indentation width for `dumps`                                   |
 | `OPT_SORT_KEYS`                           | Sort mapping keys when dumping                                  |
 | `OPT_FLOW_STYLE`                          | Emit flow style (`{}`/`[]`)                                     |
-| `OPT_LITERAL_STRINGS`                     | Emit multi-line strings as literal blocks (`\|`)                |
 | `OPT_EXPLICIT_START` / `OPT_EXPLICIT_END` | Emit `---` / `...` markers                                      |
 
 See the [documentation][docs] for the full option set, including the standard-library

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -107,8 +107,8 @@ yamlrocks.dumps(
 # b'a: 1\nb: 2\n'
 ```
 
-There are flags for flow style, literal block strings, explicit document
-markers, datetime handling, and more. The
+There are flags for flow style, sorted keys, explicit document markers,
+datetime handling, and more. The
 [options reference](/reference/options/) lists the complete set.
 
 ## A round-trip teaser

--- a/docs/src/content/docs/guides/tags.md
+++ b/docs/src/content/docs/guides/tags.md
@@ -156,7 +156,11 @@ name and still pass a `tag_handler` to cover everything else, or fall back to
 ## Emitting custom tags
 
 `dumps` is the write-side mirror of the read side: a `YAMLRocksTag` serializes
-straight back to `!tag value`, so a passthrough round-trip is byte-for-byte.
+straight back to `!tag value`, preserving the tag and its value. It re-emits
+through the normal emitter, though, so it does not reproduce the original
+source byte-for-byte: quoting, comments, and spacing follow the emitter's rules
+(`x: !custom "foo"` comes back as `x: !custom foo`). When you need byte-for-byte
+fidelity, load with `OPT_ROUND_TRIP` instead.
 
 ```python
 import yamlrocks

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -425,12 +425,16 @@ def dump_includes(
     doc: YAMLRocksDocument,
     /,
     *,
-    include_dir: str | os.PathLike[str],
+    include_dir: str | os.PathLike[str] | None = None,
 ) -> None: ...
 ```
 
-Write modified included files back to disk under `include_dir`. Only files whose
-content actually changed are written; the root document is left untouched.
+Write modified included files back to disk, each to the source path it was
+loaded from (tracked on the document when it was read), not to a new location.
+Only files whose content actually changed are written; the root document is left
+untouched. `include_dir` is optional and ignored; it is accepted only for
+call-site symmetry with `load`, and passing a different directory does **not**
+rebase the writes.
 
 ### `dump_includes_map`
 

--- a/docs/src/content/docs/reference/options.md
+++ b/docs/src/content/docs/reference/options.md
@@ -13,8 +13,14 @@ yamlrocks.dumps({"b": 1, "a": 2}, option=yamlrocks.OPT_SORT_KEYS | yamlrocks.OPT
 # b'a: 2\nb: 1\n'
 ```
 
-A flag that does not apply to a given call is ignored, so it is safe to keep a
-single `option` constant and reuse it across `loads` and `dumps`.
+Most flags that do not apply to a given call are ignored, so a single `option`
+constant can often be reused across `loads` and `dumps`. A few combinations are
+rejected with a `ValueError` rather than silently ignored, though: `loads_all`
+does not accept `OPT_ROUND_TRIP`, `OPT_INCLUDES`, `OPT_SECRETS`, or
+`OPT_ENV_VAR` (those need the single-document `load`/`loads`), and the two
+null-style dump flags (`OPT_NULL_AS_KEYWORD`, `OPT_NULL_AS_TILDE`) cannot be set
+at once. Build the mask for the call you are making rather than assuming every
+flag is harmless everywhere.
 
 ## Parsing
 


### PR DESCRIPTION
## Breaking change

None. Documentation only; no code or behavior changes.

## Proposed change

A review pass found four user-facing docs describing behavior the library does not have. Each fix was verified against the actual API (the `.pyi` stubs and the runtime):

- **`OPT_LITERAL_STRINGS` does not exist.** The README option table and the quick-start flag list both reference it, but there is no such flag (`yamlrocks.OPT_LITERAL_STRINGS` raises `AttributeError`). Multi-line strings emit as literal blocks automatically, so the row and the "literal block strings" mention are removed.
- **`dump_includes(include_dir=...)` is optional and ignored.** The API reference showed it as required and said writes happen "under `include_dir`". In fact the stub makes it optional and the implementation ignores it, writing each modified file back to the source path it was loaded from. Fixed the signature and the prose.
- **Reusing one `option` mask everywhere is not always safe.** The options reference said a non-applicable flag is simply ignored. Some combinations raise `ValueError` instead: `loads_all` rejects `OPT_ROUND_TRIP`, `OPT_INCLUDES`, `OPT_SECRETS`, and `OPT_ENV_VAR`, and the two null-style dump flags are mutually exclusive. Noted the exceptions.
- **A `YAMLRocksTag` passthrough round-trip is not byte-for-byte.** It re-emits through the normal emitter (`x: !custom "foo"` comes back as `x: !custom foo`), so the tags guide now says so and points to `OPT_ROUND_TRIP` for byte fidelity.

Prettier, codespell, and `docs/verify_examples.py` (234 blocks) all pass.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
