### PR TITLE
🐛 Resolve a non-decimal integer over i64 as a big integer

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -685,7 +685,13 @@ impl<'input> Decoder<'input> {
                     ScalarKind::Null => Value::Null,
                     ScalarKind::Bool(b) => Value::Bool(b),
                     ScalarKind::Int(i) => Value::Int(i),
-                    ScalarKind::BigInt => Value::BigInt(text),
+                    // A non-decimal big integer (`0xFF...`) is normalized to its
+                    // decimal text so the `BigInt` payload stays decimal for
+                    // Python/JSON/emit; a decimal one keeps its original text.
+                    ScalarKind::BigInt => match crate::resolver::big_int_to_decimal(&text) {
+                        Some(decimal) => Value::BigInt(Cow::Owned(decimal)),
+                        None => Value::BigInt(text),
+                    },
                     ScalarKind::Float(f) => Value::Float(f),
                     ScalarKind::Str => Value::String(text),
                     ScalarKind::Merge => {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -115,7 +115,9 @@ pub trait Resolver {
             ScalarKind::Null => ResolvedValue::Null,
             ScalarKind::Bool(b) => ResolvedValue::Bool(b),
             ScalarKind::Int(i) => ResolvedValue::Int(i),
-            ScalarKind::BigInt => ResolvedValue::BigInt(value.to_owned()),
+            ScalarKind::BigInt => {
+                ResolvedValue::BigInt(big_int_to_decimal(value).unwrap_or_else(|| value.to_owned()))
+            }
             ScalarKind::Float(f) => ResolvedValue::Float(f),
             ScalarKind::Str => ResolvedValue::String(value.to_owned()),
             ScalarKind::Merge => ResolvedValue::String("<<".to_owned()),
@@ -211,4 +213,96 @@ pub(crate) fn is_big_decimal_int(value: &str) -> bool {
         return false;
     };
     rest.bytes().all(|b| b.is_ascii_digit()) && (rest == "0" || !rest.starts_with('0'))
+}
+
+/// The decimal-string form of a non-decimal integer literal (`0xFF`, `0o17`,
+/// `0b101`, or a C-style `0777`), or `None` if `value` is already decimal (the
+/// caller keeps the original text for that case). Called only for a scalar the
+/// resolver already classified as a [`ScalarKind::BigInt`], so the body is a
+/// valid literal; this normalizes it to decimal so the `BigInt` payload stays
+/// decimal everywhere it is consumed (Python conversion, JSON, emit).
+///
+/// A leading `0`-without-a-radix-letter is C-style octal, which only the YAML 1.1
+/// classifier ever marks as a big integer, so reading it as base 8 here is
+/// unambiguous.
+pub(crate) fn big_int_to_decimal(value: &str) -> Option<String> {
+    let (negative, rest) = split_sign(value)?;
+    let cleaned: String;
+    let rest = if rest.as_bytes().contains(&b'_') {
+        cleaned = rest.chars().filter(|&c| c != '_').collect();
+        cleaned.as_str()
+    } else {
+        rest
+    };
+
+    let (radix, body) = if let Some(b) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X"))
+    {
+        (16, b)
+    } else if let Some(b) = rest.strip_prefix("0o").or_else(|| rest.strip_prefix("0O")) {
+        (8, b)
+    } else if let Some(b) = rest.strip_prefix("0b").or_else(|| rest.strip_prefix("0B")) {
+        (2, b)
+    } else if rest.len() > 1 && rest.starts_with('0') && rest.bytes().all(|b| b.is_ascii_digit()) {
+        (8, &rest[1..]) // C-style octal (`0777`); YAML 1.1 only
+    } else {
+        return None; // already decimal: keep the original text
+    };
+
+    let mut decimal = radix_to_decimal(body, radix);
+    if negative {
+        decimal.insert(0, '-');
+    }
+    Some(decimal)
+}
+
+/// Convert a string of base-`radix` digits to its decimal-string form, at
+/// arbitrary precision and without a big-integer dependency. Schoolbook
+/// multiply-accumulate over decimal digits held little-endian: for each input
+/// digit `d`, the accumulator becomes `acc * radix + d`. Only ever runs for an
+/// integer too large for `i64`, which is rare, so the `O(digits^2)` cost is fine.
+fn radix_to_decimal(body: &str, radix: u32) -> String {
+    let mut digits: Vec<u8> = vec![0]; // decimal digits of the accumulator, little-endian
+    for ch in body.chars() {
+        let mut carry = ch.to_digit(radix).unwrap_or(0);
+        for slot in digits.iter_mut() {
+            let v = u32::from(*slot) * radix + carry;
+            *slot = (v % 10) as u8;
+            carry = v / 10;
+        }
+        while carry > 0 {
+            digits.push((carry % 10) as u8);
+            carry /= 10;
+        }
+    }
+    digits.iter().rev().map(|d| (b'0' + d) as char).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::big_int_to_decimal;
+
+    #[test]
+    fn big_int_to_decimal_converts_radix_forms() {
+        // Hexadecimal, octal, binary, and C-style octal all normalize to decimal.
+        assert_eq!(
+            big_int_to_decimal("0x8000000000000000").as_deref(),
+            Some("9223372036854775808")
+        );
+        assert_eq!(big_int_to_decimal("0xff").as_deref(), Some("255"));
+        assert_eq!(big_int_to_decimal("0o17").as_deref(), Some("15"));
+        assert_eq!(big_int_to_decimal("0b1010").as_deref(), Some("10"));
+        assert_eq!(big_int_to_decimal("0777").as_deref(), Some("511"));
+        // The sign is carried onto the converted magnitude.
+        assert_eq!(big_int_to_decimal("-0x10").as_deref(), Some("-16"));
+        // Underscore separators are stripped before conversion.
+        assert_eq!(big_int_to_decimal("0xff_ff").as_deref(), Some("65535"));
+    }
+
+    #[test]
+    fn big_int_to_decimal_leaves_decimal_untouched() {
+        // A decimal literal returns `None`: the caller keeps the original text.
+        assert_eq!(big_int_to_decimal("99999999999999999999"), None);
+        assert_eq!(big_int_to_decimal("-12345"), None);
+        assert_eq!(big_int_to_decimal("0"), None);
+    }
 }

--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -86,12 +86,10 @@ fn classify_plain_11(value: &str, pyyaml_compat: bool) -> ScalarKind {
     if let Some(int) = try_parse_int_11(value) {
         return ScalarKind::Int(int);
     }
-    // A decimal integer too large for i64 is still an integer, not a string.
-    // The 1.1 form may carry underscore separators (`10_000_000_000_000_000_000`),
-    // which the shared `is_big_decimal_int` rejects; recognize them here so an
-    // underscored big integer does not silently degrade to a string while its
-    // separator-free twin stays an integer.
-    if is_big_decimal_int_11(value) {
+    // An integer too large for i64 is still an integer, not a string, whether it
+    // is decimal, hex (`0x`), binary (`0b`), or C-style octal (`0777`). The 1.1
+    // forms may carry underscore separators, which the parsers strip.
+    if is_big_int_11(value) {
         return ScalarKind::BigInt;
     }
 
@@ -130,6 +128,29 @@ fn is_big_decimal_int_11(value: &str) -> bool {
         && digits.bytes().all(|b| b.is_ascii_digit())
         // A leading zero is a C-style octal (`0777`), not a decimal big integer.
         && (digits == "0" || !digits.starts_with('0'))
+}
+
+/// Whether `value` is a valid YAML 1.1 integer literal of any magnitude:
+/// decimal, hexadecimal (`0x`), binary (`0b`), or C-style octal (`0777`), with
+/// underscore separators allowed. Only reached once [`try_parse_int_11`] has
+/// failed, so a `true` result means a big integer rather than a string.
+/// Sexagesimal (`1:30`) is intentionally not treated as a big integer.
+fn is_big_int_11(value: &str) -> bool {
+    let Some((_, rest)) = super::split_sign(value) else {
+        return false;
+    };
+    let cleaned = strip_underscores(rest);
+    let rest: &str = &cleaned;
+    if let Some(body) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
+        !body.is_empty() && body.bytes().all(|b| b.is_ascii_hexdigit())
+    } else if let Some(body) = rest.strip_prefix("0b").or_else(|| rest.strip_prefix("0B")) {
+        !body.is_empty() && body.bytes().all(|b| b == b'0' || b == b'1')
+    } else if rest.len() > 1 && rest.starts_with('0') {
+        // C-style octal (`0777`): a leading zero then octal digits.
+        rest[1..].bytes().all(|b| (b'0'..=b'7').contains(&b))
+    } else {
+        is_big_decimal_int_11(value)
+    }
 }
 
 fn try_parse_int_11(value: &str) -> Option<i64> {
@@ -268,7 +289,7 @@ fn classify_tagged_11(value: &str, tag: &str, pyyaml_compat: bool) -> ScalarKind
         "!!int" | "tag:yaml.org,2002:int" => {
             if let Some(int) = try_parse_int_11(value) {
                 ScalarKind::Int(int)
-            } else if is_big_decimal_int_11(value) {
+            } else if is_big_int_11(value) {
                 ScalarKind::BigInt
             } else {
                 ScalarKind::Str

--- a/src/resolver/yaml12.rs
+++ b/src/resolver/yaml12.rs
@@ -66,8 +66,9 @@ fn classify_plain_12(value: &str) -> ScalarKind {
     if let Some(int) = try_parse_int_12(value) {
         return ScalarKind::Int(int);
     }
-    // A decimal integer too large for i64 is still an integer, not a string.
-    if super::is_big_decimal_int(value) {
+    // An integer too large for i64 is still an integer, not a string, whether it
+    // is decimal or a hex/octal literal (`0x8000000000000000`).
+    if is_big_int_12(value) {
         return ScalarKind::BigInt;
     }
 
@@ -77,6 +78,23 @@ fn classify_plain_12(value: &str) -> ScalarKind {
     }
 
     ScalarKind::Str
+}
+
+/// Whether `value` is a valid YAML 1.2 integer literal of any magnitude: a
+/// decimal, hexadecimal (`0x`), or octal (`0o`) form. Only reached once
+/// [`try_parse_int_12`] has failed (an overflowing or otherwise too-large
+/// literal), so a `true` result means a big integer rather than a string.
+fn is_big_int_12(value: &str) -> bool {
+    let Some((_, rest)) = super::split_sign(value) else {
+        return false;
+    };
+    if let Some(body) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
+        !body.is_empty() && body.bytes().all(|b| b.is_ascii_hexdigit())
+    } else if let Some(body) = rest.strip_prefix("0o").or_else(|| rest.strip_prefix("0O")) {
+        !body.is_empty() && body.bytes().all(|b| (b'0'..=b'7').contains(&b))
+    } else {
+        super::is_big_decimal_int(value)
+    }
 }
 
 fn try_parse_int_12(value: &str) -> Option<i64> {
@@ -143,7 +161,7 @@ fn classify_tagged(value: &str, tag: &str) -> ScalarKind {
         "!!int" | "tag:yaml.org,2002:int" => {
             if let Some(int) = try_parse_int_12(value) {
                 ScalarKind::Int(int)
-            } else if super::is_big_decimal_int(value) {
+            } else if is_big_int_12(value) {
                 ScalarKind::BigInt
             } else {
                 ScalarKind::Str

--- a/tests/core/test_scalars.py
+++ b/tests/core/test_scalars.py
@@ -356,6 +356,28 @@ def test_big_integer_literals_load_as_int(text):
     assert value == int(text)
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("0x8000000000000000", 0x8000000000000000),  # hex, i64::MAX + 1
+        ("0xFFFFFFFFFFFFFFFFFF", 0xFFFFFFFFFFFFFFFFFF),
+        ("0o7777777777777777777777", 0o7777777777777777777777),  # octal
+        ("-0x8000000000000001", -0x8000000000000001),
+    ],
+)
+def test_non_decimal_big_integer_literals_load_as_int(text, expected):
+    """A hex/octal integer over i64 loads as a Python int (1.2 core schema).
+
+    The big-integer fallback used to recognize only decimal, so these overflowing
+    radix forms wrongly became strings.
+    """
+    value = yamlrocks.loads(f"x: {text}".encode())["x"]
+    assert isinstance(value, int)
+    assert value == expected
+    # The int is normalized to decimal, so to_json stays valid JSON.
+    assert yamlrocks.to_json({"x": value}) == f'{{"x":{expected}}}'.encode()
+
+
 def test_big_integer_round_trip_assignment():
     """Assigning a big int to a round-trip document keeps it an int."""
     doc = yamlrocks.loads(b"x: 1\n", option=yamlrocks.OPT_ROUND_TRIP)

--- a/tests/core/test_yaml_1_1.py
+++ b/tests/core/test_yaml_1_1.py
@@ -74,6 +74,18 @@ def test_binary_integer():
     assert load11("0b1010") == 10
 
 
+def test_non_decimal_big_integer():
+    """A hex/binary/C-octal integer over i64 resolves to a Python int, not a string.
+
+    These overflowing radix forms previously fell through to a string because the
+    big-integer fallback only recognized decimal.
+    """
+    assert load11("0x8000000000000000") == 9223372036854775808
+    assert load11("0b" + "1" * 70) == (1 << 70) - 1
+    assert load11("0" + "7" * 30) == int("7" * 30, 8)  # C-style octal
+    assert isinstance(load11("0x8000000000000000"), int)
+
+
 def test_underscores_in_integer():
     """Strip underscores from integers under OPT_YAML_1_1."""
     assert load11("1_000_000") == 1000000


### PR DESCRIPTION
## Breaking change

A hex/octal/binary integer literal larger than `i64` now loads as a Python `int` instead of a `str`. This matches PyYAML and the YAML integer model (arbitrary precision); code that relied on the previous string result for such values would change, but that result was the bug.

## Proposed change

An integer literal that overflows `i64` resolved correctly only when it was decimal. A non-decimal form, hexadecimal (`0x8000000000000000`), a long octal (`0o...`) or binary (`0b...`), or a YAML 1.1 C-style octal (`0777...`), fell through to a string, because the big-integer fallback recognized only decimal. PyYAML returns these as Python ints.

```python
yamlrocks.loads(b"x: 0x8000000000000000")["x"]
# before: "0x8000000000000000"   (str)
# after:  9223372036854775808    (int)
```

Found in a review pass. The classifiers now recognize the radix forms as big integers in both schemas (the plain path and the `!!int` tag). The literal is normalized to its **decimal** string at resolve time with a small dependency-free base-conversion routine (no `num-bigint` dependency added). Keeping the `BigInt` payload decimal is deliberate: the Python conversion, `to_json`, the schema validator, and the emitter all assume decimal text, so none of them need to change, and a hex int therefore still serializes as a valid JSON number. A decimal big integer keeps its original text untouched (zero-copy), so existing behavior is unchanged.

Verified against PyYAML across the hex/octal/binary/C-octal forms; `to_json` stays valid JSON, and the result is a genuine `int`.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
