### PR TITLE
🐛 Clear anchors between documents in the implicit-document path

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -504,6 +504,11 @@ impl<'input> Decoder<'input> {
                     }
                     directives_allowed = false;
                     self.tag_handles.clear();
+                    // Anchors do not span documents (same as the explicit `---`
+                    // arm above): an `&a` in this implicit document must not be
+                    // resolvable by an `*a` in the next, or a cross-document
+                    // reference silently resolves instead of raising.
+                    self.anchors.clear();
                     // `decode_node` returns `None` without consuming on a bare
                     // terminator (e.g. a leading `...`); force progress so the
                     // stream loop always terminates.

--- a/tests/core/test_anchors.py
+++ b/tests/core/test_anchors.py
@@ -65,5 +65,10 @@ def test_anchors_do_not_cross_documents():
     # The same cross-document reference also errors on the annotated path.
     with pytest.raises(yamlrocks.YAMLRocksDecodeError):
         yamlrocks.loads_all(b"---\n&a x\n---\n*a\n", option=yamlrocks.OPT_ANNOTATED)
+    # An *implicit* first document (no leading `---`) must clear its anchors too,
+    # or its `&x` leaks into the next document instead of raising.
+    with pytest.raises(yamlrocks.YAMLRocksDecodeError):
+        yamlrocks.loads_all(b"a: &x 1\n---\nb: *x\n")
     # Within a single document, aliases still resolve normally.
     assert yamlrocks.loads_all(b"---\na: &x 1\nb: *x\n") == [{"a": 1, "b": 1}]
+    assert yamlrocks.loads_all(b"a: &x 1\nb: *x\n") == [{"a": 1, "b": 1}]


### PR DESCRIPTION
## Breaking change

None. `a: &x 1\n---\nb: *x` previously resolved `*x` (leaking the anchor across the document boundary); it now raises an unknown-alias error, matching PyYAML, ruamel, and the YAML spec. Within a single document, aliases resolve as before.

## Proposed change

Anchors do not span documents. The explicit `---` document arm already cleared them, so a cross-document `*alias` raises. The implicit-document arm (a stream whose first document has no leading `---`) cleared `tag_handles` but not `anchors`, so an `&a` in an implicit first document leaked into the next document and its `*a` silently resolved.

This clears `anchors` in the implicit arm too, matching the explicit arm. The existing test gains the implicit-first-document case it was missing.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
