### PR TITLE
🐛 Catch Python-equal numeric duplicate keys under OPT_DUPLICATE_KEYS_ERROR

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -6,7 +6,7 @@ mod merge;
 use crate::parser::{Event, EventKind, Parser};
 use crate::resolver::{ScalarKind, Schema};
 use crate::scanner::{ScalarStyle, Span};
-use merge::{apply_merge_keys, is_merge_key, key_sig};
+use merge::{apply_merge_keys, is_merge_key};
 
 /// Decode YAML input into a nested Rust value tree.
 ///
@@ -308,6 +308,58 @@ impl<'input> Decoder<'input> {
         }
     }
 
+    /// A signature for a mapping key that collapses keys Python treats as equal:
+    /// `1`, `1.0`, and `True` are one `dict` key, so a document with all three
+    /// silently overwrites down to one entry. This mirrors Python's `==`/`hash`
+    /// (unlike [`merge::key_sig`], which is type-distinct for merge semantics), so
+    /// `OPT_DUPLICATE_KEYS_ERROR` catches a collision that only shows up once the
+    /// mapping becomes a `dict`.
+    fn python_dup_key_sig(value: &Value<'input>) -> String {
+        match value {
+            Value::Null => "null".to_owned(),
+            // Python: `True == 1`, `False == 0` (equal and same hash), so a bool
+            // collides with the matching integer.
+            Value::Bool(b) => format!("n:{}", i64::from(*b)),
+            Value::Int(i) => format!("n:{i}"),
+            Value::BigInt(s) => format!("n:{s}"),
+            Value::Float(f) => Self::float_dup_sig(*f),
+            Value::String(s) => format!("s:{}:{s}", s.len()),
+            Value::Tagged(tag, inner) => {
+                format!("t:{tag}:{}", Self::python_dup_key_sig(inner))
+            }
+            Value::Sequence(items) => {
+                let inner: Vec<String> = items.iter().map(Self::python_dup_key_sig).collect();
+                format!("seq:[{}]", inner.join(","))
+            }
+            Value::Mapping(pairs) => {
+                let inner: Vec<String> = pairs
+                    .iter()
+                    .map(|(k, v)| {
+                        format!(
+                            "{}={}",
+                            Self::python_dup_key_sig(k),
+                            Self::python_dup_key_sig(v)
+                        )
+                    })
+                    .collect();
+                format!("map:{{{}}}", inner.join(","))
+            }
+        }
+    }
+
+    /// An integral, in-range float shares a signature with the equal integer
+    /// (`1.0` collides with `1`); any other float keys off its bit pattern.
+    fn float_dup_sig(f: f64) -> String {
+        if f.is_finite()
+            && f.fract() == 0.0
+            && (-9.223_372_036_854_776e18..9.223_372_036_854_776e18).contains(&f)
+        {
+            format!("n:{}", f as i64)
+        } else {
+            format!("f:{}", f.to_bits())
+        }
+    }
+
     /// If duplicate-key checking is enabled, error when `key` was already seen in
     /// this mapping. `seen` holds an injective signature of every prior key, so
     /// membership is O(1) (a linear scan made a large mapping quadratic). The
@@ -324,7 +376,9 @@ impl<'input> Decoder<'input> {
             return Ok(());
         }
         // `insert` returns true when the key is new; a false means a duplicate.
