### PR TITLE
👷 Pin exact cargo tool versions in CI

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -47,7 +47,9 @@ jobs:
         # numpy keeps the OPT_SERIALIZE_NUMPY path inside the coverage numbers.
         run: uv sync --locked --no-install-project --no-default-groups --group build --group test --group numpy
       - name: 🏗 Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        # Pin the tool version (not just its locked deps) so coverage runs are
+        # reproducible across CI. Bump this deliberately.
+        run: cargo install cargo-llvm-cov --version =0.8.7 --locked
       - name: 🏗 Set up coverage environment
         # show-env emits shell `export KEY='VALUE'` lines. Drop the `export `
         # prefix and the surrounding single quotes so the raw values persist

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -38,7 +38,9 @@ jobs:
       - name: 🏗 Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # zizmor: ignore[superfluous-actions,stale-action-refs] stable; canonical pinned Rust toolchain installer
       - name: 🏗 Install cargo-audit
-        run: cargo install cargo-audit --locked
+        # Pin the tool version (not just its locked deps) so a release cannot
+        # change the audit build under us. Bump this deliberately.
+        run: cargo install cargo-audit --version =0.22.2 --locked
       - name: 🔍 Scan Cargo.lock against the RustSec advisory database
         run: cargo audit
 
@@ -72,7 +74,9 @@ jobs:
       - name: 🏗 Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # zizmor: ignore[superfluous-actions,stale-action-refs] stable; canonical pinned Rust toolchain installer
       - name: 🏗 Install cargo-about
-        run: cargo install cargo-about --locked --features cli
+        # Pin the tool version so the generated license file is reproducible.
+        # Bump this deliberately.
+        run: cargo install cargo-about --version =0.9.0 --locked --features cli
       - name: 🔍 Regenerate THIRD_PARTY_LICENSES.md
         # `generate` fails if a dependency uses a license not allow-listed in
         # about.toml, blocking a copyleft or unknown-license crate from slipping in.


### PR DESCRIPTION
## Breaking change

None. CI-only change; no library code, API, or output is affected. The pinned versions are the current latest, so the tools behave exactly as before (verified: `cargo-about` 0.9.0 reproduces the committed `THIRD_PARTY_LICENSES.md` byte-for-byte).

## Proposed change

The Rust tooling installs used `cargo install <tool> --locked`. `--locked` fixes the tool's own dependency graph, but not the *tool version*: each CI run installed whatever release was latest at the time, so the audit, coverage, and license-generation builds could change under us without a commit.

This pins each to an exact version on top of `--locked`:

- `cargo-llvm-cov` → `=0.8.7` (coverage)
- `cargo-audit` → `=0.22.2` (advisory scan)
- `cargo-about` → `=0.9.0` (license file generation)

The tool build is now reproducible, not just its dependency graph, which is the supply-chain posture the repository already takes for GitHub Actions (all SHA-pinned). All three are pinned to the current latest, so there is no behavior change; the versions are meant to be bumped deliberately.

Out of scope on purpose: the `prek` / pre-commit hook `rev:` tags. Those are a documented deliberate choice (see the `.pre-commit-config.yaml` header: the few non-Python hooks stay tag-pinned, each with a single source), so they are left as-is.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None (Codex review pass 2)
- This PR is related to: the CI supply-chain hardening cluster
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
