### PR TITLE
🐛 Snapshot a container before converting it to a round-trip node

### DIFF
--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -265,11 +265,15 @@ fn python_to_node_depth_inner(
         return Ok(YamlNode::new(YamlNodeKind::Scalar(s, style), span));
     }
     if let Ok(list) = obj.cast::<PyList>() {
-        let mut items = Vec::new();
-        for item in list.iter() {
+        // Snapshot the elements before converting any: conversion runs arbitrary
+        // Python code (a value's `__float__`, `__str__`, ...), and if that mutates
+        // the list, iterating it live could misbehave. Mirrors the fast path.
+        let snapshot: Vec<Bound<'_, PyAny>> = list.iter().collect();
+        let mut items = Vec::with_capacity(snapshot.len());
+        for item in &snapshot {
             items.push(python_to_node_depth(
                 py,
-                &item,
+                item,
                 double_quotes,
                 schema,
                 depth + 1,
@@ -278,11 +282,16 @@ fn python_to_node_depth_inner(
         return Ok(YamlNode::new(YamlNodeKind::Sequence(items), span));
     }
     if let Ok(dict) = obj.cast::<PyDict>() {
-        let mut pairs = Vec::new();
-        for (k, v) in dict.iter() {
+        // Snapshot the entries before converting any: conversion runs arbitrary
+        // Python code (a key/value's `__float__`, `__index__`, `__str__`, ...),
+        // and if that mutates the dict, iterating it live panics ("dictionary
+        // changed size during iteration"). Mirrors the fast path's `dict_to_pairs`.
+        let snapshot: Vec<(Bound<'_, PyAny>, Bound<'_, PyAny>)> = dict.iter().collect();
+        let mut pairs = Vec::with_capacity(snapshot.len());
+        for (k, v) in &snapshot {
             pairs.push((
-                python_to_node_depth(py, &k, double_quotes, schema, depth + 1)?,
-                python_to_node_depth(py, &v, double_quotes, schema, depth + 1)?,
+                python_to_node_depth(py, k, double_quotes, schema, depth + 1)?,
+                python_to_node_depth(py, v, double_quotes, schema, depth + 1)?,
             ));
         }
         return Ok(YamlNode::new(YamlNodeKind::Mapping(pairs), span));

--- a/tests/robustness/test_security.py
+++ b/tests/robustness/test_security.py
@@ -450,6 +450,44 @@ def test_dumps_mutating_container_does_not_use_after_free():
         pass
 
 
+def test_roundtrip_assign_mutating_dict_does_not_panic():
+    """Assigning a dict whose conversion mutates it must not panic the process.
+
+    Building the AST node runs Python (here a value's ``__float__`` adds a key);
+    the round-trip converter snapshots the entries first, so it does not iterate
+    the live dict (which raised ``dictionary changed size during iteration``).
+    """
+    doc = yamlrocks.loads(b"x: 1\n", option=yamlrocks.OPT_ROUND_TRIP)
+
+    class Evil:
+        def __init__(self, d):
+            self.d = d
+
+        def __float__(self):
+            self.d["injected"] = 99  # mutate the dict mid-conversion
+            return 1.0
+
+    data = {"a": None, "b": None}
+    data["a"] = Evil(data)
+    doc["x"] = data  # must not crash
+    assert b"a: 1.0" in yamlrocks.dumps(doc)
+
+
+def test_roundtrip_assign_mutating_list_does_not_panic():
+    """The same protection for a list assigned into a round-trip document."""
+    doc = yamlrocks.loads(b"x: 1\n", option=yamlrocks.OPT_ROUND_TRIP)
+    items: list = []
+
+    class Evil:
+        def __float__(self):
+            items.append("injected")  # mutate the list mid-conversion
+            return 2.0
+
+    items.extend([Evil(), None])
+    doc["x"] = items  # must not crash
+    yamlrocks.dumps(doc)
+
+
 def test_annotated_alias_bomb_is_bounded():
     """A doubling alias bomb (2^N nodes at N hops) must be bounded on the
     annotated/round-trip paths, not expand until OOM."""


### PR DESCRIPTION
## Breaking change

None. A previously-panicking case now completes normally; well-behaved input is unaffected.

## Proposed change

Assigning a `dict` or `list` into a round-trip `YAMLRocksDocument` iterated the live Python container while converting each element to an AST node. That conversion runs arbitrary Python code (a key or value's `__float__`, `__index__`, `__str__`, ...), and if that code mutated the container, PyO3's iterator panicked, a Rust panic reachable from ordinary Python input:

```python
doc = yamlrocks.loads(b"x: 1\n", option=yamlrocks.OPT_ROUND_TRIP)

class Evil:
    def __init__(self, d): self.d = d
    def __float__(self):
        self.d["injected"] = 99   # mutate the dict mid-conversion
        return 1.0

d = {"a": None, "b": None}
d["a"] = Evil(d)
doc["x"] = d
# before: thread panicked: "dictionary changed size during iteration"
# after:  assigns cleanly
```

Found in a review pass. The fix snapshots the entries into a `Vec` before converting any of them, exactly as the fast `dumps` path already does in `dict_to_pairs`/`list_to_values`, so the conversion walks a stable copy rather than the live container. Both the dict and list arms are covered.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
