### PR TITLE
🐛 Reject a lone-surrogate str in dumps instead of emitting U+FFFD

### DIFF
--- a/src/ffi/convert/encode.rs
+++ b/src/ffi/convert/encode.rs
@@ -12,6 +12,23 @@ use crate::typeref;
 
 use super::EncodeCtx;
 
+/// Extract a Python `str` as an owned UTF-8 `String`, rejecting unpaired
+/// surrogates rather than silently replacing them with U+FFFD. PyO3's `Display`
+/// (`to_string`) is lossy; `to_str` is strict. This keeps any data loss visible,
+/// matching the strict `bytes` branch and the decode side, so a `str` carrying a
+/// lone surrogate (from `surrogateescape`/`surrogatepass`) errors instead of
+/// emitting mojibake that no longer round-trips.
+fn pystring_to_string(s: &Bound<'_, PyString>) -> PyResult<String> {
+    s.to_str().map(str::to_owned).map_err(|_| {
+        errors::encode_error(
+            "cannot serialize a str containing unpaired surrogates; convert it to \
+             valid Unicode (or recover the original bytes and handle them \
+             explicitly) before dumping"
+                .to_string(),
+        )
+    })
+}
+
 // -- Python -> Value (for dumps) --
 /// Maximum object nesting depth when serializing. A deeply nested or cyclic
 /// (self-referential) Python object would otherwise recurse without bound and
@@ -55,7 +72,9 @@ fn python_to_value_inner(
     // check and fall through to the unchanged slow path, so behavior is
     // identical; only the common case gets faster.
     if typeref::is_exact_str(obj) {
-        return Ok(Value::String(obj.cast::<PyString>()?.to_string().into()));
+        return Ok(Value::String(
+            pystring_to_string(obj.cast::<PyString>()?)?.into(),
+        ));
     }
     if typeref::is_exact_int(obj) {
         return int_to_value(obj);
@@ -84,7 +103,7 @@ fn python_to_value_inner(
         return Ok(Value::Float(obj.extract()?));
     }
     if let Ok(s) = obj.cast::<PyString>() {
-        return Ok(Value::String(s.to_string().into()));
+        return Ok(Value::String(pystring_to_string(s)?.into()));
     }
     if let Ok(b) = obj.cast::<PyBytes>() {
         // Decode strictly: silently replacing invalid UTF-8 would corrupt

--- a/tests/core/test_dumps.py
+++ b/tests/core/test_dumps.py
@@ -47,6 +47,21 @@ def test_dumps_invalid_utf8_bytes_is_rejected():
         yamlrocks.dumps({"k": b"\xff\xfe"})
 
 
+@pytest.mark.parametrize(
+    "obj",
+    [
+        "\ud800",  # bare lone surrogate
+        b"file\xff.txt".decode("utf-8", "surrogateescape"),  # surrogateescape
+        {b"k\xff".decode("utf-8", "surrogateescape"): 1},  # as a mapping key
+        ["\udcff"],  # inside a sequence
+    ],
+)
+def test_dumps_lone_surrogate_str_is_rejected(obj):
+    """A str with an unpaired surrogate raises instead of being replaced by U+FFFD."""
+    with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="surrogate"):
+        yamlrocks.dumps(obj)
+
+
 def test_dumps_empty_collections_use_flow():
     """Dump empty mappings and sequences using flow style."""
     assert yamlrocks.dumps({"a": {}, "b": []}) == b"a: {}\nb: []\n"


### PR DESCRIPTION
## Breaking change

None. A `str` containing an unpaired surrogate previously dumped to mojibake (U+FFFD); it now raises `YAMLRocksEncodeError`. That input never round-tripped, so no correct program relied on the old behavior.

## Proposed change

The `str`-encode path in `python_to_value` used PyO3's `Display` (`to_string`), which lossily replaces an unpaired surrogate with U+FFFD. So `dumps` of a `str` carrying a lone surrogate (from `surrogateescape`/`surrogatepass`, e.g. `os.fsdecode` of a non-UTF-8 filename) silently corrupted the value and `loads(dumps(x)) != x`. The sibling `bytes` branch and the decode side both already reject this to keep data loss visible.

This extracts `str` via the strict `to_str`, raising `YAMLRocksEncodeError` on a lone surrogate, so the `str` path matches the `bytes` and decode paths. Covers a value, a mapping key, and a sequence element.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
