### PR TITLE
⚡ Speed up loads: bulk space skipping and right-sized event reserve

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -88,12 +88,18 @@ impl<'input> Parser<'input> {
 
     /// Parse all events from the input.
     pub fn parse_all(&mut self) -> Result<Vec<Event<'input>>, ScanError> {
-        // Preallocate from the source length (real YAML averages well under one
-        // event per several bytes), so the vector does not grow by repeated
-        // doubling and the copies that come with it. Capped so a crafted large
-        // input cannot force an outsized up-front allocation; past the cap the
+        // Preallocate from the source length. Structured YAML runs 2-4 bytes
+        // per event (a terse `k:` line is under 2), so a small document gets a
+        // full-density reserve (half its byte length): for a document that fits
+        // comfortably in one allocation, a single doubling right at the end of
+        // the parse costs more than the over-reserve. A large document instead
+        // gets the statistical density (an eighth): growth doublings amortize
+        // over its parse time, while a full-density reserve would allocate far
+        // past what scalar-heavy input ever fills. The cap keeps a crafted
+        // input from forcing an outsized up-front allocation; past it the
         // vector simply grows as before.
-        let mut events = Vec::with_capacity((self.input_len / 8).clamp(8, 65_536));
+        let estimate = (self.input_len / 8).max((self.input_len / 2).min(4096));
+        let mut events = Vec::with_capacity(estimate.clamp(8, 65_536));
         loop {
             let event = self.next_event()?;
             let is_end = matches!(event.kind, EventKind::StreamEnd);

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -146,11 +146,14 @@ impl<'input> Scanner<'input> {
     pub fn new(input: &'input str) -> Self {
         Self {
             reader: Reader::new(input),
-            tokens: VecDeque::new(),
-            indent_stack: Vec::new(),
+            // Pre-sized so ordinary documents never grow them: the token
+            // queue holds a handful of lookahead tokens and the indent stacks
+            // track block nesting depth.
+            tokens: VecDeque::with_capacity(16),
+            indent_stack: Vec::with_capacity(16),
             current_indent: -1,
             current_is_seq: false,
-            indent_kinds: Vec::new(),
+            indent_kinds: Vec::with_capacity(16),
             flow_level: 0,
             flow_value_seen: false,
             flow_need_sep: false,
@@ -486,7 +489,9 @@ impl<'input> Scanner<'input> {
         loop {
             match self.reader.peek() {
                 ' ' => {
-                    self.reader.advance();
+                    // Indentation and separation are runs of spaces; skip the
+                    // whole run in one pass rather than one byte per loop turn.
+                    self.reader.skip_spaces();
                 }
                 '\t' => {
                     if self.flow_level == 0 {
@@ -561,9 +566,7 @@ impl<'input> Scanner<'input> {
     /// Only skips spaces on the same line; does not cross line boundaries.
     fn check_value_after_scalar(&mut self) -> bool {
         let saved = self.reader.save();
-        while !self.reader.is_eof() && self.reader.peek() == ' ' {
-            self.reader.advance();
-        }
+        self.reader.skip_spaces();
         if !self.reader.is_eof() && self.reader.peek() == ':' {
             let next = self.reader.peek_next();
             if next.map_or(true, is_whitespace_or_break)

--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -247,6 +247,22 @@ impl<'input> Reader<'input> {
         is_whitespace_or_break_byte(self.input.as_bytes()[self.pos - 1])
     }
 
+    /// Bulk-skip a run of spaces, advancing the column by the run length.
+    ///
+    /// Spaces are single-byte, so the run is found with one tight byte scan and
+    /// `pos`/`column` update once, instead of a bounds-checked peek/advance
+    /// cycle per character. Indentation makes these runs long and frequent.
+    #[inline]
+    pub fn skip_spaces(&mut self) {
+        let bytes = self.input.as_bytes();
+        let mut i = self.pos;
+        while i < bytes.len() && bytes[i] == b' ' {
+            i += 1;
+        }
+        self.column += (i - self.pos) as u32;
+        self.pos = i;
+    }
+
     /// Advance by one character.
     #[inline]
     pub fn advance(&mut self) {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -52,7 +52,10 @@ use crate::roundtrip::ast::{YamlNode, YamlNodeKind};
 /// stack (the build paths grow the stack on demand via [`guard`], but a drop
 /// happens after those return).
 pub(crate) fn drop_value_tree(value: Value<'_>) {
-    let mut work = vec![value];
+    // Pre-sized so small trees drop with a single work-list allocation instead
+    // of doubling through the first pushes.
+    let mut work = Vec::with_capacity(32);
+    work.push(value);
     while let Some(node) = work.pop() {
         match node {
             Value::Sequence(items) => work.extend(items),


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None.

## Proposed change

Two allocation and scanning improvements on the `loads` fast path, found while profiling against other Rust-backed YAML parsers. No behavior changes, output is byte-identical.

**Bulk space skipping in the scanner.** `scan_to_next_token` consumed indentation one character at a time, paying two bounds-checked peeks plus position bookkeeping per space. The new `Reader::skip_spaces` consumes a whole run of spaces with a single byte scan and one `pos`/`column` update. On indentation-heavy documents the per-character cycle was ~8% of total instructions; callgrind measures a 2.8% instruction reduction on a 30-level nested document. `check_value_after_scalar` uses the same helper. The local skip helpers in `scalar.rs` are deliberately left untouched: routing them through the reader method regressed plain-scalar heavy documents by ~6% through inlining changes in that hot loop.

**Right-sized event vector reserve.** `parse_all` reserved one event per 8 input bytes, but measured densities on real payloads run 1.8 to 4 bytes per event (a terse `k:` line is under 2, a k8s manifest is ~4; only scalar-heavy documents are sparse at ~44). The old reserve therefore under-allocated nearly every structured document and paid a doubling, including its memcpy, right at the end of the parse (5.4% of instructions on small nested input). The reserve now uses full density for small documents, where a single doubling costs more than the over-reserve, and the statistical density for large ones, where growth amortizes and a full-density reserve would allocate far past what scalar-heavy input ever fills. The existing 65,536-event cap against crafted input is unchanged.

Also pre-sized: the scanner token queue, the indent stacks, and the iterative drop worklist, so ordinary documents never grow them.

All changes validated with callgrind instruction counts rather than wall time alone; wall time across rebuilds swings several percent on identical code from layout effects.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: performance work comparing against other Rust-backed YAML libraries

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
