### PR TITLE
✅ Require a proper decode error for invalid compliance cases

### DIFF
--- a/tests/compliance/test_yaml_test_suite.py
+++ b/tests/compliance/test_yaml_test_suite.py
@@ -170,8 +170,14 @@ def test_valid_case_round_trips_byte_identical(case_id):
 
 @pytest.mark.parametrize("case_id", ERROR_IDS)
 def test_error_case_is_rejected(case_id):
-    """Every case the suite marks invalid is rejected on load."""
-    with pytest.raises((yamlrocks.YAMLRocksDecodeError, ValueError, TypeError)):
+    """Every case the suite marks invalid is rejected with a proper decode error.
+
+    The rejection must be a ``YAMLRocksDecodeError`` (the scanner/parser/resolver
+    refusing the input), not an incidental ``ValueError``/``TypeError`` from
+    conversion or option handling, so a regression that turns a malformed
+    document into the wrong kind of failure is caught rather than passing.
+    """
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError):
         yamlrocks.loads(case_bytes(case_id))
 
 


### PR DESCRIPTION
## Breaking change

None. Test-only; tightens an assertion without changing library behavior.

## Proposed change

The YAML test-suite rejection test accepted `YAMLRocksDecodeError`, `ValueError`, or `TypeError`. That broad set means a malformed case that failed with an *incidental* `ValueError`/`TypeError` (from conversion or option handling rather than the scanner/parser/resolver actually refusing the input) would still count as "rejected", hiding a regression in how the document is rejected. Found in a review pass.

I confirmed all 94 invalid suite cases are rejected with a `YAMLRocksDecodeError` (specifically `YAMLRocksParseError`, a subclass), so the assertion is narrowed to that type alone. All 94 still pass; the change only removes the escape hatch.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
