### PR TITLE
🐛 Emit a non-first tagged mapping key in explicit-key form

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -188,9 +188,7 @@ impl<'a> Emitter<'a> {
         let ordered = self.order_pairs(pairs);
         for (i, (key, val)) in ordered.iter().enumerate() {
             self.write_indent(indent);
-            self.emit_key(key);
-            self.buf.push(b':');
-            self.emit_mapping_value(val, indent, ordered.get(i + 1).map(|p| &p.0));
+            self.emit_block_pair(key, val, indent, i > 0);
         }
     }
 
@@ -202,27 +200,27 @@ impl<'a> Emitter<'a> {
             if i > 0 {
                 self.write_indent(indent);
             }
-            self.emit_key(key);
-            self.buf.push(b':');
-            self.emit_mapping_value(val, indent, ordered.get(i + 1).map(|p| &p.0));
+            self.emit_block_pair(key, val, indent, i > 0);
         }
     }
 
-    /// Emit a mapping value after its colon, given the following key (if any).
-    /// An empty-style null (`key:` with nothing after) followed by a tagged key
-    /// would let that key's `!tag` be read as *this* value's node property
-    /// (`a:\n!t k: 1` reloads as a tag on `a`'s value, a parse error), so emit an
-    /// explicit null in that case to keep the next key on its own footing.
-    fn emit_mapping_value(&mut self, val: &Value, indent: usize, next_key: Option<&Value>) {
-        if matches!(val, Value::Null)
-            && self.options.null_style == NullStyle::Empty
-            && matches!(next_key, Some(Value::Tagged(..)))
-        {
-            self.buf.push(b' ');
-            self.buf
-                .extend_from_slice(self.options.null_style.inline_token().as_bytes());
+    /// Emit one block-mapping pair (the caller has written the key's indent). A
+    /// *non-first* tagged key is written in the explicit `? key` / `: value`
+    /// form: an inline tagged key (`!t k:`) after a previous entry would have its
+    /// `!t` read as that entry's value's node property, since a tag at the
+    /// mapping's indent binds to the preceding value (a reparse error). The `?`
+    /// indicator starts a fresh key that no preceding value can absorb. A first
+    /// pair has no preceding sibling, so it stays in the compact inline form.
+    fn emit_block_pair(&mut self, key: &Value, val: &Value, indent: usize, not_first: bool) {
+        if not_first && matches!(key, Value::Tagged(..)) {
+            self.buf.extend_from_slice(b"? ");
+            self.emit_key(key);
             self.buf.push(b'\n');
-            return;
+            self.write_indent(indent);
+            self.buf.push(b':');
+        } else {
+            self.emit_key(key);
+            self.buf.push(b':');
         }
         self.emit_value_after_colon(val, indent);
     }

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -267,17 +267,27 @@ def test_dumps_verbatim_tag_with_commas_is_allowed():
     assert out == b"!<tag:example.com,2024:foo> v\n"
 
 
-def test_dumps_null_value_before_tagged_key_stays_reloadable():
-    """An empty-null value before a tagged key emits an explicit null.
+def test_dumps_non_first_tagged_key_uses_explicit_key_form():
+    """A tagged key after another entry is emitted in explicit `? key` form.
 
-    Otherwise the tagged key's `!tag` on the next line is read as the previous
-    (empty) value's node property (`a:\\n!t k: 1`), which fails to reload.
+    An inline tagged key (`!t k:`) after a previous entry would have its `!t`
+    read as that entry's value's node property (a reparse error); the `?`
+    indicator starts a fresh key that the preceding value cannot absorb.
     """
     data = {"a": None, yamlrocks.YAMLRocksTag("!foo", "k"): 2}
     out = yamlrocks.dumps(data)
-    assert out == b"a: null\n!foo k: 2\n"
+    assert out == b"a:\n? !foo k\n: 2\n"
     # It reloads cleanly (the tagged key is dropped by default, leaving its value).
     assert yamlrocks.loads(out) == {"a": None, "k": 2}
+    # The same after a non-null value (which inline form would also corrupt).
+    assert yamlrocks.dumps({"a": 1, yamlrocks.YAMLRocksTag("!foo", "k"): 2}) == (
+        b"a: 1\n? !foo k\n: 2\n"
+    )
+
+
+def test_dumps_first_tagged_key_stays_inline():
+    """A first/only tagged key has no preceding entry, so it stays inline."""
+    assert yamlrocks.dumps({yamlrocks.YAMLRocksTag("!foo", "k"): 1}) == b"!foo k: 1\n"
     # A null value before an untagged key still uses the compact empty form.
     assert yamlrocks.dumps({"a": None, "b": 2}) == b"a:\nb: 2\n"
 


### PR DESCRIPTION
## Breaking change

A tagged mapping key that is not the first entry now serializes in the explicit `? key` / `: value` form instead of inline (`!t k:`). This is the same data; output for documents containing such keys changes shape. A first/only tagged key is unchanged (stays inline).

## Proposed change

An inline tagged key after a previous entry produced output that does not reload:

```python
yamlrocks.dumps({"a": 1, yamlrocks.YAMLRocksTag("!foo", "k"): 2})
# before: b"a: 1\n!foo k: 2\n"   -> reload fails: "a node property must be indented past its mapping key"
# after:  b"a: 1\n? !foo k\n: 2\n"
```

On reload, the `!foo` at the mapping's indent is read as a node property of the previous entry's value rather than the start of a new key. The preceding value just has to leave the cursor open to a trailing property: an empty-style null (`a:`), or a nested block mapping that ends in a null deeper in the tree. It is reachable via `loads(..., option=OPT_PASSTHROUGH_TAG)` then `dumps`, and was surfaced by the differential fuzz target.

The fix emits a non-first tagged key in the explicit `? key` / `: value` form: the `?` indicator starts a fresh key that no preceding value can absorb. This generalizes (and supersedes) the earlier null-only special case from #141, which only covered an immediate empty-null value and missed the nested cases. A first or only tagged key has no preceding sibling, so it stays in the compact inline form (`!foo k: 1`).

Note: strengthening the differential fuzz to assert re-parse surfaces a further, unrelated emitter case (an unquoted string that re-reads as a `...`/`---` document marker); that is tracked separately. This PR fixes the tagged-key class in full.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #141
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
