### PR TITLE
🐛 Indent a tagged sequence item under its dash when indentless

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -377,7 +377,19 @@ impl<'a> Emitter<'a> {
                 Value::Tagged(tag, inner) => {
                     self.buf.push(b' ');
                     self.buf.extend_from_slice(tag.as_bytes());
-                    self.emit_value_after_colon(inner, indent);
+                    match inner.as_ref() {
+                        // A tagged block sequence must indent under the dash, even
+                        // in indentless mode: the tag sits on the dash line, so an
+                        // indentless inner sequence (dashes at the outer column)
+                        // would not bind to the tag. Its dashes would read as more
+                        // items of the outer sequence, dropping the tag and merging
+                        // the nesting on reload. Indenting keeps it the tag's child.
+                        Value::Sequence(s) if self.is_block(inner) => {
+                            self.buf.push(b'\n');
+                            self.emit_block_sequence(s, child_indent);
+                        }
+                        _ => self.emit_value_after_colon(inner, indent),
+                    }
                 }
                 _ => {
                     self.buf.push(b' ');
@@ -1034,6 +1046,30 @@ mod tests {
         };
         let out = emit(&v, &opts);
         assert_eq!(out, "k: !t\n  - a\n  - b\n");
+        assert_eq!(reparse(&out), v, "tag survives the round-trip: {out:?}");
+    }
+
+    #[test]
+    fn tagged_sequence_item_keeps_its_tag_in_indentless_mode() {
+        // A tagged block sequence that is itself an *item* of a sequence must
+        // indent under the dash even in indentless mode: the tag sits on the dash
+        // line, so an indentless inner sequence (dashes at the outer column) would
+        // read as more items of the outer sequence, dropping the tag and merging
+        // the nesting on reload.
+        let v = Value::Sequence(vec![
+            Value::Null,
+            Value::Tagged(
+                "!t".to_owned(),
+                Box::new(Value::Sequence(vec![Value::Null])),
+            ),
+            Value::Null,
+        ]);
+        let opts = EmitOptions {
+            indentless_sequences: true,
+            ..EmitOptions::default()
+        };
+        let out = emit(&v, &opts);
+        assert_eq!(out, "-\n- !t\n  -\n-\n");
         assert_eq!(reparse(&out), v, "tag survives the round-trip: {out:?}");
     }
 


### PR DESCRIPTION
## Breaking change

None for any valid document. `dumps` output changes only for the broken case described below (a tagged block sequence that is itself an item of a sequence, emitted in indentless mode). That output already dropped the tag and merged the nesting on reload, so the change only turns lossy output into correct output.

## Proposed change

A tagged block sequence that is itself an item of a sequence was emitted with its inner sequence at the outer indent in indentless mode. The inner dashes then read as more items of the outer sequence on reload, dropping the tag and merging the nesting: `[null, !t [null], null]` came back as `[null, [null, null]]`. The mapping-value path already guarded this; the sequence-item path did not.

This indents the inner block sequence under the dash so it stays the tagged node's child.

Found by the strengthened `differential_options` fuzz target, which asserts that `dumps` output always reloads to the same value.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (found by the differential-options fuzz target)
- This PR is related to: the emitter round-trip hardening pass
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
