### PR TITLE
🐛 Bound include expansion to stop a diamond-lattice fan-out

### DIFF
--- a/docs/src/content/docs/reference/exceptions.md
+++ b/docs/src/content/docs/reference/exceptions.md
@@ -74,7 +74,7 @@ subclasses let you react to a specific cause:
 | `YAMLRocksSchemaError`             | [schema validation](/guides/schema-validation/) fails; `.schema_path` is the JSON path of the offending node                                                   |
 | `YAMLRocksIncludeNotFoundError`    | an `!include` target does not exist                                                                                                                            |
 | `YAMLRocksCircularIncludeError`    | an `!include` chain forms a cycle                                                                                                                              |
-| `YAMLRocksIncludeDepthError`       | an `!include` chain is too deep                                                                                                                                |
+| `YAMLRocksIncludeDepthError`       | an `!include` chain is too deep, or expands too many files in total (a fan-out)                                                                                |
 | `YAMLRocksIncludeConfinementError` | an `!include` resolves outside `include_dir`                                                                                                                   |
 | `YAMLRocksSecretNotFoundError`     | a `!secret` name is not in any `secrets.yaml`                                                                                                                  |
 | `YAMLRocksEnvVarError`             | an `!env_var` is undefined and has no default                                                                                                                  |

--- a/src/include/mod.rs
+++ b/src/include/mod.rs
@@ -16,6 +16,19 @@ mod secret;
 /// linear chain of distinct files so it cannot exhaust the stack or memory.
 const MAX_INCLUDE_DEPTH: usize = 50;
 
+/// Maximum number of file expansions a single load may perform across all
+/// `!include`/`!include_dir_*` directives. Depth and cycle detection only bound a
+/// single path through the include graph; neither stops a *diamond* lattice from
+/// re-expanding a shared subtree once per route to it. A handful of tiny files
+/// that each include the *next one twice* (`a.yaml`: `x: !include b.yaml` and
+/// `y: !include b.yaml`; `b.yaml` likewise includes `c.yaml` twice; and so on)
+/// then expand the deepest file `2^depth` times, a billion-laughs amplification
+/// that depth alone cannot catch. This total-work budget caps the whole expansion
+/// regardless of shape; 10,000 is far above any real configuration (the real-world
+/// corpus expands a few hundred) yet trips the doubling attack in well under a
+/// second.
+const MAX_INCLUDE_EXPANSIONS: usize = 10_000;
+
 /// Which application tag families the resolver should expand. Each tag crosses
 /// a different trust boundary (`!include` reads files, `!secret` reads a secrets
 /// file, `!env_var` reads the process environment), so each is opt-in on its