-        if seen.insert(key_sig(key)) {
+        // Use the Python-equality signature so `1`/`1.0`/`True` collide the way
+        // they will once the mapping is a `dict`.
+        if seen.insert(Self::python_dup_key_sig(key)) {
             return Ok(());
         }
         let name = match key {

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -192,7 +192,11 @@ fn collect_node_divergences(node: &YamlNode, schema: Schema, out: &mut Vec<Strin
 }
 
 /// A canonical, type-tagged signature for a mapping key so equal keys collide
-/// and differently-typed keys (`1` vs `"1"`) do not.
+/// and differently-typed keys (`1` vs `"1"`) do not. Numeric keys collapse the
+/// way Python's `dict` does (`1`, `1.0`, and `True` are one key), so the
+/// duplicate-key check catches a collision that only appears once the mapping
+/// becomes a `dict`. The plain merge key `<<` keeps the `s:<<` signature its
+/// caller special-cases.
 fn key_signature(node: &YamlNode, schema: Schema) -> String {
     match &node.kind {
         YamlNodeKind::Null => "null".to_owned(),
@@ -200,10 +204,21 @@ fn key_signature(node: &YamlNode, schema: Schema) -> String {
             let resolved = schema.resolve(text, *style, node.tag.as_deref());
             match resolved {
                 ResolvedValue::Null => "null".to_owned(),
-                ResolvedValue::Bool(b) => format!("b:{b}"),
-                ResolvedValue::Int(i) => format!("i:{i}"),
-                ResolvedValue::BigInt(s) => format!("i:{s}"),
-                ResolvedValue::Float(f) => format!("f:{f}"),
+                // Python: `True == 1`, `False == 0`, so a bool collides with the
+                // matching integer; an integral float collides with the integer.
+                ResolvedValue::Bool(b) => format!("n:{}", i64::from(b)),
+                ResolvedValue::Int(i) => format!("n:{i}"),
+                ResolvedValue::BigInt(s) => format!("n:{s}"),
+                ResolvedValue::Float(f) => {
+                    if f.is_finite()
+                        && f.fract() == 0.0
+                        && (-9.223_372_036_854_776e18..9.223_372_036_854_776e18).contains(&f)
+                    {
+                        format!("n:{}", f as i64)
+                    } else {
+                        format!("f:{}", f.to_bits())
+                    }
+                }
                 ResolvedValue::String(s) => format!("s:{s}"),
             }
         }

--- a/tests/features/test_options.py
+++ b/tests/features/test_options.py
@@ -133,6 +133,34 @@ def test_duplicate_keys_distinguish_value_types():
     assert out == {1: "a", "1": "b"}
 
 
+@pytest.mark.parametrize(
+    "src",
+    [
+        b"1: a\n1.0: b\n",  # int vs equal float
+        b"true: a\n1: b\n",  # bool True vs 1
+        b"0: a\nfalse: b\n",  # 0 vs False
+        b"2.0: a\n2: b\n",  # integral float vs int
+    ],
+)
+@pytest.mark.parametrize(
+    "extra", [0, yamlrocks.OPT_ROUND_TRIP, yamlrocks.OPT_ANNOTATED]
+)
+def test_duplicate_keys_error_catches_python_equal_numeric_keys(src, extra):
+    """Keys distinct in YAML but equal as Python dict keys (1, 1.0, True) are flagged."""
+    with pytest.raises(yamlrocks.YAMLRocksDuplicateKeyError):
+        yamlrocks.loads(src, option=yamlrocks.OPT_DUPLICATE_KEYS_ERROR | extra)
+
+
+def test_duplicate_keys_numeric_non_equal_are_allowed():
+    """Numerically distinct keys (1 and 2, 1 and 1.5) are not duplicates."""
+    assert yamlrocks.loads(
+        b"1: a\n2: b\n", option=yamlrocks.OPT_DUPLICATE_KEYS_ERROR
+    ) == {1: "a", 2: "b"}
+    assert yamlrocks.loads(
+        b"1: a\n1.5: b\n", option=yamlrocks.OPT_DUPLICATE_KEYS_ERROR
+    ) == {1: "a", 1.5: "b"}
+
+
 def test_option_flags_are_distinct_bits():
     """Each option flag is a single distinct bit."""
     flags = [


### PR DESCRIPTION
## Breaking change

None by default (last-wins is unchanged). With `OPT_DUPLICATE_KEYS_ERROR` set, a mapping that repeats a key under two Python-equal spellings (`1` and `1.0`, `True` and `1`, `0` and `False`) now raises `YAMLRocksDuplicateKeyError` instead of silently keeping the last value, matching ruamel.

## Proposed change

Keys distinct in YAML but equal as Python dict keys collapse to one entry once the mapping becomes a `dict`, so one silently overwrote the other even with the strict option set. Detection used a type-distinct signature (merge's `key_sig`), which kept `1` and `1.0` apart.

This adds a Python-equality signature that collapses a bool/int/bigint/integral-float to the same integer signature, used in both duplicate-key paths (the fast decoder and the round-trip composer). Numerically distinct keys (`1` vs `2`, `1` vs `1.5`) and cross-type keys (`1` vs `"1"`) are still allowed. The now-unused `key_sig` import is dropped.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
