### PR TITLE
🐛 Quote a string that re-reads as a document-end marker

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -749,6 +749,17 @@ pub(crate) fn needs_quoting(value: &str, schema: Schema) -> bool {
         return true;
     }
 
+    // A string beginning with the document-end marker `...` followed by a space
+    // or tab also reparses as the end of the document (the marker needs only
+    // trailing whitespace, not a bare line), so everything after it is lost. The
+    // exact `...` is covered by the keyword match above; the `---` document-start
+    // marker (bare or with trailing content) is covered by the leading-`-`
+    // indicator check below.
+    if value.as_bytes().starts_with(b"...") && matches!(value.as_bytes().get(3), Some(b' ' | b'\t'))
+    {
+        return true;
+    }
+
     // Strict YAML 1.1 reads bare `y`/`Y`/`n`/`N` as booleans. The default schema
     // and the PyYAML-compat 1.1 variant both treat them as plain strings (the
     // common, legitimate config use), so they are quoted only when the output
@@ -1082,6 +1093,21 @@ mod tests {
             ..EmitOptions::default()
         };
         assert!(emit(&v, &single).contains("'yes'"));
+    }
+
+    #[test]
+    fn document_marker_strings_are_quoted() {
+        // A `...` document-end marker needs only trailing whitespace, so a string
+        // like `... y` re-reads as the end of the document and loses everything
+        // after it unless quoted. The exact `...` and any `---`-prefixed string
+        // are covered too; a `...` with non-whitespace after it (`...x`) is not a
+        // marker and stays bare.
+        for marker in ["...", "... y", "...  z", "---", "--- y"] {
+            let out = emit(&s(marker), &EmitOptions::default());
+            assert_eq!(reparse(&out), s(marker), "marker round-trips: {out:?}");
+        }
+        // Not a marker: no trailing whitespace, so no quoting is forced.
+        assert_eq!(emit(&s("...x"), &EmitOptions::default()), "...x\n");
     }
 
     #[test]


### PR DESCRIPTION
## Breaking change

None for any valid document. `dumps` output changes only for the broken case described below (a string that begins with `...` followed by whitespace). That output was already invalid: it reparsed as a document-end marker and dropped data, so the change only turns lossy output into correct output.

## Proposed change

A string starting with `...` followed by a space or tab was emitted bare. The YAML document-end marker needs only trailing whitespace, not a bare line, so `dumps("... y")` produced `... y`, which reparses as the end of the document and silently drops everything after it. The exact `...` was already quoted in `needs_quoting`; `...` plus whitespace slipped through.

This quotes a `...`-prefix string when whitespace follows. The `---` document-start marker is already covered by the existing leading-`-` indicator check, and a `...x` (no trailing whitespace) is not a marker and stays bare.

Found by the strengthened `differential_options` fuzz target, which asserts that `dumps` output always reloads to the same value.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (found by the differential-options fuzz target)
- This PR is related to: the emitter round-trip hardening pass
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
