### PR TITLE
✅ Assert the fast emitter's output always re-parses in differential fuzz

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,7 @@ pub mod fuzz {
     /// Restricted to the YAML 1.2 schema on purpose: the fast emitter targets
     /// 1.2 quoting rules, so re-decoding its output under 1.1 (where bare `yes`
     /// is a bool, not the string it emitted) would diverge by design, not by
-    /// bug. Re-decode failures and multi-document output are skipped rather than
-    /// asserted, for the reasons [`roundtrip`] documents; only a successful,
-    /// single-document re-decode that *disagrees on data* is a finding.
+    /// bug. Every other step is a hard assertion: see [`check_emit_roundtrip`].
     pub fn differential(input: &str) {
         let Ok(documents) = decode_with(input, Schema::Yaml12, false, false) else {
             return;
@@ -165,23 +163,33 @@ pub mod fuzz {
     /// Emit `document` with `options`, re-decode the output, and assert the data
     /// survived unchanged. Shared by both differential targets so a divergence is
     /// reported identically (the panic message names the options that triggered
-    /// it). Re-decode failures and multi-document output are skipped, not
-    /// asserted, for the reasons [`roundtrip`] documents.
+    /// it).
+    ///
+    /// Every step is a hard assertion, unlike the round-trip target's lenient
+    /// re-compose. The fast emitter takes a freshly decoded `Value` tree (no user
+    /// edits) and must always produce valid YAML that `loads` reads back as the
+    /// *same single document*. So invalid UTF-8, output that fails to re-decode, or
+    /// output that splits into several documents is itself a `dumps` bug, not a
+    /// case to skip. Three such bugs were found and fixed this way: an unquoted
+    /// `...`-marker string, a folded scalar breaking onto a marker line, and an
+    /// indentless tagged sequence item merging into its parent.
     fn check_emit_roundtrip(
         input: &str,
         document: &crate::decode::Value<'_>,
         options: &EmitOptions,
     ) {
         let emitted = encode(document, options);
-        let Ok(text) = std::str::from_utf8(&emitted) else {
-            return;
-        };
-        let Ok(reparsed) = decode_with(text, Schema::Yaml12, false, false) else {
-            return;
-        };
-        if reparsed.len() != 1 {
-            return;
-        }
+        let text = std::str::from_utf8(&emitted).unwrap_or_else(|e| {
+            panic!("dumps emitted invalid UTF-8\n  options:  {options:?}\n  input:    {input:?}\n  error:    {e}")
+        });
+        let reparsed = decode_with(text, Schema::Yaml12, false, false).unwrap_or_else(|e| {
+            panic!("dumps emitted YAML that loads rejects\n  options:  {options:?}\n  input:    {input:?}\n  emitted:  {text:?}\n  error:    {e:?}")
+        });
+        assert_eq!(
+            reparsed.len(),
+            1,
+            "dumps emitted multi-document YAML\n  options:  {options:?}\n  input:    {input:?}\n  emitted:  {text:?}"
+        );
         assert!(
             values_equiv(document, &reparsed[0]),
             "dumps/loads diverged on data\n  options:  {options:?}\n  input:    {input:?}\n  emitted:  {text:?}\n  original: {document:?}\n  reparsed: {:?}",


### PR DESCRIPTION
## Breaking change

None. This change is fuzz-harness only; it touches no library code and no public API.

## Proposed change

The differential fuzz oracle (`check_emit_roundtrip`, shared by the `differential` and `differential_options` targets) used to silently `return` when the re-emitted YAML failed to re-decode, split into several documents, or was invalid UTF-8. That hid the worst `dumps` bug class: output a reader rejects or reshapes, with no crash to flag it.

This tightens the oracle so each of those is a hard finding. The fast emitter takes a freshly decoded `Value` tree (no user edits), so it must always produce valid YAML that `loads` reads back as the same single document; anything else is a `dumps` bug. The lenient `roundtrip` target (the round-trip emitter, which re-emits modified documents and can legitimately produce composer-rejected output for exotic inputs) is left untouched.

This is the closing step of the fuzz-and-fix pass: the three emitter bugs the strict oracle surfaced are already fixed and merged (#144 quoting a `...` document-end marker, #145 keeping a folded scalar off a marker line, #146 indenting a tagged sequence item under its dash). With those in, both differential targets now run clean under the strict oracle (702k and 1.5M executions locally, zero findings).

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: #144, #145, #146 (the emitter bugs this strict oracle surfaced)
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
