### PR TITLE
🐛 Emit compact scientific notation for large/small floats in to_json

### DIFF
--- a/src/encode/json.rs
+++ b/src/encode/json.rs
@@ -75,13 +75,13 @@ fn write_float(out: &mut String, value: f64) {
         out.push_str("null");
         return;
     }
-    let s = format!("{value}");
-    // Keep floats distinguishable from integers (`1.0`, not `1`).
-    if s.contains(['.', 'e', 'E']) {
-        out.push_str(&s);
-    } else {
-        let _ = write!(out, "{s}.0");
-    }
+    // Reuse the shared canonical spelling (the YAML path uses it too), so a large
+    // or tiny magnitude emits in scientific notation (`1.0e+16`) rather than
+    // Rust's default `{}`, which never uses exponents and would expand `1e100` to
+    // 101 digits. The `.`/mantissa keeps it distinguishable from an integer, and
+    // the special values are already handled above (so `.inf`/`.nan` never reach
+    // here). The exponent form (`1.0e+16`) is valid JSON and parses back exactly.
+    out.push_str(&crate::emit_util::canonical_float(value));
 }
 
 fn write_array(

--- a/tests/core/test_json.py
+++ b/tests/core/test_json.py
@@ -43,6 +43,19 @@ def test_non_finite_floats_become_null():
     )
 
 
+@pytest.mark.parametrize(
+    "value", [1e16, 1e-7, 1e100, 1.7976931348623157e308, 5e-324, 0.1]
+)
+def test_large_and_tiny_floats_use_compact_scientific_notation(value):
+    """A large- or small-magnitude float emits in compact scientific notation
+    (e.g. `1.0e+16`), not a full positional decimal that balloons to hundreds of
+    digits, and it round-trips exactly through stdlib json."""
+    out = yamlrocks.to_json({"v": value})
+    # No grotesque expansion: `1e100` must not become a 100-digit string.
+    assert len(out) < 40
+    assert json.loads(out)["v"] == value
+
+
 def test_non_string_scalar_keys_are_stringified():
     """Int/bool/null/float keys stringify to their JSON scalar text."""
     assert yamlrocks.to_json({None: 1}) == b'{"null":1}'


### PR DESCRIPTION
## Breaking change

None. `to_json` float *values* are unchanged and still parse to the same number; only the textual spelling of large/small-magnitude floats changes (e.g. `1e100` was a 101-digit decimal, now `1.0e+100`).

## Proposed change

`to_json` rendered floats with Rust's default `Display`, which never uses exponential notation, so `1e16` became `10000000000000000.0` and `1e100` a 101-digit string. The values were valid JSON but the output ballooned and diverged from stdlib `json`, orjson, and yamlrocks's own `dumps`.

`write_float` now routes through the shared `emit_util::canonical_float` (the YAML path already uses it), so a large or tiny magnitude emits as `1.0e+16`. The mantissa's dot keeps it distinguishable from an integer, non-finite values still project to `null`, and the exponent form is valid JSON that parses back exactly.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
