### PR TITLE
🐛 Preserve an explicit '?' mapping key on round-trip re-emit

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -787,7 +787,7 @@ impl<'input> Decoder<'input> {
             // collection-end markers are likewise not nodes, returning without
             // consuming lets the enclosing collection see its own terminator
             // rather than silently swallowing it.
-            EventKind::Key
+            EventKind::Key { .. }
             | EventKind::StreamEnd
             | EventKind::DocumentEnd
             | EventKind::DocumentStart
@@ -889,7 +889,7 @@ impl<'input> Decoder<'input> {
                 EventKind::FlowEntry => {
                     self.pos += 1;
                 }
-                EventKind::Key => {
+                EventKind::Key { .. } => {
                     let key_span = events[self.pos].span;
                     self.pos += 1;
                     // An explicit `?` key (which reaches here with a `Key`
@@ -1026,7 +1026,8 @@ impl<'input> Decoder<'input> {
         }
         // A `Key` marker (the scanner's detection of `[a: b]` or an explicit
         // `[? a : b]`) introduces a single-pair mapping element.
-        if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Key) {
+        if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Key { .. })
+        {
             let key_span = events[self.pos].span;
             self.pos += 1;
             let key = self.decode_node(events)?.unwrap_or(Value::Null);
@@ -1081,7 +1082,7 @@ impl<'input> Decoder<'input> {
                                 | EventKind::SequenceEnd
                                 | EventKind::MappingEnd
                                 | EventKind::BlockEnd
-                                | EventKind::Key
+                                | EventKind::Key { .. }
                         )
                     {
                         items.push(Value::Null);

--- a/src/parser/event.rs
+++ b/src/parser/event.rs
@@ -59,7 +59,13 @@ pub enum EventKind<'input> {
 
     BlockEnd,
 
-    Key,
+    /// A mapping key marker. `explicit` is true when the source wrote the key
+    /// with an explicit `?` indicator; false for an implicit `key:`. Only the
+    /// round-trip composer reads it (to preserve the `?` on re-emit); the fast
+    /// decode path ignores it.
+    Key {
+        explicit: bool,
+    },
     Value,
     SequenceEntry,
     FlowEntry,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -162,9 +162,11 @@ impl<'input> Parser<'input> {
             }
             TokenKind::FlowSequenceEnd => Ok(Event::new(EventKind::SequenceEnd, span)),
 
-            TokenKind::Key => {
-                // Key is followed by the actual key value
-                Ok(Event::new(EventKind::Key, span))
+            TokenKind::Key { explicit } => {
+                // Key is followed by the actual key value; carry whether the
+                // source used an explicit `?` so the round-trip emitter can
+                // restore it.
+                Ok(Event::new(EventKind::Key { explicit }, span))
             }
             TokenKind::Value => Ok(Event::new(EventKind::Value, span)),
 

--- a/src/roundtrip/ast.rs
+++ b/src/roundtrip/ast.rs
@@ -50,6 +50,13 @@ pub struct YamlNode {
     /// re-emission; a *loaded* null always re-emits in its original form so an
     /// untouched value stays byte-for-byte.
     pub synthetic: bool,
+    /// Whether this node, as a mapping key, was written with an explicit `?`
+    /// indicator in the source (`? key`). Only meaningful when the node sits in
+    /// key position; `false` otherwise. Preserved so re-emission after an edit
+    /// keeps the author's explicit-key form instead of collapsing it to the
+    /// implicit `key:` form. A key that structurally *requires* the explicit form
+    /// (a block collection or block scalar) is emitted explicitly regardless.
+    pub explicit_key: bool,
 }
 
 impl YamlNode {
@@ -71,6 +78,7 @@ impl YamlNode {
             directives: Vec::new(),
             leading_bom: false,
             synthetic: false,
+            explicit_key: false,
         }
     }
 

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -692,7 +692,7 @@ impl<'input> Composer<'input> {
             // loop can observe them. A bare `Key` means an empty value followed
             // by a sibling key (a nested mapping is always preceded by
             // `MappingStart`), so it is a null value, not a new mapping.
-            EventKind::Key
+            EventKind::Key { .. }
             | EventKind::StreamEnd
             | EventKind::DocumentEnd
             | EventKind::DocumentStart
@@ -778,11 +778,15 @@ impl<'input> Composer<'input> {
                 EventKind::FlowEntry => {
                     self.pos += 1;
                 }
-                EventKind::Key => {
+                EventKind::Key { explicit } => {
+                    let explicit = *explicit;
                     self.pos += 1;
-                    let key = self
+                    let mut key = self
                         .compose_node(events)?
                         .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()));
+                    // Remember an author-written `?` so re-emission after an edit
+                    // keeps the explicit-key form instead of collapsing it.
+                    key.explicit_key = explicit;
                     if self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value)
                     {
                         self.pos += 1;
@@ -923,12 +927,16 @@ impl<'input> Composer<'input> {
 
         // An explicit `Key` marker (`[a: b]`, `[? a : b]`) opens a single-pair
         // mapping element.
-        if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Key) {
+        if let Some(EventKind::Key { explicit }) =
+            (self.pos < events.len() && flow).then(|| &events[self.pos].kind)
+        {
+            let explicit = *explicit;
             let pair_span = events[self.pos].span;
             self.pos += 1;
-            let key = self
+            let mut key = self
                 .compose_node(events)?
                 .unwrap_or_else(|| null(pair_span));
+            key.explicit_key = explicit;
             if self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value) {
                 self.pos += 1;
             }
@@ -983,7 +991,7 @@ impl<'input> Composer<'input> {
                     | EventKind::SequenceEnd
                     | EventKind::MappingEnd
                     | EventKind::BlockEnd
-                    | EventKind::Key
+                    | EventKind::Key { .. }
             )
         {
             return Ok(Some(YamlNode::new(YamlNodeKind::Null, dash_span)));

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -722,6 +722,12 @@ fn is_empty_scalar(node: &YamlNode) -> bool {
 /// (plain or quoted scalars, aliases, empty or single-line flow collections)
 /// stays inline. Found by the `roundtrip` fuzz target.
 fn key_needs_explicit(key: &YamlNode) -> bool {
+    // The author wrote an explicit `?`: preserve it on re-emit (fidelity), as
+    // long as the key can still open with a `? ` line. A block collection or a
+    // block scalar is emitted explicitly anyway, below.
+    if key.explicit_key && matches!(&key.kind, YamlNodeKind::Scalar(..) | YamlNodeKind::Alias(_)) {
+        return true;
+    }
     match &key.kind {
         YamlNodeKind::Mapping(m) => key.style == NodeStyle::Block && !m.is_empty(),
         YamlNodeKind::Sequence(s) => key.style == NodeStyle::Block && !s.is_empty(),
@@ -816,6 +822,30 @@ mod tests {
             &reparsed[0].kind,
             YamlNodeKind::Scalar(s, _) if s == "\u{feff}*"
         ));
+    }
+
+    /// An author-written explicit `?` key survives a re-emit (after an edit),
+    /// while an implicit key never sprouts one. Regression for the explicit-key
+    /// fidelity fix.
+    #[test]
+    fn explicit_scalar_key_is_preserved_on_reemit() {
+        for src in [
+            "? explicit\n: value\n",
+            "? a\n: 1\n? b\n: 2\n",
+            "map:\n  ? k\n  : v\n",
+        ] {
+            let out = reemit(src);
+            assert!(
+                out.contains("? "),
+                "explicit `?` dropped for {src:?}:\n{out}"
+            );
+            assert!(same_value(src, &out));
+        }
+        let implicit = reemit("a: 1\nb: 2\n");
+        assert!(
+            !implicit.contains('?'),
+            "implicit key gained a `?`:\n{implicit}"
+        );
     }
 
     /// A loaded (non-synthetic) null re-emits empty regardless of the style, while

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -921,7 +921,8 @@ impl<'input> Scanner<'input> {
         if self.flow_level > 0 {
             self.flow_explicit_key = true;
         }
-        self.tokens.push_back(Token::new(TokenKind::Key, span));
+        self.tokens
+            .push_back(Token::new(TokenKind::Key { explicit: true }, span));
         Ok(())
     }
 
@@ -955,7 +956,8 @@ impl<'input> Scanner<'input> {
                         .insert(at, Token::new(TokenKind::BlockMappingStart, key_span));
                     at += 1;
                 }
-                self.tokens.insert(at, Token::new(TokenKind::Key, key_span));
+                self.tokens
+                    .insert(at, Token::new(TokenKind::Key { explicit: false }, key_span));
             } else {
                 let column = self.reader.column() as i32;
                 self.roll_indent(column, span, TokenKind::BlockMappingStart)?;
@@ -1221,7 +1223,8 @@ impl<'input> Scanner<'input> {
                 let key_col = span.column as i32;
                 self.roll_indent(key_col, span, TokenKind::BlockMappingStart)?;
             }
-            self.tokens.push_back(Token::new(TokenKind::Key, span));
+            self.tokens
+                .push_back(Token::new(TokenKind::Key { explicit: false }, span));
             let mut scalar = Token::new(TokenKind::Scalar(value, style), span);
             scalar.end_offset = content_end;
             self.tokens.push_back(scalar);
@@ -1353,7 +1356,8 @@ impl<'input> Scanner<'input> {
                     let key_col = span.column as i32;
                     self.roll_indent(key_col, span, TokenKind::BlockMappingStart)?;
                 }
-                self.tokens.push_back(Token::new(TokenKind::Key, span));
+                self.tokens
+                    .push_back(Token::new(TokenKind::Key { explicit: false }, span));
                 let mut scalar = Token::new(TokenKind::Scalar(value, ScalarStyle::Plain), span);
                 scalar.end_offset = content_end;
                 self.tokens.push_back(scalar);

--- a/src/scanner/token.rs
+++ b/src/scanner/token.rs
@@ -70,7 +70,14 @@ pub enum TokenKind<'input> {
     FlowSequenceEnd,
     FlowEntry,
 
-    Key,
+    /// A mapping key marker. `explicit` is true when the source wrote the key
+    /// with an explicit `?` indicator (`? key`), false for an implicit key
+    /// (`key:`, including the retroactive marker the scanner inserts when a `:`
+    /// confirms a key). Preserved so the round-trip emitter can re-emit the
+    /// author's `?` form after an edit instead of collapsing it to implicit.
+    Key {
+        explicit: bool,
+    },
     Value,
 
     Scalar(Cow<'input, str>, ScalarStyle),

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -210,6 +210,20 @@ def test_edit_preserves_foot_comment():
     assert b"# foot" in yamlrocks.dumps(doc)
 
 
+def test_explicit_question_mark_key_survives_edit():
+    """An author's explicit `? key` survives a re-emit after an unrelated edit."""
+    doc = yamlrocks.loads(b"? explicit\n: value\nother: 1\n", option=RT)
+    doc["other"] = 2
+    assert doc.to_yaml() == b"? explicit\n: value\nother: 2\n"
+
+
+def test_implicit_key_does_not_gain_question_mark_on_edit():
+    """An ordinary implicit key must not sprout a `?` when the document is edited."""
+    doc = yamlrocks.loads(b"a: 1\nother: 1\n", option=RT)
+    doc["other"] = 2
+    assert doc.to_yaml() == b"a: 1\nother: 2\n"
+
+
 def test_edit_preserves_sequence_item_comment():
     """Replacing a sequence item keeps the comment attached to it."""
     doc = yamlrocks.loads(b"- one  # first\n- two\n", option=RT)


### PR DESCRIPTION
## Breaking change

None. This only affects re-emission of a *modified* round-trip document: an author's `? key` is now preserved instead of collapsing to `key:`. An unmodified document already re-emits from its cached source bytes, so byte-for-byte fidelity is unchanged.

## Proposed change

An explicit `?` mapping key collapsed to the implicit `key: value` form when a round-trip document was re-emitted after an edit, because the emitter decided `?` purely by whether the key structurally needs it.

This threads an `explicit` flag through the `Key` token and event (true only at the scanner's `?` site; false for an implicit or retroactively-inserted key), records it on the composed key node as `explicit_key`, and has the emitter's `key_needs_explicit` honor it for scalar/alias keys. The fast decode path ignores the flag. A key that structurally requires the explicit form (a block collection or block scalar) is still emitted explicitly regardless.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
