### PR TITLE
🐛 Match PyYAML float and underscore rules under PyYAML-compat

### DIFF
--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -82,6 +82,17 @@ fn classify_plain_11(value: &str, pyyaml_compat: bool) -> ScalarKind {
         return ScalarKind::Str;
     }
 
+    // PyYAML's resolver does not treat a leading underscore as numeric (`_5` and
+    // `_1.5` are strings); only an interior separator (`1_000`) is allowed. The
+    // lenient default 1.1 reading accepts the leading form, so this only narrows
+    // PyYAML-compat. A sign may precede the underscore (`-_5`).
+    if pyyaml_compat {
+        let after_sign = value.strip_prefix(['+', '-']).unwrap_or(value);
+        if after_sign.starts_with('_') {
+            return ScalarKind::Str;
+        }
+    }
+
     // Integer
     if let Some(int) = try_parse_int_11(value) {
         return ScalarKind::Int(int);
@@ -94,7 +105,7 @@ fn classify_plain_11(value: &str, pyyaml_compat: bool) -> ScalarKind {
     }
 
     // Float
-    if let Some(float) = try_parse_float_11(value) {
+    if let Some(float) = try_parse_float_11(value, pyyaml_compat) {
         return ScalarKind::Float(float);
     }
 
@@ -211,7 +222,7 @@ fn parse_sexagesimal_int(value: &str) -> Option<i64> {
     Some(result)
 }
 
-fn try_parse_float_11(value: &str) -> Option<f64> {
+fn try_parse_float_11(value: &str, pyyaml_compat: bool) -> Option<f64> {
     if let Some(f) = super::parse_special_float(value) {
         return Some(f);
     }
@@ -229,7 +240,27 @@ fn try_parse_float_11(value: &str) -> Option<f64> {
         return parse_sexagesimal_float(clean);
     }
 
+    // PyYAML's resolver is stricter than the lenient 1.1 reading: a base-10 float
+    // must carry a `.`, and an exponent must have an explicit sign. So `1e3` and
+    // `1.0e3` are plain strings under PyYAML, while `1.5e+3` is a float. The
+    // default (non-compat) 1.1 mode keeps the lenient reading.
+    if pyyaml_compat && !pyyaml_float_shape(clean) {
+        return None;
+    }
+
     clean.parse::<f64>().ok()
+}
+
+/// Whether `value` matches PyYAML's base-10 float shape: it contains a `.`, and
+/// any `e`/`E` exponent is immediately followed by an explicit `+`/`-` sign.
+fn pyyaml_float_shape(value: &str) -> bool {
+    if !value.contains('.') {
+        return false;
+    }
+    match value.bytes().position(|b| b == b'e' || b == b'E') {
+        Some(pos) => matches!(value.as_bytes().get(pos + 1), Some(b'+' | b'-')),
+        None => true,
+    }
 }
 
 fn parse_sexagesimal_float(value: &str) -> Option<f64> {
@@ -365,6 +396,24 @@ mod tests {
         assert_eq!(plain_pyyaml("on"), ResolvedValue::Bool(true));
         assert_eq!(plain_pyyaml("off"), ResolvedValue::Bool(false));
         assert_eq!(plain_pyyaml("no"), ResolvedValue::Bool(false));
+    }
+
+    #[test]
+    fn pyyaml_compat_narrows_floats_and_leading_underscore() {
+        // PyYAML keeps `1e3`/`1.0e3` (no dot, or unsigned exponent) and a
+        // leading-underscore value as strings; the lenient default 1.1 reading
+        // (`plain`) parses them as numbers.
+        for value in ["1e3", "1.0e3", "_5", "_1.5"] {
+            assert!(
+                matches!(plain_pyyaml(value), ResolvedValue::String(_)),
+                "{value:?}"
+            );
+        }
+        assert_eq!(plain_pyyaml("1.5e+3"), ResolvedValue::Float(1500.0));
+        assert_eq!(plain_pyyaml("5_"), ResolvedValue::Int(5));
+        // The default 1.1 mode stays lenient.
+        assert_eq!(plain("1e3"), ResolvedValue::Float(1000.0));
+        assert_eq!(plain("_5"), ResolvedValue::Int(5));
     }
 
     #[test]

--- a/tests/core/test_yaml_1_1.py
+++ b/tests/core/test_yaml_1_1.py
@@ -225,6 +225,40 @@ def test_pyyaml_compat_keeps_word_booleans():
     assert loadpy("no") is False
 
 
+def test_pyyaml_compat_float_requires_dot_and_signed_exponent():
+    """Under PyYAML-compat a float needs a dot, and an exponent an explicit sign.
+
+    PyYAML's resolver rejects `1e3` and `1.0e3` as floats (they stay strings),
+    while `1.5e+3` is a float. The lenient default 1.1 reading keeps `1e3` a
+    float, so this only narrows PyYAML-compat.
+    """
+    for value in ["1e3", "1E3", "1.0e3", ".5e3"]:
+        assert loadpy(value) == value
+        assert isinstance(loadpy(value), str)
+    assert loadpy("1.5e+3") == 1500.0
+    assert loadpy("1.5e-3") == 0.0015
+    assert loadpy(".5e+3") == 500.0
+    assert loadpy("1.") == 1.0
+    # The lenient default 1.1 mode still reads a dotless exponent as a float.
+    assert load11("1e3") == 1000.0
+
+
+def test_pyyaml_compat_rejects_a_leading_underscore():
+    """A leading underscore is not numeric under PyYAML-compat (`_5` is a string).
+
+    Only an interior separator (`1_000`) is allowed; PyYAML never starts a number
+    with `_`. The lenient default 1.1 mode keeps `_5` an int.
+    """
+    for value in ["_5", "_1.5", "-_5"]:
+        assert loadpy(value) == value
+        assert isinstance(loadpy(value), str)
+    # Interior and trailing underscores stay numeric, matching PyYAML.
+    assert loadpy("1_000") == 1000
+    assert loadpy("5_") == 5
+    # The lenient default 1.1 mode still reads a leading underscore as numeric.
+    assert load11("_5") == 5
+
+
 def test_yaml_1_1_alone_is_spec_correct():
     """Plain OPT_YAML_1_1 keeps bare y/n as booleans, per the real 1.1 spec."""
     assert load11("y") is True


### PR DESCRIPTION
## Breaking change

Under `OPT_PYYAML_COMPAT` only, a few values that previously resolved to numbers now resolve to strings, matching PyYAML: `1e3`, `1.0e3` (and other dotless/unsigned-exponent forms) and a leading-underscore value like `_5`. The default `OPT_YAML_1_1` and the YAML 1.2 default are unchanged.

## Proposed change

`OPT_PYYAML_COMPAT` is meant to mirror PyYAML's resolver, but two forms diverged (found in a review pass, verified against PyYAML):

```python
PYC = yamlrocks.OPT_YAML_1_1 | yamlrocks.OPT_PYYAML_COMPAT
yamlrocks.loads(b"x: 1e3", option=PYC)["x"]   # before: 1000.0   after: "1e3"   (PyYAML: "1e3")
yamlrocks.loads(b"x: _5",  option=PYC)["x"]   # before: 5        after: "_5"    (PyYAML: "_5")
```

PyYAML's resolver is stricter than yamlrocks' lenient 1.1 reading:

- A base-10 float must contain a `.`, and an exponent must carry an explicit sign. So `1.5e+3` is a float, while `1e3` and `1.0e3` are strings.
- A leading underscore is not numeric: `_5`/`_1.5` are strings; only an interior separator (`1_000`) or trailing (`5_`) is allowed.

Both rules are applied **only when `OPT_PYYAML_COMPAT` is set**. The default `OPT_YAML_1_1` keeps its lenient reading (`1e3` → `1000.0`, `_5` → `5`), YAML 1.2 is untouched (`1e3` is a valid 1.2 float), and an explicit `!!float` tag stays lenient (PyYAML's `float("1e3")` succeeds under a tag). Verified against real PyYAML across the float and underscore forms.

The companion strict-1.1 and 1.2 cases from the same review (`1e3`/`_5` in strict 1.1, and `0777` in 1.2) are intentionally left as-is per the project's three-schema design.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
