### PR TITLE
👷 Build and test against the locked dependency graph

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x86_64
-          args: --release --out dist --interpreter ${{ matrix.python }}
+          args: --release --locked --out dist --interpreter ${{ matrix.python }}
           manylinux: auto
       - name: 🧪 Test the built wheel
         shell: bash
@@ -135,7 +135,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.python }}
+          args: --release --locked --out dist --interpreter ${{ matrix.python }}
       - name: 🧪 Test the built wheel
         shell: bash
         run: bash .github/scripts/test_wheel.sh
@@ -187,7 +187,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.python }}
+          args: --release --locked --out dist --interpreter ${{ matrix.python }}
       - name: 🧪 Test the built wheel
         shell: bash
         run: bash .github/scripts/test_wheel.sh
@@ -235,7 +235,7 @@ jobs:
           # build-only (shipped, not run): a free-threaded interpreter is not
           # readily available in the emulated container, and free-threaded runtime
           # behaviour is already exercised natively on x86_64.
-          args: "--release --out dist --interpreter '3.12 3.13 3.14${{ matrix.target == 'aarch64' && ' 3.14t' || '' }}'"
+          args: "--release --locked --out dist --interpreter '3.12 3.13 3.14${{ matrix.target == 'aarch64' && ' 3.14t' || '' }}'"
           manylinux: auto
       - name: 🧪 Test the built wheel under emulation
         # aarch64/armv7/ppc64le install the manylinux wheel and run the full
@@ -339,7 +339,7 @@ jobs:
           # musl wheels are build-only (shipped, not run): there is no
           # free-threaded musl interpreter image to test them in, and
           # free-threaded runtime behaviour is exercised natively on x86_64.
-          args: "--release --out dist --interpreter '3.12 3.13 3.14${{ (matrix.target == 'x86_64' || matrix.target == 'aarch64') && ' 3.14t' || '' }}'"
+          args: "--release --locked --out dist --interpreter '3.12 3.13 3.14${{ (matrix.target == 'x86_64' || matrix.target == 'aarch64') && ' 3.14t' || '' }}'"
           manylinux: musllinux_1_2
       - name: 🧪 Test the built wheel on Alpine (musl, native x86_64)
         # Native musl runtime, no emulation. Tests the image's CPython (one

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -47,7 +47,7 @@ jobs:
         env:
           CARGO_PROFILE_RELEASE_STRIP: "false"
           CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
-        run: uv run --no-sync maturin develop --release
+        run: uv run --no-sync maturin develop --release --locked
       - name: 🚀 Run benchmarks under CodSpeed
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -47,7 +47,7 @@ jobs:
         # numpy keeps the OPT_SERIALIZE_NUMPY path inside the coverage numbers.
         run: uv sync --locked --no-install-project --no-default-groups --group build --group test --group numpy
       - name: 🏗 Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
       - name: 🏗 Set up coverage environment
         # show-env emits shell `export KEY='VALUE'` lines. Drop the `export `
         # prefix and the surrounding single quotes so the raw values persist
@@ -59,9 +59,9 @@ jobs:
       - name: 🧹 Clean coverage data
         run: cargo llvm-cov clean --workspace
       - name: 🚀 Run the Rust unit tests (instrumented)
-        run: cargo test --lib
+        run: cargo test --locked --lib
       - name: 🏗 Build and install yamlrocks (instrumented)
-        run: uv run --no-sync maturin develop
+        run: uv run --no-sync maturin develop --locked
       - name: 🚀 Run pytest to exercise the Rust core
         # The llvm-cov-instrumented build carries far more baseline memory than
         # the normal extension (per-region counters, larger code, profile

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: 🏗 Install dependencies
         run: uv sync --locked --no-install-project --no-default-groups --group build
       - name: 🏗 Build and install yamlrocks
-        run: uv run --no-sync maturin develop --release
+        run: uv run --no-sync maturin develop --release --locked
       - name: 🚀 Run and verify every documented example
         run: uv run --no-sync python docs/verify_examples.py
 

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -10,7 +10,9 @@ on:
     - cron: "0 6 * * 1"
   pull_request:
     paths:
+      - "Cargo.toml"
       - "Cargo.lock"
+      - "pyproject.toml"
       - "uv.lock"
       - "docs/package-lock.json"
       - ".github/workflows/security-audit.yaml"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: 🏗 Install dependencies
         run: uv sync --locked --no-install-project --no-default-groups --group build --group test
       - name: 🏗 Build and install yamlrocks
-        run: uv run --no-sync maturin develop --release
+        run: uv run --no-sync maturin develop --release --locked
       - name: 🚀 Run the real-world config suite
         run: uv run --no-sync pytest tests/realworld -m realworld -q
 
@@ -79,4 +79,4 @@ jobs:
       - name: 🚀 Run cargo test
         # The pure engine (scanner, parser, resolver, decode, encode, ...) has
         # direct unit tests; the Python suite covers the PyO3 boundary on top.
-        run: cargo test --lib
+        run: cargo test --locked --lib


### PR DESCRIPTION
## Breaking change

None for contributors who keep `Cargo.lock` in sync (the normal workflow). A PR that edits `Cargo.toml` without updating `Cargo.lock` will now fail CI instead of silently building a freshly-resolved dependency graph; the fix is to commit the updated lockfile.

## Proposed change

Nothing forced CI to build and test against the committed `Cargo.lock`. The release wheel builds, the `maturin develop` steps, and `cargo test` all ran without `--locked`, so a change to `Cargo.toml` that did not update `Cargo.lock` would silently resolve a new dependency graph, and release wheels could ship from dependencies that never appeared in a lockfile diff (the security audit only triggers on lockfile changes). Found in a review pass.

This adds `--locked` to every Rust build and test path:

- the five `PyO3/maturin-action` wheel legs in `build-wheels.yaml` (the release-critical ones),
- `maturin develop` in `tests.yaml`, `docs.yaml`, `codspeed.yaml`, and `coverage.yaml`,
- `cargo test` in `tests.yaml` and `coverage.yaml`,
- `cargo install cargo-llvm-cov` (the only Rust tool install that lacked `--locked`).

With `--locked`, an out-of-sync lockfile fails fast, so any dependency change must land in `Cargo.lock` to pass, which in turn triggers the security audit. As defense in depth, the audit now also runs when `Cargo.toml` or `pyproject.toml` changes, not only the lockfiles.

I verified locally that the lockfile is in sync (`cargo test --locked --lib` passes, `maturin develop --release --locked` builds), and `actionlint`/`zizmor`/`prettier` pass on the changed workflows. The sdist build is left without `--locked` (it does not compile the crate).

Two related CI findings from the same review are deliberately left for follow-up, as both need live-run validation: tightening the release publish-gate to require the cp315 / free-threaded wheels the matrix already builds, and SHA-pinning the `prek` package and pre-commit hook repositories.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