@@ -57,6 +70,10 @@ pub struct IncludeResolver {
     /// Whether `!include_dir_*` descends into subdirectories (`os.walk`-style).
     /// Off by default (top level only); enabled via `OPT_INCLUDE_DIR_RECURSIVE`.
     dir_recursive: bool,
+    /// Running count of file expansions this load has performed, bounded by
+    /// [`MAX_INCLUDE_EXPANSIONS`] to stop a diamond-lattice fan-out (see that
+    /// constant). Incremented once per included-file read in `read_and_compose`.
+    expansions: usize,
     /// Non-fatal diagnostics gathered during resolution (e.g. a non-`debug`
     /// `logger:` value in a `secrets.yaml`), surfaced to the caller to emit
     /// through Python logging.
@@ -108,6 +125,7 @@ impl IncludeResolver {
             secrets_cache: HashMap::new(),
             tags,
             dir_recursive: false,
+            expansions: 0,
             warnings: Vec::new(),
             collect_missing_secrets: false,
             missing_secrets: Vec::new(),
@@ -685,6 +703,25 @@ impl IncludeResolver {
         display: &str,
         stack: &[(PathBuf, u32)],
     ) -> Result<(u32, Vec<YamlNode>), IncludeError> {
+        // Bound the total number of file expansions, not just the chain depth: a
+        // diamond lattice re-expands a shared subtree once per route and would
+        // otherwise blow up as `2^depth` from a few tiny files (see
+        // [`MAX_INCLUDE_EXPANSIONS`]). Every include/dir file read funnels through
+        // here, so this single check covers all directive families.
+        self.expansions += 1;
+        if self.expansions > MAX_INCLUDE_EXPANSIONS {
+            return Err(IncludeError {
+                kind: IncludeErrorKind::Depth,
+                message: format!(
+                    "include expansion exceeded the maximum of {MAX_INCLUDE_EXPANSIONS} files \
+                     (a fan-out of nested includes)"
+                ),
+                path: path.to_path_buf(),
+                include_stack: stack.to_vec(),
+                span: None,
+            });
+        }
+
         let content = std::fs::read_to_string(path).map_err(|e| IncludeError {
             kind: IncludeErrorKind::NotFound,
             message: format!("cannot read included file '{display}': {e}"),

--- a/tests/robustness/test_security.py
+++ b/tests/robustness/test_security.py
@@ -561,6 +561,50 @@ def test_alias_bomb_terminates_within_time_budget():
     assert proc.stdout.strip() == b"OK"
 
 
+# A doubling lattice of includes (each file includes the next twice) re-expands a
+# shared subtree once per route, so without a total-expansion budget it reads the
+# leaf 2**depth times: a few tiny files, billions of reads. The depth cap does not
+# catch it (the lattice is wide, not deep). Runs in a subprocess so a regression
+# that removes the budget is caught by the wall-clock timeout, not left to hang.
+_INCLUDE_FANOUT_SCRIPT = """
+import os, tempfile, yamlrocks
+d = tempfile.mkdtemp()
+depth = 40  # 2**40 leaf reads without the expansion budget
+for i in range(depth):
+    with open(os.path.join(d, f"c{i}.yaml"), "w") as f:
+        f.write(f"a: !include c{i + 1}.yaml\\nb: !include c{i + 1}.yaml\\n")
+with open(os.path.join(d, f"c{depth}.yaml"), "w") as f:
+    f.write("leaf: 1\\n")
+try:
+    yamlrocks.loads(
+        b"root: !include c0.yaml\\n", option=yamlrocks.OPT_INCLUDES, include_dir=d
+    )
+    raise SystemExit("include fan-out was not rejected")
+except yamlrocks.YAMLRocksDecodeError:
+    pass
+print("OK")
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="subprocess timeout semantics")
+def test_include_fanout_terminates_within_time_budget():
+    """A diamond lattice of includes must terminate within a wall-clock budget,
+    not just "eventually". The total-expansion budget bounds the work; a
+    regression that drops it would re-expand a shared subtree 2**depth times and
+    hang, which the subprocess timeout turns into a clean failure.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _INCLUDE_FANOUT_SCRIPT], capture_output=True, timeout=30
+    )
+    assert proc.returncode == 0, (
+        f"include fan-out did not terminate cleanly: rc={proc.returncode} "
+        f"stderr={proc.stderr.decode()[:300]}"
+    )
+    assert proc.stdout.strip() == b"OK"
+
+
 def test_schema_validation_resolves_aliases():
     """The schema validator still sees an alias as its referent, not null."""
     src = b"defaults: &d {port: 80}\nserver: *d\n"


### PR DESCRIPTION
## Breaking change

A single load that expands more than 10,000 included files now raises `YAMLRocksIncludeDepthError` instead of continuing. No real configuration approaches this (the real-world corpus expands a few hundred, and a synthetic 2,000-file `!include_dir_merge_named` loads in well under a second); only a pathological or malicious fan-out reaches the cap.

## Proposed change

Include resolution had a depth cap (50) and cycle detection, but both only bound a single path through the include graph. Neither stops a *diamond* lattice from re-expanding a shared subtree once per route to it. A handful of tiny files that each include the next twice (`a: !include b\nb: !include b` doubling at each level) then expands `2^depth` times: a billion-laughs amplification via includes. The original review flagged this for `!include_dir_*`, but it is broader: plain `!include` is affected too (the reproduction below uses only plain `!include`).

Measured, with the depth cap in place but no expansion budget (clean `2^depth` scaling):

| depth | time   |
| ----- | ------ |
| 8     | 0.015s |
| 12    | 0.25s  |
| 16    | 4.2s   |
| 18    | 16.6s  |

At the depth-50 cap that is roughly `2^50` reads from ~51 tiny files: effectively an unbounded hang.

This adds a global `MAX_INCLUDE_EXPANSIONS = 10,000` budget at the single `read_and_compose` chokepoint that every include and directory-include file read funnels through, so one check covers all directive families. The budget bounds total work regardless of graph shape, which is what depth and cycle detection cannot do. With it, the doubling attack is rejected in under half a second.

A wall-clock subprocess test (mirroring the alias-bomb time-budget test) builds a depth-40 doubling lattice and asserts it terminates within a budget; a regression that drops the cap would re-expand `2^40` times and hang, which the subprocess timeout turns into a clean failure.

The reused `YAMLRocksIncludeDepthError` now covers both "too deep" and "too many files in total"; its reference-doc description is updated to match.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (Codex review pass 2; confirmed and measured locally)
- This PR is related to: the include security review cluster
- Link to a separate documentation pull request: None (the one affected reference row is updated here)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
