### PR TITLE
🐛 Guard against orphaning an alias when deleting an anchor target

### DIFF
--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -171,7 +171,21 @@ impl YAMLRocksDocument {
         if self.nodes.len() == 1 {
             let anchors = build_anchor_map(&self.nodes);
             let schema = self.schema;
-            del_child(py, &mut self.nodes[0], key, schema, &anchors)
+            // Guard against orphaning an alias: if the document has aliases,
+            // snapshot the tree and the aliases already dangling, delete, then
+            // roll back if the delete leaves a *newly* dangling `*alias`.
+            let snapshot = document_has_aliases(&self.nodes)
+                .then(|| (self.nodes.clone(), dangling_alias_names(&self.nodes)));
+            del_child(py, &mut self.nodes[0], key, schema, &anchors)?;
+            if let Some((snapshot, before)) = snapshot {
+                let after = dangling_alias_names(&self.nodes);
+                if let Some(name) = after.difference(&before).next() {
+                    let name = name.clone();
+                    self.nodes = snapshot;
+                    return Err(dangling_alias_error(&name));
+                }
+            }
+            Ok(())
         } else {
             let idx: usize = key.extract()?;
             if idx >= self.nodes.len() {
@@ -596,9 +610,23 @@ impl YAMLRocksDocumentView {
         let mut doc = self.root.borrow_mut(py);
         let schema = doc.schema;
         let anchors = build_anchor_map(&doc.nodes);
+        // Guard against orphaning an alias elsewhere in the document (see the
+        // top-level `__delitem__`): snapshot the tree and the already-dangling
+        // aliases, roll back only if the delete newly orphans one.
+        let snapshot = document_has_aliases(&doc.nodes)
+            .then(|| (doc.nodes.clone(), dangling_alias_names(&doc.nodes)));
         let node = resolve_path_mut(&mut doc.nodes, &self.path)
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("stale view"))?;
-        del_child(py, node, key, schema, &anchors)
+        del_child(py, node, key, schema, &anchors)?;
+        if let Some((snapshot, before)) = snapshot {
+            let after = dangling_alias_names(&doc.nodes);
+            if let Some(name) = after.difference(&before).next() {
+                let name = name.clone();
+                doc.nodes = snapshot;
+                return Err(dangling_alias_error(&name));
+            }
+        }
+        Ok(())
     }
 
     fn __contains__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<bool> {
@@ -1438,6 +1466,66 @@ fn set_child(
             "node is not a mapping or sequence",
         )),
     }
+}
+
+/// Collect every `*alias` name referenced anywhere in a node subtree.
+fn collect_alias_names(node: &YamlNode, out: &mut std::collections::HashSet<String>) {
+    match &node.kind {
+        YamlNodeKind::Alias(name) => {
+            out.insert(name.clone());
+        }
+        YamlNodeKind::Mapping(pairs) => {
+            for (k, v) in pairs {
+                collect_alias_names(k, out);
+                collect_alias_names(v, out);
+            }
+        }
+        YamlNodeKind::Sequence(items) => {
+            for item in items {
+                collect_alias_names(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Whether the document references any alias at all. A document with no aliases
+/// can never be left with a dangling one, so the delete guard skips the (cloning)
+/// safety check entirely, keeping the common no-anchor case cheap.
+fn document_has_aliases(nodes: &[YamlNode]) -> bool {
+    let mut aliases = std::collections::HashSet::new();
+    for node in nodes {
+        collect_alias_names(node, &mut aliases);
+    }
+    !aliases.is_empty()
+}
+
+/// The set of `*alias` names that no longer resolve to an `&anchor` anywhere in
+/// the document. The delete guard compares this set before and after a delete so
+/// only a *newly* orphaned alias blocks the operation: the round-trip/compose
+/// path does not validate alias targets at load time, so a document may already
+/// carry a dangling alias, and an unrelated delete must not be blamed for it.
+fn dangling_alias_names(nodes: &[YamlNode]) -> std::collections::HashSet<String> {
+    let mut anchors = HashMap::new();
+    for node in nodes {
+        collect_anchor_refs(node, &mut anchors);
+    }
+    let mut aliases = std::collections::HashSet::new();
+    for node in nodes {
+        collect_alias_names(node, &mut aliases);
+    }
+    aliases.retain(|name| !anchors.contains_key(name));
+    aliases
+}
+
+/// The error raised when a delete would orphan an alias (leave a `*name` with no
+/// `&name`), which would emit YAML that no longer parses.
+fn dangling_alias_error(name: &str) -> PyErr {
+    pyo3::exceptions::PyValueError::new_err(format!(
+        "deleting this node would remove anchor '&{name}', still referenced by an \
+         alias '*{name}' elsewhere; the result would not re-parse. Remove or \
+         rewrite the alias first."
+    ))
 }
 
 fn del_child(

--- a/tests/core/test_anchors.py
+++ b/tests/core/test_anchors.py
@@ -72,3 +72,49 @@ def test_anchors_do_not_cross_documents():
     # Within a single document, aliases still resolve normally.
     assert yamlrocks.loads_all(b"---\na: &x 1\nb: *x\n") == [{"a": 1, "b": 1}]
     assert yamlrocks.loads_all(b"a: &x 1\nb: *x\n") == [{"a": 1, "b": 1}]
+
+
+def test_deleting_an_anchor_target_still_referenced_raises():
+    """Deleting an anchor target an alias still references raises, leaving the doc intact."""
+    import pytest
+
+    doc = yamlrocks.loads(
+        b"base: &b\n  x: 1\nref: *b\nother: 2\n", option=yamlrocks.OPT_ROUND_TRIP
+    )
+    with pytest.raises(ValueError, match="alias"):
+        del doc["base"]
+    assert doc.to_yaml() == b"base: &b\n  x: 1\nref: *b\nother: 2\n"
+    assert yamlrocks.loads(doc.to_yaml())["ref"] == {"x": 1}
+
+
+def test_deleting_the_alias_itself_is_allowed():
+    """Removing the alias (not its anchor target) is safe and leaves valid YAML."""
+    doc = yamlrocks.loads(
+        b"base: &b\n  x: 1\nref: *b\nother: 2\n", option=yamlrocks.OPT_ROUND_TRIP
+    )
+    del doc["ref"]
+    assert yamlrocks.loads(doc.to_yaml()) == {"base": {"x": 1}, "other": 2}
+
+
+def test_deleting_a_nested_anchor_target_still_referenced_raises():
+    """The guard covers a nested-view delete, not only the top-level path."""
+    import pytest
+
+    src = b"outer:\n  inner: &b 1\nref: *b\n"
+    doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
+    with pytest.raises(ValueError, match="alias"):
+        del doc["outer"]["inner"]
+    assert doc.to_yaml() == src
+    assert yamlrocks.loads(doc.to_yaml())["ref"] == 1
+
+
+def test_deleting_unrelated_key_with_preexisting_dangling_alias_is_allowed():
+    """A delete is only blocked for an alias it *newly* orphans.
+
+    The round-trip path does not validate alias targets at load time, so a
+    document can already carry a dangling `*alias`. Deleting an unrelated key must
+    not be blamed for that pre-existing break.
+    """
+    doc = yamlrocks.loads(b"a: 1\nb: *ghost\nc: 3\n", option=yamlrocks.OPT_ROUND_TRIP)
+    del doc["c"]
+    assert doc.to_yaml() == b"a: 1\nb: *ghost\n"


### PR DESCRIPTION
## Breaking change

None. This only rejects a delete that would produce YAML that no longer parses; it does not change the result of any delete that was already valid.

## Proposed change

Deleting a node that carries an `&anchor` still referenced by a `*alias` elsewhere in the document left the alias dangling, so the re-emitted YAML no longer parsed. The mutation API allowed it, which turned a valid document into a broken one with no warning.

`__delitem__` (both the top-level document and a node view) now snapshots the node tree before the delete, but only when the document actually references an alias, so the common no-anchor case stays allocation-free. After the delete it checks for a `*alias` with no matching `&anchor`; if one is found it restores the snapshot and raises a `ValueError` naming the anchor, leaving the document untouched. Removing the alias itself (rather than its target) stays allowed.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
