### PR TITLE
🐛 Make the PyYAML compat shim resolve scalars like PyYAML

### DIFF
--- a/pysrc/yamlrocks/compat.py
+++ b/pysrc/yamlrocks/compat.py
@@ -39,6 +39,14 @@ __all__ = [
 YAMLError = yamlrocks.YAMLRocksError
 
 
+# PyYAML's SafeLoader uses the YAML 1.1 resolver: `yes`/`no`/`on`/`off` are
+# booleans, `0777` is octal, `1_000` has underscores, and so on. To be a faithful
+# drop-in, the shim resolves scalars the same way via `OPT_PYYAML_COMPAT` (which
+# also keeps bare `y`/`n` as strings, exactly as PyYAML does). Without it, a
+# config like `enabled: yes` would silently load as the string `"yes"`.
+_COMPAT = yamlrocks.OPT_PYYAML_COMPAT
+
+
 def _read(stream: Any) -> Any:
     """Accept a str/bytes document or a file-like object, like PyYAML."""
     if hasattr(stream, "read"):
@@ -48,7 +56,7 @@ def _read(stream: Any) -> Any:
 
 def safe_load(stream: Any) -> Any:
     """Parse the first YAML document from ``stream`` (str, bytes, or file)."""
-    return yamlrocks.loads(_read(stream))
+    return yamlrocks.loads(_read(stream), option=_COMPAT)
 
 
 def safe_load_all(stream: Any) -> list[Any]:
@@ -57,7 +65,7 @@ def safe_load_all(stream: Any) -> list[Any]:
     PyYAML returns a generator; this returns a list, which is iterable in the
     same way for the common ``list(yaml.safe_load_all(...))`` usage.
     """
-    return yamlrocks.loads_all(_read(stream))
+    return yamlrocks.loads_all(_read(stream), option=_COMPAT)
 
 
 # YAMLRocks does not deserialize arbitrary Python objects, so the full-power
@@ -74,7 +82,10 @@ def load_all(stream: Any, Loader: Any = None) -> list[Any]:
 
 
 def _dump_options(default_flow_style: bool, sort_keys: bool, indent: int | None) -> int:
-    option = 0
+    # Target the PyYAML (1.1) schema on the way out too, so a dumped string that
+    # a 1.1 reader would read as a bool/number/timestamp (`yes`, `0777`, a date)
+    # is quoted, matching PyYAML's own output and keeping round-trips faithful.
+    option = _COMPAT
     if default_flow_style:
         option |= yamlrocks.OPT_FLOW_STYLE
     if sort_keys:

--- a/tests/compat/test_compat_shim.py
+++ b/tests/compat/test_compat_shim.py
@@ -34,6 +34,20 @@ def test_load_is_safe_load():
     assert yaml.load("a: 1", Loader=object()) == {"a": 1}
 
 
+def test_shim_resolves_scalars_like_pyyaml():
+    """As a PyYAML drop-in, the shim uses PyYAML's YAML 1.1 resolution: `yes`/`on`
+    are booleans, `0777` is octal, `1_000` has underscores. Without this the shim
+    would silently load a config's `enabled: yes` as the string `"yes"`."""
+    assert yaml.safe_load("v: yes") == {"v": True}
+    assert yaml.safe_load("v: 'no'") == {"v": "no"}  # quoted stays a string
+    assert yaml.safe_load("v: 0777") == {"v": 511}
+    assert yaml.safe_load("v: 1_000") == {"v": 1000}
+    # PyYAML omits bare y/n from booleans; the shim matches (they stay strings).
+    assert yaml.safe_load("v: y") == {"v": "y"}
+    # A string a 1.1 reader would coerce is quoted on the way out, so it survives.
+    assert yaml.safe_load(yaml.safe_dump({"v": "yes"})) == {"v": "yes"}
+
+
 def test_safe_dump_returns_str():
     """safe_dump returns a str when no stream is given."""
     out = yaml.safe_dump({"a": 1, "b": 2})


### PR DESCRIPTION
## Breaking change

The `yamlrocks.compat` shim's `safe_load`/`safe_load_all`/`safe_dump` now resolve scalars under PyYAML's YAML 1.1 rules instead of the YAML 1.2 core schema. Anyone who relied on the shim's previous (incorrect) 1.2 behavior will see a change: `yes`/`no`/`on`/`off` now become booleans, `0777` becomes octal `511`, `1_000` becomes `1000`. This is the whole point of a PyYAML drop-in, and it only affects the `compat` shim, not `yamlrocks.loads`/`dumps`. If you want 1.2 resolution, use `yamlrocks.loads` directly.

## Proposed change

The `compat` shim documents itself as a drop-in for PyYAML (`import yamlrocks.compat as yaml`), but `safe_load`/`safe_load_all` called `yamlrocks.loads` with no option, so scalars resolved under the 1.2 core schema. PyYAML's `SafeLoader` uses the YAML 1.1 resolver, so a config like `enabled: yes` silently loaded as the string `"yes"` rather than `True`. Across 25 common scalar forms, 13 differed from PyYAML.

This wires `OPT_PYYAML_COMPAT` into the shim's load and dump paths. Scalar resolution now matches PyYAML (`yes`/`on` booleans, octal, underscores), bare `y`/`n` stay strings exactly as PyYAML does, and a dumped string that a 1.1 reader would coerce is quoted so it round-trips. Sampled parity goes from 13/25 differing to 0/25.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
