### PR TITLE
🐛 Keep a folded scalar off the start of a marker line

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -512,7 +512,13 @@ impl<'a> Emitter<'a> {
             // A multi-line quoted scalar must be indented past its block context,
             // so the line's leading indent is too shallow for a value after a dash
             // (`- k: ...`, where it would land at the mapping's own column).
-            let cont_indent = self.current_column();
+            //
+            // Clamp a root scalar's column 0 to 1: a continuation line at column 0
+            // that happens to start with `---`/`...` re-reads as a document marker
+            // ("a document marker cannot appear inside a quoted scalar"). The fold
+            // already strips a continuation line's leading whitespace on reload, so
+            // the extra space leaves the value unchanged.
+            let cont_indent = self.current_column().max(1);
             let (quote, body) = if single_ok {
                 (b'\'', crate::emit_util::single_quoted_body(value))
             } else {
@@ -1144,6 +1150,27 @@ mod tests {
         }
         // Not a marker: no trailing whitespace, so no quoting is forced.
         assert_eq!(emit(&s("...x"), &EmitOptions::default()), "...x\n");
+    }
+
+    #[test]
+    fn folded_root_scalar_never_starts_a_line_with_a_marker() {
+        // Folding a quoted scalar at the document root indents continuation lines
+        // to column 0, where a piece like `---`/`...` re-reads as a document marker
+        // ("a document marker cannot appear inside a quoted scalar"). Continuation
+        // indent is clamped to 1 so no line begins at column 0; the leading space
+        // is stripped on reload, so the value is unchanged.
+        let opts = EmitOptions {
+            width: 1,
+            ..EmitOptions::default()
+        };
+        for value in ["p= ---  ]", "x --- y", "a ... b", "..."] {
+            let out = emit(&s(value), &opts);
+            assert_eq!(
+                reparse(&out),
+                s(value),
+                "folded marker round-trips: {out:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Breaking change

None for any valid document. `dumps` output changes only for the broken case described below (a quoted scalar folded at a narrow width whose continuation line would otherwise begin with `---`/`...` at column 0). That output was already invalid, so the change only turns rejected output into correct output.

## Proposed change

Folding a quoted scalar at the document root indents continuation lines to column 0. When a folded line then began with `---` or `...`, it re-read as a document marker: `dumps("p= ---  ]", width=1)` emitted `"p=\n---  ]"`, which a reader rejects ("a document marker cannot appear inside a quoted scalar").

This clamps a root scalar's continuation indent to 1 so no folded line starts at column 0. The fold already strips a continuation line's leading whitespace on reload, so the extra space leaves the value unchanged.

Found by the strengthened `differential_options` fuzz target, which asserts that `dumps` output always reloads to the same value.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (found by the differential-options fuzz target)
- This PR is related to: the emitter round-trip hardening pass
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
