### PR TITLE
🐛 Stop echoing a secrets.yaml logger value into the log

### DIFF
--- a/src/include/secret.rs
+++ b/src/include/secret.rs
@@ -136,13 +136,18 @@ impl IncludeResolver {
                                 // logger's level), so it is never a usable secret.
                                 // Its only valid value is `debug`; anything else
                                 // is a non-fatal misconfiguration worth surfacing.
+                                // The offending value is deliberately not echoed:
+                                // it is content from `secrets.yaml`, and the warning
+                                // goes to logs, which may be less protected than the
+                                // secrets file itself.
                                 if key_name == "logger" {
                                     let value = scalar_text(val).unwrap_or_default();
                                     if !value.eq_ignore_ascii_case("debug") {
-                                        self.warn(format!(
-                                            "secrets.yaml: 'logger: debug' expected, but \
-                                             'logger: {value}' found"
-                                        ));
+                                        self.warn(
+                                            "secrets.yaml: 'logger: debug' expected, but a \
+                                             different value was found"
+                                                .to_owned(),
+                                        );
                                     }
                                 } else {
                                     map.insert(key_name, val.clone());

--- a/tests/features/test_secret_tag.py
+++ b/tests/features/test_secret_tag.py
@@ -129,14 +129,17 @@ def test_nested_secret_in_secrets_file_is_rejected(tmp_path):
 
 
 def test_bad_logger_value_logs_but_does_not_fail(tmp_path, caplog):
-    """A non-debug logger value in secrets.yaml logs a warning and continues."""
-    (tmp_path / "secrets.yaml").write_text("logger: info\nfoo: bar\n")
+    """A non-debug logger value in secrets.yaml logs a warning and continues,
+    without echoing the offending value (secrets.yaml content) into the log."""
+    (tmp_path / "secrets.yaml").write_text("logger: s3cr3t-leak\nfoo: bar\n")
     with caplog.at_level("WARNING", logger="yamlrocks"):
         data = yamlrocks.loads(
             b"x: !secret foo", option=SECRETS, include_dir=str(tmp_path)
         )
     assert data == {"x": "bar"}
     assert any("logger: debug" in r.message for r in caplog.records)
+    # The bad value lives in secrets.yaml, so it must never reach the log.
+    assert not any("s3cr3t-leak" in r.message for r in caplog.records)
 
 
 def test_good_logger_value_is_silent(tmp_path, caplog):


### PR DESCRIPTION
## Breaking change

None. The behavior is unchanged (a non-`debug` `logger:` in `secrets.yaml` still logs a warning and is still ignored as a secret); only the warning's text changes, and the warning string is not part of the public API.

## Proposed change

When a `secrets.yaml` carries the reserved `logger:` key with a value other than `debug`, the resolver logs a warning. That warning echoed the raw value: `'logger: debug' expected, but 'logger: <value>' found`. The value is content from `secrets.yaml`, and the warning lands in application logs, which are often less protected than the secrets file. So a misconfiguration (or anything a user accidentally placed there) leaked from the secrets file into the logs.

The warning now reports only that a non-`debug` value was found, without echoing it. The resolution behavior is unchanged and still matches `home-assistant-libs/annotatedyaml` (the `logger` key is reserved, `debug` enables debug logging, anything else warns and is ignored); only the exact log string differs, and that string is not a compatibility surface.

The existing test now writes a secret-looking `logger:` value and asserts it never reaches the log, alongside the existing check that the warning still fires.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (Codex review pass 2)
- This PR is related to: the include security review cluster
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
