### PR TITLE
🐛 Keep leading-zero sexagesimal values as strings under YAML 1.1

### DIFF
--- a/docs/src/content/docs/reference/options.md
+++ b/docs/src/content/docs/reference/options.md
@@ -58,14 +58,14 @@ yamlrocks.loads(b"a: yes", option=yamlrocks.OPT_YAML_1_1)  # {'a': True}
 ```
 
 The same flag makes `dumps` produce 1.1-safe output: a string only YAML 1.1 reads
-as a non-string (a bare `y`/`n`, or sexagesimal like `01:02:03`) is quoted, so it
+as a non-string (a bare `y`/`n`, or sexagesimal like `10:20:30`) is quoted, so it
 survives a round-trip through a 1.1 reader:
 
 ```python
 import yamlrocks
 
-yamlrocks.dumps({"mac": "01:02:03"})                              # b'mac: 01:02:03\n'
-yamlrocks.dumps({"mac": "01:02:03"}, option=yamlrocks.OPT_YAML_1_1)  # b'mac: "01:02:03"\n'
+yamlrocks.dumps({"elapsed": "10:20:30"})                              # b'elapsed: 10:20:30\n'
+yamlrocks.dumps({"elapsed": "10:20:30"}, option=yamlrocks.OPT_YAML_1_1)  # b'elapsed: "10:20:30"\n'
 ```
 
 `OPT_DUPLICATE_KEYS_ERROR` rejects a repeated key with the offending location in

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -845,7 +845,7 @@ pub(crate) fn needs_quoting(value: &str, schema: Schema) -> bool {
     //
     // When the output targets a YAML 1.1 schema, quote exactly what *that* schema
     // re-reads as a number, so the value survives a round-trip through it. Both
-    // 1.1 variants read sexagesimal (`1:30`, MAC-like `01:02:03`) and leading-
+    // 1.1 variants read sexagesimal (`1:30`, `10:20:30`) and leading-
     // underscore numerics (`_5`); PyYAML-compat differs from strict 1.1 only in
     // its boolean set (the bare `y`/`n` case handled above), not in numbers. The
     // 1.2 default keeps its conservative cross-schema quoting: it quotes 1.1
@@ -1182,17 +1182,17 @@ mod tests {
 
     #[test]
     fn yaml_1_1_quotes_what_its_schema_reads_as_non_strings() {
-        // `y`/`N` are booleans only under strict 1.1; sexagesimal (`01:02:03`) is
+        // `y`/`N` are booleans only under strict 1.1; sexagesimal (`10:20:30`) is
         // a number under both 1.1 variants. Each schema quotes exactly what it
         // would re-read as a non-string, so the output round-trips under it.
         let v = Value::Mapping(vec![
             (s("a"), s("y")),
             (s("b"), s("N")),
-            (s("c"), s("01:02:03")),
+            (s("c"), s("10:20:30")),
         ]);
         // Default (1.2): none of these are non-strings, so all bare.
         let dflt = emit(&v, &EmitOptions::default());
-        assert_eq!(dflt, "a: y\nb: N\nc: 01:02:03\n");
+        assert_eq!(dflt, "a: y\nb: N\nc: 10:20:30\n");
         // Strict 1.1: bare `y`/`N` bools and sexagesimal all quoted.
         let y11 = emit(
             &v,
@@ -1201,9 +1201,9 @@ mod tests {
                 ..EmitOptions::default()
             },
         );
-        assert_eq!(y11, "a: \"y\"\nb: \"N\"\nc: \"01:02:03\"\n");
+        assert_eq!(y11, "a: \"y\"\nb: \"N\"\nc: \"10:20:30\"\n");
         // PyYAML-compat 1.1: bare `y`/`N` are NOT booleans (left bare), but it
-        // still reads sexagesimal, so `01:02:03` is quoted.
+        // still reads sexagesimal, so `10:20:30` is quoted.
         let pyyaml = emit(
             &v,
             &EmitOptions {
@@ -1211,7 +1211,7 @@ mod tests {
                 ..EmitOptions::default()
             },
         );
-        assert_eq!(pyyaml, "a: y\nb: N\nc: \"01:02:03\"\n");
+        assert_eq!(pyyaml, "a: y\nb: N\nc: \"10:20:30\"\n");
     }
 
     #[test]

--- a/src/resolver/yaml11.rs
+++ b/src/resolver/yaml11.rs
@@ -199,6 +199,10 @@ fn try_parse_int_11(value: &str) -> Option<i64> {
 }
 
 fn parse_sexagesimal_int(value: &str) -> Option<i64> {
+    // The YAML 1.1 int sexagesimal production is `[-+]?[1-9][0-9_]*(:[0-5]?[0-9])+`
+    // (PyYAML matches it exactly). The leading segment must start `1`-`9`, so a
+    // leading-zero first segment (`03:30`, `0:30`, a time of day) is a string,
+    // not base-60. The float form allows a leading zero, so it is handled apart.
     let mut result: i64 = 0;
     for (i, part) in value.split(':').enumerate() {
         // A per-segment sign (`5:+30`) is not sexagesimal; the value's own sign is
@@ -207,12 +211,18 @@ fn parse_sexagesimal_int(value: &str) -> Option<i64> {
             return None;
         }
         let n: i64 = part.parse().ok()?;
-        // Only the leading segment may exceed 59 (e.g. `90:00`); every later
-        // segment is a base-60 digit and must stay in 0..60. Keying this off the
-        // position rather than the running total keeps a legitimate leading `0`
-        // (as in `0:30`) from being mistaken for the first segment again later.
-        if i > 0 && !(0..60).contains(&n) {
-            return None;
+        if i == 0 {
+            // The leading segment matches `[1-9][0-9]*`: it may exceed 59
+            // (`90:00`) but must not start with `0`.
+            if part.starts_with('0') {
+                return None;
+            }
+        } else {
+            // Every later segment is a base-60 digit `[0-5]?[0-9]`: one or two
+            // digits, staying in 0..60.
+            if part.len() > 2 || !(0..60).contains(&n) {
+                return None;
+            }
         }
         // A value too large to hold in an i64 is not representable as an int, so
         // fall back to a string (`None`) instead of overflowing, exactly as the
@@ -446,10 +456,24 @@ mod tests {
         // Classic base-60: 1:30 == 90, and a leading segment may exceed 59.
         assert_eq!(plain("1:30"), ResolvedValue::Int(90));
         assert_eq!(plain("90:00"), ResolvedValue::Int(5400));
-        // A leading zero segment must not be mistaken for "no segment yet": a
-        // later out-of-range segment is still rejected.
-        assert_eq!(plain("0:30"), ResolvedValue::Int(30));
-        assert!(matches!(plain("0:90"), ResolvedValue::String(_)));
+        assert_eq!(plain("1:2:3"), ResolvedValue::Int(3723));
+        // The spec production is `[1-9][0-9_]*(:[0-5]?[0-9])+`: a leading-zero
+        // first segment is NOT base-60 but a plain string, so a time of day like
+        // `03:30` stays `"03:30"` and does not become 210 (PyYAML agrees).
+        for value in ["0:30", "03:30", "00:00", "023:30"] {
+            assert!(
+                matches!(plain(value), ResolvedValue::String(_)),
+                "{value:?}"
+            );
+        }
+        // A later segment is a single base-60 digit `[0-5]?[0-9]`: out of range
+        // (`1:90`) or more than two digits (`1:030`) falls back to a string.
+        for value in ["1:90", "1:030"] {
+            assert!(
+                matches!(plain(value), ResolvedValue::String(_)),
+                "{value:?}"
+            );
+        }
         // A chain long enough to overflow i64 during base-60 accumulation must
         // fall back to a string, not panic (debug) or wrap (release). Found by
         // the `decode` fuzz target.

--- a/tests/core/test_dumps.py
+++ b/tests/core/test_dumps.py
@@ -503,7 +503,7 @@ Y11 = yamlrocks.OPT_YAML_1_1
 PYC = yamlrocks.OPT_PYYAML_COMPAT
 
 
-@pytest.mark.parametrize("value", ["y", "Y", "n", "N", "1:30", "01:02:03", "_5"])
+@pytest.mark.parametrize("value", ["y", "Y", "n", "N", "1:30", "10:20:30", "_5"])
 def test_dumps_yaml_1_1_quotes_its_ambiguities_but_default_does_not(value):
     """Strict 1.1 quotes a string it reads as a non-string; the 1.2 default does not."""
     assert b'"' not in yamlrocks.dumps({"k": value})
@@ -511,7 +511,7 @@ def test_dumps_yaml_1_1_quotes_its_ambiguities_but_default_does_not(value):
 
 
 @pytest.mark.parametrize("schema", [Y11, PYC])
-@pytest.mark.parametrize("value", ["1:30", "01:02:03", "_5", "yes", "0777", "on"])
+@pytest.mark.parametrize("value", ["1:30", "10:20:30", "_5", "yes", "0777", "on"])
 def test_dumps_1_1_output_round_trips_under_its_schema(schema, value):
     """1.1 and PyYAML-compat dump output re-reads identically under the same schema."""
     obj = {"k": value}

--- a/tests/core/test_yaml_1_1.py
+++ b/tests/core/test_yaml_1_1.py
@@ -116,6 +116,18 @@ def test_negative_sexagesimal():
     assert load11("-1:30") == -90
 
 
+@pytest.mark.parametrize("text", ["03:30", "0:30", "00:00", "023:30", "1:030", "1:90"])
+def test_leading_zero_and_out_of_range_sexagesimal_stay_strings(text):
+    """The 1.1 int production is `[1-9][0-9_]*(:[0-5]?[0-9])+`: a leading-zero
+    first segment (a time of day like `03:30`) or an out-of-range/oversized
+    later segment is a plain string, not base-60. PyYAML agrees."""
+    assert load11(text) == text
+    assert (
+        yamlrocks.loads(f"x: {text}".encode(), option=yamlrocks.OPT_PYYAML_COMPAT)["x"]
+        == text
+    )
+
+
 def test_underscores_in_float():
     """Strip underscores from floats under OPT_YAML_1_1."""
     assert load11("1_000.5") == 1000.5

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -274,7 +274,7 @@ def test_round_trip_keeps_valid_complex_and_flow_keys(src):
 # original text; only the edited value is re-quoted.)
 
 
-@pytest.mark.parametrize("value", ["y", "01:02:03", "_5"])
+@pytest.mark.parametrize("value", ["y", "10:20:30", "_5"])
 def test_edit_in_a_1_1_document_is_quoted_1_1_safely(value):
     """An edit into a 1.1-loaded document is quoted so it re-reads as a string under 1.1."""
     doc = yamlrocks.loads(b"k: hello\n", option=RT | yamlrocks.OPT_YAML_1_1)


### PR DESCRIPTION
## Breaking change

Under `OPT_YAML_1_1` and `OPT_PYYAML_COMPAT`, a leading-zero sexagesimal value like `03:30` now resolves to the string `"03:30"` instead of the base-60 integer `210`. This matches PyYAML and ruamel. Anyone who (incorrectly) relied on `03:30` becoming `210` will see the string instead, but that was silent data corruption of a common time-of-day value, so the change is a fix. The default YAML 1.2 schema never resolved sexagesimal and is unaffected.

## Proposed change

The YAML 1.1 integer sexagesimal production is `[-+]?[1-9][0-9_]*(:[0-5]?[0-9])+`: the leading segment must start `1`-`9`, and every later segment is one or two base-60 digits. `parse_sexagesimal_int` only rejected a per-segment sign, so `03:30` parsed as `210`, and `1:030` as `60`. A time of day in a Home Assistant / ESPHome / Ansible config silently became an integer.

This enforces the spec production: a leading-zero first segment (`03:30`, `0:30`, `00:00`, `023:30`) and an oversized later segment (`1:030`) now stay strings. Genuine base-60 values (`1:30`, `90:00`, `1:2:3`) still resolve. A shared 1.1 dump test that used `01:02:03` as a sexagesimal example now uses `10:20:30`, since `01:02:03` is correctly a string.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
