### PR TITLE
🐛 Write includes back atomically without following a symlink

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -698,7 +698,9 @@ pub fn dump_includes(
     let _ = include_dir;
     let changes = get_include_changes(py, doc)?;
     for (path, content) in changes {
-        std::fs::write(&path, &content)
+        // Atomic, symlink-safe write: a tracked source file swapped for a symlink
+        // between load and write-back must not redirect the write out of the tree.
+        crate::safe_io::atomic_write(&path, &content)
             .map_err(|e| PyValueError::new_err(format!("cannot write {}: {e}", path.display())))?;
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod include;
 mod parser;
 mod resolver;
 mod roundtrip;
+mod safe_io;
 mod scanner;
 mod schema;
 mod stack;

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -1446,8 +1446,11 @@ fn key_error(node: &YamlNode, key: &Bound<'_, PyAny>) -> PyErr {
 }
 
 /// Write `bytes` to `path`, surfacing IO errors as Python `OSError`.
+///
+/// Uses an atomic, symlink-safe write so a source file swapped for a symlink
+/// between load and `save` cannot redirect the write outside the config tree.
 fn write_file(path: &std::path::Path, bytes: &[u8]) -> PyResult<()> {
-    std::fs::write(path, bytes).map_err(|e| {
+    crate::safe_io::atomic_write(path, bytes).map_err(|e| {
         pyo3::exceptions::PyOSError::new_err(format!("cannot write {}: {e}", path.display()))
     })
 }

--- a/src/safe_io.rs
+++ b/src/safe_io.rs
@@ -1,0 +1,118 @@
+//! Atomic, symlink-safe file writes for include write-back.
+//!
+//! Writable includes (`dump_includes`, `YAMLRocksDocument.save`) re-write source
+//! files that were recorded when the document was loaded. A plain
+//! `std::fs::write` follows a symlink at the target path, so an attacker who can
+//! swap a tracked source file for a symlink between load and write-back could
+//! redirect the write to a file outside the configuration tree (a narrow but real
+//! clobber-outside-the-tree vector when a privileged process writes back a tree
+//! an attacker can stage).
+//!
+//! [`atomic_write`] closes this: it writes the new content to a fresh temporary
+//! file in the same directory, created with `O_CREAT | O_EXCL` (which never
+//! follows a symlink), then renames it over the target. `rename` replaces the
+//! path itself rather than following it, so a symlink swapped in at the target is
+//! overwritten, not traversed, and the write stays in the tree. The rename is
+//! also atomic, so a concurrent reader sees either the old file or the new one,
+//! never a half-written one.
+
+use std::fs::OpenOptions;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Per-process counter making each temporary file name unique without randomness.
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Write `bytes` to `path` atomically and without following a symlink at `path`.
+///
+/// Writes to a temporary sibling file and renames it over `path`. See the module
+/// docs for why this is the safe write for include write-back.
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        // A bare file name (no parent) is written relative to the current
+        // directory, so the temporary file belongs there too.
+        _ => Path::new("."),
+    };
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "cannot write a path that ends in `..` or is empty",
+        )
+    })?;
+
+    // Create a uniquely named temporary file in the target's directory. `O_EXCL`
+    // (via `create_new`) both guarantees the name is unused and refuses to follow
+    // a symlink, so the staged content is never written through one. The temp
+    // must share the directory (and thus the filesystem) so the later rename is a
+    // cheap atomic metadata operation, not a cross-device copy.
+    let pid = std::process::id();
+    let (tmp_path, mut file) = loop {
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut name = file_name.to_os_string();
+        name.push(format!(".yamlrocks-tmp.{pid}.{counter}"));
+        let candidate: PathBuf = dir.join(name);
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => break (candidate, file),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    };
+
+    // Write the content, then move it into place. On any failure remove the
+    // temporary file so a partial write never lingers next to the real one.
+    let staged = file.write_all(bytes).and_then(|()| file.flush());
+    drop(file);
+    if let Err(e) = staged.and_then(|()| std::fs::rename(&tmp_path, path)) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::atomic_write;
+    use std::fs;
+
+    /// A fresh write lands the exact bytes at the path.
+    #[test]
+    fn writes_new_file() {
+        let dir = std::env::temp_dir().join(format!("yamlrocks-safeio-new-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("out.yaml");
+        atomic_write(&target, b"key: value\n").unwrap();
+        assert_eq!(fs::read(&target).unwrap(), b"key: value\n");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Overwriting a symlinked target replaces the link with a real file instead
+    /// of writing through it, so the link's target is left untouched.
+    #[test]
+    #[cfg(unix)]
+    fn replaces_symlink_instead_of_following_it() {
+        let dir =
+            std::env::temp_dir().join(format!("yamlrocks-safeio-link-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let outside = dir.join("outside.txt");
+        fs::write(&outside, b"original\n").unwrap();
+        let target = dir.join("link.yaml");
+        std::os::unix::fs::symlink(&outside, &target).unwrap();
+
+        atomic_write(&target, b"new: data\n").unwrap();
+
+        // The link target was not clobbered, and the path is now a real file.
+        assert_eq!(fs::read(&outside).unwrap(), b"original\n");
+        assert!(!fs::symlink_metadata(&target)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read(&target).unwrap(), b"new: data\n");
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/tests/features/test_includes.py
+++ b/tests/features/test_includes.py
@@ -159,6 +159,31 @@ def test_dump_includes_requires_include_document():
         yamlrocks.dump_includes_map(doc)
 
 
+@pytest.mark.skipif(os.name != "posix", reason="symlink semantics differ on Windows")
+def test_dump_includes_does_not_write_through_a_swapped_symlink(config_dir):
+    """A source file swapped for a symlink between load and write-back must be
+    replaced, not followed: the write stays in the tree and the link target
+    outside it is left untouched (an atomic, symlink-safe write)."""
+    tmp_path, root = config_dir
+    doc = yamlrocks.loads(root.encode(), option=RT_INC, include_dir=str(tmp_path))
+    doc["automation"][1]["trigger"] = "civil_dusk"
+
+    # Stage the attack: replace the tracked source file with a symlink that points
+    # at a file outside the configuration tree.
+    outside = tmp_path.parent / "outside.txt"
+    outside.write_text("do-not-clobber\n")
+    target = tmp_path / "automations.yaml"
+    target.unlink()
+    target.symlink_to(outside)
+
+    yamlrocks.dump_includes(doc, include_dir=str(tmp_path))
+
+    # The outside file is untouched, and the include path is now a real file.
+    assert outside.read_text() == "do-not-clobber\n"
+    assert not target.is_symlink()
+    assert "civil_dusk" in target.read_text()
+
+
 def test_include_dir_list(tmp_path):
     """!include_dir_list yields one entry per file in sorted order."""
     # !include_dir_list yields one entry per file (in sorted filename order).


### PR DESCRIPTION
## Breaking change

Write-back (`dump_includes`, `YAMLRocksDocument.save`) now replaces a target that is a symlink with a regular file, instead of writing through the symlink to its target. If you relied on a source file being an intentional symlink and on write-back following it, that link is now replaced by a real file. This is the deliberate trade-off: at write time an intentional in-tree symlink and an attacker-swapped one are indistinguishable, and not following it is the safe choice. The common case (a real source file) is unaffected.

## Proposed change

Writable includes re-write source files recorded when the document was loaded. Both write-back sites used `std::fs::write`, which follows a symlink at the target path. An attacker who can swap a tracked source file for a symlink between load and write-back could redirect the write to a file outside the configuration tree: a narrow but real clobber-outside-the-tree vector when a privileged process writes back a tree an attacker can stage.

This adds `src/safe_io.rs::atomic_write` and routes both `dump_includes` (`src/ffi/mod.rs`) and `YAMLRocksDocument.save` (`src/roundtrip/document.rs`) through it. It stages the new content to a fresh temporary file in the same directory, created with `O_CREAT | O_EXCL` (which never follows a symlink), then renames it over the target. `rename` replaces the path itself rather than following it, so a symlink swapped in at the target is overwritten, not traversed, and the write stays in the tree. The rename is also atomic, so a concurrent reader never sees a half-written file.

The read side was assessed too and is already mitigated: `confine` returns the canonical, symlink-resolved path and `read_and_compose` reads exactly that (the same holds for secrets and directory entries), so the read TOCTOU's final-component swap is already closed. The residual mid-path-component race needs `openat2`/`O_NOFOLLOW` (non-portable) and is out of scope.

Tests: two Rust unit tests in `safe_io` (a fresh write lands the bytes; overwriting a symlinked target replaces the link and leaves its target untouched), and a Python integration test that swaps the tracked source file for a symlink pointing outside the tree and asserts `dump_includes` leaves the outside file untouched and writes a real file in-tree.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (Codex review pass 2)
- This PR is related to: the include security review cluster
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
