### PR TITLE
👷 Bump Cargo.lock with the release version so --locked builds pass

### DIFF
--- a/.github/scripts/set_version.py
+++ b/.github/scripts/set_version.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Set the package version in Cargo.toml and pyproject.toml from a release tag.
+"""Set the package version in Cargo.toml, pyproject.toml, and Cargo.lock from a
+release tag.
 
 Usage: ``set_version.py <tag>`` where ``<tag>`` is e.g. ``v1.2.3`` or ``1.2.3``.
-The leading ``v`` is stripped and the version is lowercased. Both manifests have
-their first ``version = "..."`` line rewritten in place.
+The leading ``v`` is stripped and the version is lowercased. The two manifests
+have their first ``version = "..."`` line rewritten in place, and the crate's own
+entry in Cargo.lock is updated to match. That last step matters because the wheel
+builds run ``maturin ... --locked``: leaving Cargo.lock at the old version makes
+cargo refuse the bumped manifest ("cannot update the lock file ... --locked").
 """
 
 from __future__ import annotations
@@ -24,14 +28,46 @@ def set_version(path: pathlib.Path, version: str) -> None:
     print(f"Set {path} version to {version}")
 
 
+def package_name(cargo_toml: pathlib.Path) -> str:
+    """The crate name from the ``[package]`` table of Cargo.toml."""
+    in_package = False
+    for line in cargo_toml.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_package = stripped == "[package]"
+        elif in_package:
+            match = re.match(r'name = "(.+?)"', stripped)
+            if match:
+                return match.group(1)
+    raise SystemExit(f"could not find a [package] name in {cargo_toml}")
+
+
+def set_lock_version(path: pathlib.Path, name: str, version: str) -> None:
+    """Update the crate's own ``[[package]]`` entry in Cargo.lock. In the lock
+    format the ``version`` line immediately follows the ``name`` line."""
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.strip() == f'name = "{name}"':
+            after = lines[i + 1] if i + 1 < len(lines) else ""
+            if not after.startswith("version = "):
+                raise SystemExit(f"unexpected layout for {name} package in {path}")
+            lines[i + 1] = f'version = "{version}"\n'
+            path.write_text("".join(lines), encoding="utf-8")
+            print(f"Set {path} {name} version to {version}")
+            return
+    raise SystemExit(f"could not find the {name} package in {path}")
+
+
 def main() -> None:
     if len(sys.argv) != 2:
         raise SystemExit("usage: set_version.py <tag>")
     version = sys.argv[1].removeprefix("v").lower()
     if not re.fullmatch(r"[0-9][0-9a-z.+-]*", version):
         raise SystemExit(f"refusing to set suspicious version: {version!r}")
-    set_version(pathlib.Path("Cargo.toml"), version)
+    cargo_toml = pathlib.Path("Cargo.toml")
+    set_version(cargo_toml, version)
     set_version(pathlib.Path("pyproject.toml"), version)
+    set_lock_version(pathlib.Path("Cargo.lock"), package_name(cargo_toml), version)
 
 
 if __name__ == "__main__":

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -7,8 +7,17 @@ they depend on what maturin actually bundles rather than on runtime behavior.
 from __future__ import annotations
 
 import pathlib
+import subprocess
+import sys
 
 import yamlrocks
+
+_SET_VERSION = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / ".github"
+    / "scripts"
+    / "set_version.py"
+)
 
 
 def _package_dir() -> pathlib.Path:
@@ -29,3 +38,39 @@ def test_ships_py_typed_marker():
 def test_ships_type_stub():
     """The inline type stub for the native module ships alongside it."""
     assert (_package_dir() / "__init__.pyi").is_file()
+
+
+def test_set_version_bumps_cargo_lock_in_lockstep(tmp_path):
+    """``set_version.py`` must update the crate's own entry in Cargo.lock, not
+    just the manifests. The wheel builds run ``maturin ... --locked``, so a stale
+    lock makes cargo reject the bumped manifest ("cannot update the lock file ...
+    --locked") and the whole release fails. Run the real script against fixture
+    files and assert every version moves together, leaving dependency pins alone.
+    """
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "yamlrocks"\nversion = "0.1.0"\n\n'
+        '[lib]\nname = "_yamlrocks"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "yamlrocks"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    # A realistic lock: our own crate plus a dependency that must not be touched.
+    (tmp_path / "Cargo.lock").write_text(
+        "version = 4\n\n"
+        '[[package]]\nname = "memchr"\nversion = "2.7.4"\n\n'
+        '[[package]]\nname = "yamlrocks"\nversion = "0.1.0"\n'
+        'dependencies = [\n "memchr",\n]\n',
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [sys.executable, str(_SET_VERSION), "v2.3.4"], cwd=tmp_path, check=True
+    )
+
+    assert 'version = "2.3.4"' in (tmp_path / "Cargo.toml").read_text("utf-8")
+    assert 'version = "2.3.4"' in (tmp_path / "pyproject.toml").read_text("utf-8")
+    lock = (tmp_path / "Cargo.lock").read_text("utf-8")
+    assert 'name = "yamlrocks"\nversion = "2.3.4"' in lock
+    # The dependency pin is left exactly as it was.
+    assert 'name = "memchr"\nversion = "2.7.4"' in lock


### PR DESCRIPTION
## Breaking change

None. Release-tooling only; no library code, API, or runtime behavior changes.

## Proposed change

The v0.4.0 release failed: every wheel build errored with

```
error: cannot update the lock file Cargo.lock because --locked was passed to prevent this
💥 maturin failed
```

This release was the first to build wheels with `maturin ... --locked` (added in #136). The release flow's `set_version.py` rewrites the version in `Cargo.toml` and `pyproject.toml` from the tag, but never touched `Cargo.lock`. So after the bump the lock's own `yamlrocks` entry was still the old version, and `--locked` refused to let cargo update it, failing the build before a single wheel was produced.

`set_version.py` now also updates the crate's own `[[package]]` entry in `Cargo.lock` to match, deriving the crate name from the `[package]` table of `Cargo.toml` so a future rename cannot silently desync the lock. Dependency pins are left untouched.

Verified locally: after `set_version.py 0.4.0`, `cargo metadata --locked` exits 0 (it errored before). A new test in `tests/test_packaging.py` runs the real script against fixture manifests and asserts `Cargo.toml`, `pyproject.toml`, and the `Cargo.lock` self-entry all move to the new version together, while a dependency pin in the lock stays exactly as it was.

Note for re-shipping: `release.yaml` builds from the published tag's commit, so the existing `v0.4.0` tag (which predates this fix) must be re-pointed at a commit that includes this change before re-publishing.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: the failed v0.4.0 release build
- This PR is related to: #136 (which added `--locked` to the wheel builds)
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
