### PR TITLE
🐛 Preserve Decimal precision in dumps instead of routing through f64

### DIFF
--- a/src/ffi/convert/encode.rs
+++ b/src/ffi/convert/encode.rs
@@ -457,10 +457,7 @@ fn special_type_to_value(
     };
     match type_name.as_str() {
         "Decimal" if type_module()? == "decimal" => {
-            if let Ok(f) = obj.extract::<f64>() {
-                return Ok(Some(Value::Float(f)));
-            }
-            return Ok(Some(Value::String(obj.str()?.to_string().into())));
+            return decimal_to_value(py, obj);
         }
         "UUID" if type_module()? == "uuid" => {
             return Ok(Some(Value::String(obj.str()?.to_string().into())))
@@ -477,6 +474,45 @@ fn special_type_to_value(
     }
 
     Ok(None)
+}
+
+/// Convert a `decimal.Decimal` to a `Value` without silently losing precision.
+///
+/// The old path extracted an `f64`, which rounds a 30-digit integer or a
+/// high-precision fraction down to a double. Instead:
+/// - a non-finite Decimal (`NaN`/`Infinity`) keeps the `f64` path, so it renders
+///   as `.nan`/`.inf` like any float;
+/// - an integral Decimal becomes a `BigInt` of its exact digits (arbitrary
+///   precision, re-reads as an `int`);
+/// - a fractional Decimal that an `f64` captures exactly (its shortest repr
+///   round-trips back to the same Decimal) becomes that `Float`, so a plain
+///   `Decimal("3.14")` still emits as `3.14`;
+/// - any other fractional Decimal keeps its exact digits as a string, so the
+///   value is preserved in the output rather than rounded away.
+fn decimal_to_value(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Option<Value<'static>>> {
+    // `is_finite` is false for NaN/Infinity; fall back to the float rendering.
+    if !obj.call_method0("is_finite")?.extract::<bool>()? {
+        let f = obj.extract::<f64>().unwrap_or(f64::NAN);
+        return Ok(Some(Value::Float(f)));
+    }
+    // Fixed-point form (`format(d, "f")`) gives the exact digits with no
+    // scientific `E` notation, so `Decimal("1E+29")` becomes `100...0`.
+    let fixed: String = obj.call_method1("__format__", ("f",))?.extract()?;
+    if !fixed.contains('.') {
+        return Ok(Some(Value::BigInt(fixed.into())));
+    }
+    // Emit as a plain float when an f64 captures the value to full working
+    // precision, i.e. the float's shortest repr round-trips back to the same
+    // Decimal (`Decimal(repr(float(d))) == d`).
+    if let Ok(f) = obj.extract::<f64>() {
+        let repr = pyo3::types::PyFloat::new(py, f).repr()?;
+        let round_tripped = obj.get_type().call1((repr,))?;
+        if obj.eq(&round_tripped)? {
+            return Ok(Some(Value::Float(f)));
+        }
+    }
+    // Higher precision than an f64 can hold: keep the exact digits verbatim.
+    Ok(Some(Value::String(fixed.into())))
 }
 
 /// Whether `obj` is an `enum.Enum` instance (detected via its metaclass).

--- a/src/ffi/convert/encode.rs
+++ b/src/ffi/convert/encode.rs
@@ -12,6 +12,23 @@ use crate::typeref;
 
 use super::EncodeCtx;
 
+/// Extract a Python `str` as an owned UTF-8 `String`, rejecting unpaired
+/// surrogates rather than silently replacing them with U+FFFD. PyO3's `Display`
+/// (`to_string`) is lossy; `to_str` is strict. This keeps any data loss visible,
+/// matching the strict `bytes` branch and the decode side, so a `str` carrying a
+/// lone surrogate (from `surrogateescape`/`surrogatepass`) errors instead of
+/// emitting mojibake that no longer round-trips.
+fn pystring_to_string(s: &Bound<'_, PyString>) -> PyResult<String> {
+    s.to_str().map(str::to_owned).map_err(|_| {
+        errors::encode_error(
+            "cannot serialize a str containing unpaired surrogates; convert it to \
+             valid Unicode (or recover the original bytes and handle them \
+             explicitly) before dumping"
+                .to_string(),
+        )
+    })
+}
+
 // -- Python -> Value (for dumps) --
 /// Maximum object nesting depth when serializing. A deeply nested or cyclic
 /// (self-referential) Python object would otherwise recurse without bound and
@@ -55,7 +72,9 @@ fn python_to_value_inner(
     // check and fall through to the unchanged slow path, so behavior is
     // identical; only the common case gets faster.
     if typeref::is_exact_str(obj) {
-        return Ok(Value::String(obj.cast::<PyString>()?.to_string().into()));
+        return Ok(Value::String(
+            pystring_to_string(obj.cast::<PyString>()?)?.into(),
+        ));
     }
     if typeref::is_exact_int(obj) {
         return int_to_value(obj);
@@ -84,7 +103,7 @@ fn python_to_value_inner(
         return Ok(Value::Float(obj.extract()?));
     }
     if let Ok(s) = obj.cast::<PyString>() {
-        return Ok(Value::String(s.to_string().into()));
+        return Ok(Value::String(pystring_to_string(s)?.into()));
     }
     if let Ok(b) = obj.cast::<PyBytes>() {
         // Decode strictly: silently replacing invalid UTF-8 would corrupt

--- a/tests/core/test_dumps.py
+++ b/tests/core/test_dumps.py
@@ -47,6 +47,21 @@ def test_dumps_invalid_utf8_bytes_is_rejected():
         yamlrocks.dumps({"k": b"\xff\xfe"})
 
 
+@pytest.mark.parametrize(
+    "obj",
+    [
+        "\ud800",  # bare lone surrogate
+        b"file\xff.txt".decode("utf-8", "surrogateescape"),  # surrogateescape
+        {b"k\xff".decode("utf-8", "surrogateescape"): 1},  # as a mapping key
+        ["\udcff"],  # inside a sequence
+    ],
+)
+def test_dumps_lone_surrogate_str_is_rejected(obj):
+    """A str with an unpaired surrogate raises instead of being replaced by U+FFFD."""
+    with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="surrogate"):
+        yamlrocks.dumps(obj)
+
+
 def test_dumps_empty_collections_use_flow():
     """Dump empty mappings and sequences using flow style."""
     assert yamlrocks.dumps({"a": {}, "b": []}) == b"a: {}\nb: []\n"

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -173,6 +173,19 @@ def test_decimal_is_number():
     assert _dump_load({"v": decimal.Decimal("3.14")}) == {"v": 3.14}
 
 
+def test_decimal_preserves_precision_not_via_f64():
+    """A Decimal carrying more precision than an f64 holds keeps its exact digits
+    in the output rather than rounding through a double. A large integral Decimal
+    stays an exact integer; a high-precision fraction keeps its full text."""
+    import yamlrocks
+
+    big = decimal.Decimal("100000000000000000000000000001")
+    assert yamlrocks.dumps(big).strip() == b"100000000000000000000000000001"
+    assert yamlrocks.loads(yamlrocks.dumps(big)) == 100000000000000000000000000001
+    frac = "3.141592653589793238462643383279"
+    assert frac.encode() in yamlrocks.dumps(decimal.Decimal(frac))
+
+
 def test_pathlib_path():
     """pathlib.Path serializes to its string representation."""
     # str(Path) is OS-native (forward slashes on POSIX, backslashes on Windows),


### PR DESCRIPTION
> Stacked on #176 (lone-surrogate fix); both touch `src/ffi/convert/encode.rs`. The base will retarget to `main` once #176 merges. Review only the top commit here.

## Breaking change

A `decimal.Decimal` with more precision than an `f64` holds now dumps to its exact digits rather than a rounded double: a large integral Decimal emits as an exact integer (was `1.0e+29`), and a high-precision fraction keeps its full text (as a quoted string, since a YAML float would round it on reload). A plain `Decimal("3.14")` still emits as `3.14`. Output changes only for Decimals that were previously being rounded, i.e. silently corrupted.

## Proposed change

`dumps` of a `Decimal` extracted an `f64`, so `Decimal("100000000000000000000000000001")` became `1.0e+29` and high-precision fractions were truncated. A `Decimal` is used precisely because `float` is not good enough, so coercing through `f64` defeats its purpose.

`decimal_to_value` converts without loss: non-finite → the float rendering (`.nan`/`.inf`); integral → a `BigInt` of the exact digits (arbitrary precision, re-reads as `int`); a fraction an `f64` captures exactly (shortest-repr round-trip) → that `Float`, so `Decimal("3.14")` stays `3.14`; any higher-precision fraction → its exact digits verbatim.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
