### PR TITLE
🐛 Canonicalize a verbatim tag for handlers and passthrough

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -86,6 +86,17 @@ pub fn is_custom_tag(tag: &str) -> bool {
     !(tag.starts_with("!!") || tag.starts_with("tag:yaml.org,2002:"))
 }
 
+/// Canonicalize a verbatim tag `!<uri>` to the bare `uri` it names, so a tag
+/// handler or the passthrough `YAMLRocksTag` sees the resolved URI
+/// (`tag:example.com,2020:foo`) rather than the `!<...>` wrapper. This matches
+/// how a `%TAG`-shorthand tag is already expanded, so the two spellings of the
+/// same tag reach the caller identically. Any non-verbatim tag is unchanged.
+pub(crate) fn canonical_tag(tag: &str) -> &str {
+    tag.strip_prefix("!<")
+        .and_then(|inner| inner.strip_suffix('>'))
+        .unwrap_or(tag)
+}
+
 /// Move ownership of the scalar text out of the `Scalar` event at `pos`, leaving
 /// the event's text empty. The decoder calls this exactly once as it consumes a
 /// scalar, handing the string straight to a `Value::String` without a copy.

--- a/src/ffi/convert/decode.rs
+++ b/src/ffi/convert/decode.rs
@@ -15,13 +15,19 @@ pub(super) fn resolve_tagged(
     inner: Py<PyAny>,
     tags: TagPolicy<'_, '_>,
 ) -> PyResult<Py<PyAny>> {
+    // Canonicalize a verbatim `!<uri>` to its bare URI for a registry lookup and
+    // the handler callback, so both see the resolved tag (`tag:example.com,2020:foo`),
+    // matching `%TAG`-shorthand expansion. A passthrough `YAMLRocksTag` keeps the
+    // original `!<...>` spelling: `dumps`/`validate_tag` require a leading `!`, so a
+    // bare URI could not be re-emitted and a load/dump round-trip would break.
+    let canonical = crate::decode::canonical_tag(tag);
     if let Some(registry) = tags.registry {
-        if let Some(func) = registry.get_item(tag)? {
+        if let Some(func) = registry.get_item(canonical)? {
             return Ok(func.call1((inner,))?.unbind());
         }
     }
     if let Some(handler) = tags.handler {
-        return Ok(handler.call1((tag, inner))?.unbind());
+        return Ok(handler.call1((canonical, inner))?.unbind());
     }
     if tags.passthrough {
         return Ok(YAMLRocksTag {

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -387,3 +387,42 @@ def test_duplicate_tag_directive_is_rejected():
         yamlrocks.loads(src)
     # A different handle on the same line is fine.
     assert yamlrocks.loads(b"%TAG !e! tag:a:\n%TAG !f! tag:b:\n---\nx: 1\n") == {"x": 1}
+
+
+def test_verbatim_tag_canonicalized_for_handler():
+    """A verbatim `!<uri>` reaches a handler as the bare URI, like `%TAG` expansion."""
+    src = b"x: !<tag:example.com,2020:app/foo> bar\n"
+    seen = []
+    yamlrocks.loads(src, tag_handler=lambda tag, val: seen.append(tag) or val)
+    assert seen == ["tag:example.com,2020:app/foo"]
+
+
+def test_verbatim_tag_passthrough_keeps_verbatim_spelling():
+    """A passthrough `YAMLRocksTag` keeps the `!<...>` spelling so `dumps` accepts it.
+
+    Canonicalizing the passthrough tag to a bare URI would make `dumps` reject it
+    (`validate_tag` requires a leading `!`), breaking the load/dump round-trip.
+    """
+    src = b"x: !<tag:example.com,2020:app/foo> bar\n"
+    node = yamlrocks.loads(src, option=yamlrocks.OPT_PASSTHROUGH_TAG)["x"]
+    assert node.tag == "!<tag:example.com,2020:app/foo>"
+    # The verbatim tag survives a dump/load round-trip through the passthrough object.
+    reloaded = yamlrocks.loads(
+        yamlrocks.dumps(node), option=yamlrocks.OPT_PASSTHROUGH_TAG
+    )
+    assert reloaded.tag == node.tag
+    assert reloaded.value == node.value
+
+
+def test_verbatim_tag_value_round_trips():
+    """A verbatim-tagged value survives a dump/load round-trip via passthrough.
+
+    The default `loads` strips custom tags, so this exercises `OPT_PASSTHROUGH_TAG`,
+    where the `!<...>` spelling is preserved and `dumps` can re-emit it.
+    """
+    for src in [b"!<tag:example.com,2020:foo> bar", b"!<a> y"]:
+        tag = yamlrocks.loads(src, option=yamlrocks.OPT_PASSTHROUGH_TAG)
+        reloaded = yamlrocks.loads(
+            yamlrocks.dumps(tag), option=yamlrocks.OPT_PASSTHROUGH_TAG
+        )
+        assert (reloaded.tag, reloaded.value) == (tag.tag, tag.value), src


### PR DESCRIPTION
## Breaking change

A verbatim tag `!<uri>` now reaches a `tag_handler`, a `tags` registry lookup, and a passthrough `YAMLRocksTag.tag` as the bare URI (`tag:example.com,2020:foo`) instead of the `!<...>` wrapper. Code that matched the literal `!<...>` string would need to match the URI, but that already had to handle the URI form for `%TAG`-shorthand tags, so this makes the two consistent.

## Proposed change

A verbatim tag reached the Python tag boundary as `!<...>`, while a `%TAG`-shorthand tag arrived as the resolved URI, so a handler keyed on the URI never matched the verbatim spelling.

A new `canonical_tag` helper unwraps `!<uri>` to its bare URI, applied in `resolve_tagged` (the single Python-facing boundary for the registry, handler, and passthrough). The `Value`/AST keeps the original spelling, so `dumps` still re-emits a verbatim tag verbatim and a round-trip stays byte-for-byte.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.
