### PR TITLE
✅ Bound an alias bomb by wall-clock time, not just "eventually"

### DIFF
--- a/tests/robustness/test_security.py
+++ b/tests/robustness/test_security.py
@@ -522,6 +522,45 @@ def test_schema_validation_alias_bomb_is_bounded():
         pass
 
 
+# A doubling alias bomb (2^N nodes at N hops) run through the round-trip and
+# schema-validation paths. The in-process tests above catch a crash or OOM
+# quickly; this script runs in a subprocess so a *time* regression (the bomb
+# expanding for a long time before terminating, or hanging outright) is caught
+# by the parent's wall-clock timeout instead of silently passing after the work.
+_ALIAS_BOMB_SCRIPT = """
+import yamlrocks
+src = b"a0: &a0 [x]\\n"
+for i in range(1, 40):
+    src += f"a{i}: &a{i} [*a{i - 1}, *a{i - 1}]\\n".encode()
+src += b"top: *a39\\n"
+try:
+    yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP, schema={"type": "object"})
+except Exception:
+    pass
+yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_yaml()
+print("OK")
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="subprocess timeout semantics")
+def test_alias_bomb_terminates_within_time_budget():
+    """An alias bomb must terminate well within a wall-clock budget, not just
+    "eventually". The shared alias-node budget bounds the work, so a regression
+    that lets it expand unbounded would hang; the subprocess timeout turns that
+    into a clean failure instead of a multi-minute (or infinite) test.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _ALIAS_BOMB_SCRIPT], capture_output=True, timeout=30
+    )
+    assert proc.returncode == 0, (
+        f"alias bomb did not terminate cleanly: rc={proc.returncode} "
+        f"stderr={proc.stderr.decode()[:300]}"
+    )
+    assert proc.stdout.strip() == b"OK"
+
+
 def test_schema_validation_resolves_aliases():
     """The schema validator still sees an alias as its referent, not null."""
     src = b"defaults: &d {port: 80}\nserver: *d\n"


### PR DESCRIPTION
## Breaking change

None. Test-only; adds coverage, changes no library behavior.

## Proposed change

The alias-bomb robustness tests verified that a doubling alias bomb does not crash or exhaust memory, but they had no time guard: they only required the operation to finish or raise, so a regression that let the bomb expand for minutes (or hang outright) before terminating would still pass. Found in a review pass.

This adds a subprocess-run alias bomb (the round-trip and schema-validation paths) with a parent wall-clock timeout, so an unbounded-expansion regression turns into a clean failure instead of a multi-minute or infinite test. The existing in-process tests stay as the fast crash/OOM check. A subprocess is used deliberately: a Python `SIGALRM` handler only runs at bytecode boundaries and cannot interrupt a long-running Rust call, so a subprocess timeout is the only reliable wall-clock guard for a potential hang.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
