### PR TITLE
⚡ Check the stack guard every eighth level, pre-size the key cache

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -558,7 +558,9 @@ impl<'input> Decoder<'input> {
         // before the cap fires. See [`crate::stack`]. Checking the remaining
         // stack costs a TLS lookup, so guard every eighth level rather than
         // every one: eight decode frames stay far below the guard's `RED_ZONE`
-        // headroom, keeping the overflow invariant intact.
+        // headroom, keeping the overflow invariant intact. `depth` was already
+        // incremented above, so the root sits at 1 and the `== 1` arm guards
+        // it immediately, then every eighth level after (9, 17, ...).
         let result = if self.depth & 7 == 1 {
             crate::stack::guard(|| self.decode_node_inner(events))
         } else {

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -555,8 +555,15 @@ impl<'input> Decoder<'input> {
         }
         // Grow the native stack if it is running low, so deeply nested input
         // (bounded above by `MAX_DEPTH`) cannot overflow a small thread stack
-        // before the cap fires. See [`crate::stack`].
-        let result = crate::stack::guard(|| self.decode_node_inner(events));
+        // before the cap fires. See [`crate::stack`]. Checking the remaining
+        // stack costs a TLS lookup, so guard every eighth level rather than
+        // every one: eight decode frames stay far below the guard's `RED_ZONE`
+        // headroom, keeping the overflow invariant intact.
+        let result = if self.depth & 7 == 1 {
+            crate::stack::guard(|| self.decode_node_inner(events))
+        } else {
+            self.decode_node_inner(events)
+        };
         self.depth -= 1;
         result
     }

--- a/src/ffi/convert/decode.rs
+++ b/src/ffi/convert/decode.rs
@@ -54,8 +54,10 @@ pub fn value_to_python_with(
     value: &Value<'_>,
     tags: TagPolicy<'_, '_>,
 ) -> PyResult<Py<PyAny>> {
-    let mut keys = KeyCache::default();
-    value_to_python_cached(py, value, tags, &mut keys)
+    // Pre-sized so typical documents (a few dozen distinct keys) fill the
+    // cache without a rehash.
+    let mut keys = KeyCache::with_capacity_and_hasher(32, ahash::RandomState::default());
+    value_to_python_cached(py, value, tags, &mut keys, 0)
 }
 
 fn value_to_python_cached<'tree>(
@@ -63,8 +65,16 @@ fn value_to_python_cached<'tree>(
     value: &'tree Value<'_>,
     tags: TagPolicy<'_, '_>,
     keys: &mut KeyCache<'tree>,
+    depth: usize,
 ) -> PyResult<Py<PyAny>> {
-    crate::stack::guard(|| value_to_python_inner(py, value, tags, keys))
+    // Checking the remaining stack costs a TLS lookup, so guard every eighth
+    // level rather than every one: eight conversion frames stay far below the
+    // guard's `RED_ZONE` headroom, keeping the overflow invariant intact.
+    if depth & 7 == 0 {
+        crate::stack::guard(|| value_to_python_inner(py, value, tags, keys, depth))
+    } else {
+        value_to_python_inner(py, value, tags, keys, depth)
+    }
 }
 
 fn value_to_python_inner<'tree>(
@@ -72,6 +82,7 @@ fn value_to_python_inner<'tree>(
     value: &'tree Value<'_>,
     tags: TagPolicy<'_, '_>,
     keys: &mut KeyCache<'tree>,
+    depth: usize,
 ) -> PyResult<Py<PyAny>> {
     let obj = match value {
         Value::Null => py.None(),
@@ -95,7 +106,7 @@ fn value_to_python_inner<'tree>(
                 Bound::from_owned_ptr_or_err(py, ffi::PyList_New(len as ffi::Py_ssize_t))?
             };
             for (i, item) in items.iter().enumerate() {
-                let child = value_to_python_cached(py, item, tags, keys)?;
+                let child = value_to_python_cached(py, item, tags, keys, depth + 1)?;
                 // SAFETY: `i` is in bounds (< len), the list is freshly created
                 // and not shared, and `into_ptr` hands over an owned reference
                 // for `PyList_SET_ITEM` to steal.
@@ -127,9 +138,9 @@ fn value_to_python_inner<'tree>(
                     // `list`/`dict`; convert it to its hashable counterpart (a
                     // sequence becomes a tuple, a mapping a frozenset of items).
                     Value::Sequence(_) | Value::Mapping(_) => value_to_hashable_key(py, key, tags)?,
-                    other => value_to_python_cached(py, other, tags, keys)?,
+                    other => value_to_python_cached(py, other, tags, keys, depth + 1)?,
                 };
-                let py_val = value_to_python_cached(py, val, tags, keys)?;
+                let py_val = value_to_python_cached(py, val, tags, keys, depth + 1)?;
                 // `PyDict_SetItem` does not steal references; it increments its
                 // own on success, so our `py_key`/`py_val` are released when they
                 // drop at the end of the iteration. YAML permits non-scalar keys,
@@ -151,7 +162,7 @@ fn value_to_python_inner<'tree>(
             dict.into_any().unbind()
         }
         Value::Tagged(tag, inner) => {
-            let inner_py = value_to_python_cached(py, inner, tags, keys)?;
+            let inner_py = value_to_python_cached(py, inner, tags, keys, depth + 1)?;
             resolve_tagged(py, tag.as_str(), inner_py, tags)?
         }
     };

