### PR TITLE
🐛 Parse an empty flow-mapping key as null instead of swapping key and value

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -788,11 +788,16 @@ impl<'input> Decoder<'input> {
 
             // A bare `Key` here means an empty value followed by a sibling key
             // at the same indent (a nested mapping is always preceded by
-            // `MappingStart`). The value is null; do not consume the key. The
+            // `MappingStart`). The value is null; do not consume the key. A
+            // `Value` marks a `:` separator, so meeting one while decoding a
+            // node means that node (an empty key like `{: 1}` or `{? : 1}`, or
+            // an empty value) is null; leave the `:` for the caller to consume,
+            // otherwise the following scalar would be misread as this node. The
             // collection-end markers are likewise not nodes, returning without
             // consuming lets the enclosing collection see its own terminator
             // rather than silently swallowing it.
             EventKind::Key { .. }
+            | EventKind::Value
             | EventKind::StreamEnd
             | EventKind::DocumentEnd
             | EventKind::DocumentStart
@@ -1044,9 +1049,21 @@ impl<'input> Decoder<'input> {
             return Ok(Some(Value::Mapping(vec![(key, val)])));
         }
         let key_span = events.get(self.pos).map(|e| e.span).unwrap_or_default();
-        let Some(key) = self.decode_node(events)? else {
-            return Ok(None);
-        };
+        // An implicit single-pair mapping whose key is empty (`[: v]`): the `:`
+        // has no preceding node, so `decode_node` stops on the `Value` without
+        // consuming it. The key is null and the `Value` branch below builds the
+        // pair. Distinguish this from a genuine end (where `decode_node` also
+        // returns `None`) by checking for the `Value` marker first.
+        let key =
+            if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value)
+            {
+                Value::Null
+            } else {
+                match self.decode_node(events)? {
+                    Some(key) => key,
+                    None => return Ok(None),
+                }
+            };
         // Implicit single-pair mapping with no `Key` marker (e.g. an anchored
         // key `[&c c: d]`): a `:` follows the node.
         if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value) {

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -949,6 +949,24 @@ impl<'input> Composer<'input> {
             ));
         }
 
+        // An implicit single-pair mapping with an empty key (`[: v]`): a `:` with
+        // no preceding node opens the pair, so the key is null (mirrors the fast
+        // path's empty-key handling in `decode_sequence_item`).
+        if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value) {
+            let pair_span = events[self.pos].span;
+            self.pos += 1;
+            let val = self
+                .compose_node(events)?
+                .unwrap_or_else(|| null(pair_span));
+            return Ok(Some(
+                YamlNode::new(
+                    YamlNodeKind::Mapping(vec![(null(pair_span), val)]),
+                    pair_span,
+                )
+                .with_style(NodeStyle::Flow),
+            ));
+        }
+
         let Some(key) = self.compose_node(events)? else {
             return Ok(None);
         };

--- a/tests/core/test_loads.py
+++ b/tests/core/test_loads.py
@@ -70,6 +70,35 @@ def test_flow_mapping_bare_keys_are_null():
     }
 
 
+def test_flow_mapping_empty_key_is_null_not_swapped():
+    """An empty flow-mapping key (`{: v}`, `{? : v}`) is `{null: v}`, not swapped."""
+    assert yamlrocks.loads(b"{: 1}") == {None: 1}
+    assert yamlrocks.loads(b"{? : 1}") == {None: 1}
+    assert yamlrocks.loads(b"{a: 1, : 2}") == {"a": 1, None: 2}
+    assert yamlrocks.loads(b"{:}") == {None: None}
+    assert yamlrocks.loads(b"[{: 1}]") == [{None: 1}]
+    assert yamlrocks.loads(b"[: v]") == [{None: "v"}]
+
+
+def test_block_mapping_empty_key_is_null():
+    """A block-mapping entry with an empty key (`: 1`, `:`) is `{null: ...}`."""
+    assert yamlrocks.loads(b": 1") == {None: 1}
+    assert yamlrocks.loads(b":") == {None: None}
+    assert yamlrocks.loads(b": 1", option=yamlrocks.OPT_ANNOTATED) == {None: 1}
+
+
+def test_flow_sequence_single_pair_empty_key_round_trips():
+    """An empty-key flow single pair (`[: v]`) survives the round-trip path.
+
+    The round-trip composer must mirror the fast path here: the element is a
+    one-entry mapping `{null: v}`, not a dropped node, and re-emitting stays
+    byte-for-byte.
+    """
+    assert yamlrocks.loads(b"[: v]", option=yamlrocks.OPT_ANNOTATED) == [{None: "v"}]
+    doc = yamlrocks.loads(b"[: v]\n", option=yamlrocks.OPT_ROUND_TRIP)
+    assert yamlrocks.dumps(doc) == b"[: v]\n"
+
+
 def test_flow_sequence():
     """Parse a flow-style sequence into a list."""
     assert yamlrocks.loads(b"[1, 2, 3]") == [1, 2, 3]


### PR DESCRIPTION
## Breaking change

None. `{: 1}` previously decoded to `{1: None}` (silent corruption) and now decodes to `{None: 1}`, matching PyYAML and ruamel. No correct program relied on the swapped form.

## Proposed change

An empty key in a flow mapping (`{: 1}`, `{? : 1}`, or a later `{a: 1, : 2}` entry) was decoded with the value promoted to the key and a null value, so `{: 1}` became `{1: None}` instead of `{None: 1}`. PyYAML and ruamel both read it as `{None: 1}`.

In `decode_node`, a `Value` event (a `:` separator) met while decoding a node now yields an empty (null) node without consuming the `:`, instead of skipping it and misreading the following scalar as the node. `decode_sequence_item` handles the implicit empty-key single-pair entry (`[: v]` is `[{null: v}]`). Covers block-mapping, flow-mapping, and flow-sequence forms.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
