### PR TITLE
🐛 Emit an explicit null before a tagged mapping key

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -186,11 +186,11 @@ impl<'a> Emitter<'a> {
 
     fn emit_block_mapping(&mut self, pairs: &[(Value, Value)], indent: usize) {
         let ordered = self.order_pairs(pairs);
-        for (key, val) in ordered.iter() {
+        for (i, (key, val)) in ordered.iter().enumerate() {
             self.write_indent(indent);
             self.emit_key(key);
             self.buf.push(b':');
-            self.emit_value_after_colon(val, indent);
+            self.emit_mapping_value(val, indent, ordered.get(i + 1).map(|p| &p.0));
         }
     }
 
@@ -204,8 +204,27 @@ impl<'a> Emitter<'a> {
             }
             self.emit_key(key);
             self.buf.push(b':');
-            self.emit_value_after_colon(val, indent);
+            self.emit_mapping_value(val, indent, ordered.get(i + 1).map(|p| &p.0));
         }
+    }
+
+    /// Emit a mapping value after its colon, given the following key (if any).
+    /// An empty-style null (`key:` with nothing after) followed by a tagged key
+    /// would let that key's `!tag` be read as *this* value's node property
+    /// (`a:\n!t k: 1` reloads as a tag on `a`'s value, a parse error), so emit an
+    /// explicit null in that case to keep the next key on its own footing.
+    fn emit_mapping_value(&mut self, val: &Value, indent: usize, next_key: Option<&Value>) {
+        if matches!(val, Value::Null)
+            && self.options.null_style == NullStyle::Empty
+            && matches!(next_key, Some(Value::Tagged(..)))
+        {
+            self.buf.push(b' ');
+            self.buf
+                .extend_from_slice(self.options.null_style.inline_token().as_bytes());
+            self.buf.push(b'\n');
+            return;
+        }
+        self.emit_value_after_colon(val, indent);
     }
 
     /// Emit the portion after a mapping key's colon, choosing inline or block.

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -267,6 +267,21 @@ def test_dumps_verbatim_tag_with_commas_is_allowed():
     assert out == b"!<tag:example.com,2024:foo> v\n"
 
 
+def test_dumps_null_value_before_tagged_key_stays_reloadable():
+    """An empty-null value before a tagged key emits an explicit null.
+
+    Otherwise the tagged key's `!tag` on the next line is read as the previous
+    (empty) value's node property (`a:\\n!t k: 1`), which fails to reload.
+    """
+    data = {"a": None, yamlrocks.YAMLRocksTag("!foo", "k"): 2}
+    out = yamlrocks.dumps(data)
+    assert out == b"a: null\n!foo k: 2\n"
+    # It reloads cleanly (the tagged key is dropped by default, leaving its value).
+    assert yamlrocks.loads(out) == {"a": None, "k": 2}
+    # A null value before an untagged key still uses the compact empty form.
+    assert yamlrocks.dumps({"a": None, "b": 2}) == b"a:\nb: 2\n"
+
+
 def test_dumps_shorthand_tag_with_flow_indicator_is_rejected():
     """A flow indicator terminates a shorthand tag scan, so it would corrupt.
 


### PR DESCRIPTION
## Breaking change

None. A previously-corrupt output is now valid; well-formed cases are unchanged.

## Proposed change

`dumps` of a mapping where a null value is emitted in the compact empty style (`a:` with nothing after it) and is followed by a tagged key produced output that does not reload:

```python
data = {"a": None, yamlrocks.YAMLRocksTag("!foo", "k"): 2}
yamlrocks.dumps(data)
# before: b"a:\n!foo k: 2\n"   -> reload fails: "a node property must be indented past its mapping key"
# after:  b"a: null\n!foo k: 2\n"  -> reloads
```

On reload, the `!foo` at column 0 on the next line is read as a node property of `a`'s empty value rather than the start of a new key. It is reachable through a real API path: `loads(..., option=OPT_PASSTHROUGH_TAG)` returns `YAMLRocksTag` keys, and dumping them hits this. The bug was originally surfaced by the differential fuzz target.

The fix emits an explicit null (`a: null`) when an empty-style null value is immediately followed by a tagged key, so the key stands on its own line. The common case, a null value before an ordinary key, keeps the compact empty form (`a:\nb: 2`).

Note: strengthening the differential fuzz to assert that emitted YAML always re-parses surfaces further, distinct tagged-key/layout emitter edge cases (for example a tagged key following a flow-mapping value). Those are tracked for a dedicated fuzz-and-fix pass; this PR fixes the one confirmed, reachable case in isolation.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