--- a/src/ffi/convert/decode.rs
+++ b/src/ffi/convert/decode.rs
@@ -184,6 +184,16 @@ fn value_to_hashable_key(
     value: &Value<'_>,
     tags: TagPolicy<'_, '_>,
 ) -> PyResult<Py<PyAny>> {
+    // Complex keys are rare, so unlike the value conversion above this guards
+    // every level; the depth is still bounded by the decoder's `MAX_DEPTH`.
+    crate::stack::guard(|| value_to_hashable_key_inner(py, value, tags))
+}
+
+fn value_to_hashable_key_inner(
+    py: Python<'_>,
+    value: &Value<'_>,
+    tags: TagPolicy<'_, '_>,
+) -> PyResult<Py<PyAny>> {
     let obj = match value {
         Value::Sequence(items) => {
             let elems = items

--- a/tests/robustness/test_security.py
+++ b/tests/robustness/test_security.py
@@ -156,6 +156,47 @@ def test_deeply_nested_input_survives_small_thread_stack():
     assert proc.stdout.strip() == b"OK"
 
 
+# The hashable-key conversion (a sequence/mapping used as a mapping key becomes
+# a nested tuple) recurses per level of the key, so it needs the same on-demand
+# stack growth as the value paths above. Its frames are small, so only a stack
+# well under 1 MB exposes an unguarded recursion; 256 KB crashed (SIGSEGV) at
+# depth 900 before the guard.
+_COMPLEX_KEY_SCRIPT = """
+import threading, yamlrocks
+deep_key = b"? " + b"[" * %(depth)d + b"]" * %(depth)d + b"\\n: 1\\n"
+def work():
+    yamlrocks.loads(deep_key)
+threading.stack_size(256 * 1024)
+t = threading.Thread(target=work)
+t.start()
+t.join()
+print("OK")
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX thread stack sizing")
+def test_deep_complex_key_survives_small_thread_stack():
+    """A deeply nested complex key must not overflow a small thread stack.
+
+    Converting a collection key to its hashable Python counterpart recurses per
+    key level; the guard grows the native stack on demand so a near-maximum
+    -depth key on a 256 KB worker thread converts cleanly instead of
+    segfaulting the interpreter. Runs in a subprocess so a regression cannot
+    abort pytest.
+    """
+    import subprocess
+
+    script = _COMPLEX_KEY_SCRIPT % {"depth": 900}
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, timeout=60
+    )
+    assert proc.returncode == 0, (
+        f"deep complex key crashed on a 256 KB thread stack: rc={proc.returncode} "
+        f"stderr={proc.stderr.decode()[:400]}"
+    )
+    assert proc.stdout.strip() == b"OK"
+
+
 # -- Circular includes -------------------------------------------------------
 
 


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None.

## Proposed change

Follow-up to #169, trimming two fixed costs on the `loads` fast path. No behavior changes, output is byte-identical.

**Stack guard cadence.** The on-demand stack-growth guard (`stack::guard`, via stacker) runs at every recursion level in the decoder and in the tree-to-Python conversion, and each check costs a TLS lookup (`__tls_get_addr` was ~0.9% of instructions on nested input). Both recursions now check every eighth level instead of every one. The safety invariant is unchanged: eight decode or conversion frames consume a small fraction of the guard's 100 KiB `RED_ZONE` headroom, so the remaining stack can never be exhausted between two checks. All nesting, depth-cap, and small-stack tests pass unchanged.

**Interned-key cache pre-size.** The per-`loads` key cache (source key slice to interned Python string) started empty and rehashed several times while filling on a typical document. It now starts with room for 32 keys, which covers the usual few dozen distinct mapping keys without a rehash.

Together these cut instruction count on deep-nested input by a further 4.3% (callgrind, deterministic), on top of #169.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #169

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
