### PR TITLE
🐛 Apply merge keys on the AST data paths, not just the fast path

### DIFF
--- a/src/ffi/convert/annotate.rs
+++ b/src/ffi/convert/annotate.rs
@@ -7,7 +7,8 @@ use pyo3::types::{PyDict, PyFloat, PyList};
 use crate::ffi::types::{YAMLRocksAnnotatedDict, YAMLRocksAnnotatedList};
 use crate::resolver::{ResolvedValue, Schema};
 use crate::roundtrip::value::{
-    key_is_collection, node_to_python_cached, node_to_python_key, ObjectCache,
+    is_ast_merge_key, key_is_collection, mapping_has_merge_key, merge_converted_into,
+    node_to_python_cached, node_to_python_key, ObjectCache,
 };
 use crate::roundtrip::{YamlNode, YamlNodeKind};
 
@@ -230,7 +231,39 @@ fn annotate_node_cached_inner(
             });
             let obj = Bound::new(py, init)?;
             let dict = obj.as_any().cast::<PyDict>()?;
+            let has_merge = mapping_has_merge_key(pairs);
             for (key, val) in pairs {
+                let py_val = annotate_node_cached(
+                    py,
+                    val,
+                    paths,
+                    schema,
+                    tags,
+                    anchors,
+                    annotate_numbers,
+                    cache,
+                )?;
+                // Apply a `<<` merge like the fast path, so annotated data reads
+                // the same as `loads()`. The merged-in entries keep their own
+                // annotations (they come from the source mapping's nodes).
+                if has_merge && is_ast_merge_key(key) {
+                    if let Some(preserve) = merge_converted_into(dict, py_val.bind(py))? {
+                        let py_key = annotate_node_cached(
+                            py,
+                            key,
+                            paths,
+                            schema,
+                            tags,
+                            anchors,
+                            annotate_numbers,
+                            cache,
+                        )?;
+                        if !dict.contains(&py_key)? {
+                            dict.set_item(py_key, preserve)?;
+                        }
+                    }
+                    continue;
+                }
                 // Annotate keys too, not just values: a string key becomes an
                 // `YAMLRocksAnnotatedStr` carrying its own line/column/file, so callers can
                 // point an error at the exact key. `YAMLRocksAnnotatedStr` is a `str`
@@ -252,16 +285,6 @@ fn annotate_node_cached_inner(
                         cache,
                     )?
                 };
-                let py_val = annotate_node_cached(
-                    py,
-                    val,
-                    paths,
-                    schema,
-                    tags,
-                    anchors,
-                    annotate_numbers,
-                    cache,
-                )?;
                 dict.set_item(py_key, py_val)?;
             }
             Ok(obj.into_any().unbind())
@@ -423,14 +446,25 @@ fn node_to_python_with_tags_cached_inner(
         }
         YamlNodeKind::Mapping(pairs) => {
             let dict = PyDict::new(py);
+            let has_merge = mapping_has_merge_key(pairs);
             for (key, val) in pairs {
+                let py_val =
+                    node_to_python_with_tags_cached(py, val, schema, tags, anchors, cache)?;
+                if has_merge && is_ast_merge_key(key) {
+                    if let Some(preserve) = merge_converted_into(&dict, py_val.bind(py))? {
+                        let py_key =
+                            node_to_python_with_tags_cached(py, key, schema, tags, anchors, cache)?;
+                        if !dict.contains(&py_key)? {
+                            dict.set_item(py_key, preserve)?;
+                        }
+                    }
+                    continue;
+                }
                 let py_key = if key_is_collection(key, anchors) {
                     node_to_python_key(py, key, schema, anchors, cache)
                 } else {
                     node_to_python_with_tags_cached(py, key, schema, tags, anchors, cache)?
                 };
-                let py_val =
-                    node_to_python_with_tags_cached(py, val, schema, tags, anchors, cache)?;
                 dict.set_item(py_key, py_val)?;
             }
             dict.into_any().unbind()

--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -96,12 +96,35 @@ fn node_to_python_cached_inner(
         }
         YamlNodeKind::Mapping(pairs) => {
             let dict = PyDict::new(py);
-            for (key, val) in pairs {
-                dict.set_item(
-                    node_to_python_key(py, key, schema, anchors, cache),
-                    node_to_python_cached(py, val, schema, anchors, cache),
-                )
-                .unwrap();
+            if mapping_has_merge_key(pairs) {
+                for (key, val) in pairs {
+                    let py_val = node_to_python_cached(py, val, schema, anchors, cache);
+                    if is_ast_merge_key(key) {
+                        // Fold the merge value's keys in, keeping any explicit
+                        // key already set. A non-mergeable value stays under the
+                        // literal `<<`, as the fast path preserves it.
+                        if let Some(preserve) =
+                            merge_converted_into(&dict, py_val.bind(py)).unwrap()
+                        {
+                            let py_key = node_to_python_key(py, key, schema, anchors, cache);
+                            if !dict.contains(&py_key).unwrap() {
+                                dict.set_item(py_key, preserve).unwrap();
+                            }
+                        }
+                    } else {
+                        // An explicit key wins over a merge, so it overwrites.
+                        dict.set_item(node_to_python_key(py, key, schema, anchors, cache), py_val)
+                            .unwrap();
+                    }
+                }
+            } else {
+                for (key, val) in pairs {
+                    dict.set_item(
+                        node_to_python_key(py, key, schema, anchors, cache),
+                        node_to_python_cached(py, val, schema, anchors, cache),
+                    )
+                    .unwrap();
+                }
             }
             dict.into_any().unbind()
         }
@@ -114,6 +137,67 @@ fn node_to_python_cached_inner(
         cache.insert(name.clone(), obj.clone_ref(py));
     }
     obj
+}
+
+/// Whether a mapping-key node is a real YAML merge key (`<<`): a *plain* `<<`
+/// scalar (a quoted `"<<"` is a literal string key), or a node carrying an
+/// explicit `!!merge` tag. Mirrors the fast-path resolver's merge detection so
+/// the AST-based conversions (round-trip `to_dict`, includes, annotated) apply
+/// merges identically to `loads()`.
+pub(crate) fn is_ast_merge_key(key: &YamlNode) -> bool {
+    if let Some(tag) = &key.tag {
+        return matches!(tag.as_str(), "!!merge" | "tag:yaml.org,2002:merge");
+    }
+    matches!(&key.kind, YamlNodeKind::Scalar(text, ScalarStyle::Plain) if text == "<<")
+}
+
+/// Whether any key in a mapping's pairs is a merge key, so the hot no-merge path
+/// stays a plain insert loop and only mappings that actually carry `<<` pay for
+/// the merge-aware handling.
+pub(crate) fn mapping_has_merge_key(pairs: &[(YamlNode, YamlNode)]) -> bool {
+    pairs.iter().any(|(k, _)| is_ast_merge_key(k))
+}
+
+/// Merge an already-converted `<<` value into `dict`, inserting only keys not
+/// already present (so explicit keys and earlier merges win, matching PyYAML,
+/// ruamel, and the fast path). Returns the object to preserve under the literal
+/// `<<` key, or `None` when the value merged completely:
+///
+/// - A mapping merges its entries and returns `None`.
+/// - A sequence merges each element and returns only the elements that could not
+///   be merged, as a list (`None` if all merged), so a mergeable element is not
+///   also duplicated under `<<`. Mirrors the fast path's `merge_into`.
+/// - Anything else (a scalar or custom-tagged node) is returned as-is to
+///   preserve under `<<`, exactly as the fast path does.
+///
+/// `dict.contains` uses Python equality, so a key already present under any
+/// spelling is not overwritten.
+pub(crate) fn merge_converted_into<'py>(
+    dict: &Bound<'py, PyDict>,
+    source: &Bound<'py, PyAny>,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    if let Ok(src) = source.cast::<PyDict>() {
+        for (k, v) in src.iter() {
+            if !dict.contains(&k)? {
+                dict.set_item(k, v)?;
+            }
+        }
+        Ok(None)
+    } else if let Ok(list) = source.cast::<PyList>() {
+        let leftover = PyList::empty(source.py());
+        for item in list.iter() {
+            if let Some(unmerged) = merge_converted_into(dict, &item)? {
+                leftover.append(unmerged)?;
+            }
+        }
+        if leftover.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(leftover.into_any()))
+        }
+    } else {
+        Ok(Some(source.clone()))
+    }
 }
 
 /// Whether a mapping-key node is (or, for an alias, resolves to) a collection.

--- a/tests/core/test_merge_keys.py
+++ b/tests/core/test_merge_keys.py
@@ -125,3 +125,51 @@ def test_merge_key_inside_a_complex_key_does_not_leak_to_tag_handler():
     out = yamlrocks.loads(b"{<<: 1}: v\n", tag_handler=handler)
     assert out == {(("<<", 1),): "v"}
     assert seen == []
+
+
+def test_merge_applied_on_all_data_paths_not_just_fast():
+    """`<<` merges must be applied on every path that returns DATA (annotated,
+    includes, round-trip to_dict), matching the fast `loads()`. Round-trip
+    `to_yaml()` still keeps `<<` literal for byte-for-byte fidelity."""
+    src = b"d: &d\n  x: 1\no:\n  <<: *d\n  y: 9\n"
+    expected = {"x": 1, "y": 9}
+    assert yamlrocks.loads(src)["o"] == expected
+    assert dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED)["o"]) == expected
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES)["o"] == expected
+    doc = yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP)
+    assert doc.to_dict()["o"] == expected
+    # Fidelity: the emitted source still carries the literal merge key.
+    assert doc.to_yaml() == src
+
+
+def test_merge_via_include_is_applied_after_resolution(tmp_path):
+    """`<<: !include base.yaml` merges the included mapping in, the Home Assistant
+    packages pattern, instead of leaving a literal `<<` key."""
+    (tmp_path / "base.yaml").write_bytes(b"x: 1\ny: 2\n")
+    root = b"obj:\n  <<: !include base.yaml\n  y: 9\n"
+    out = yamlrocks.loads(
+        root, option=yamlrocks.OPT_INCLUDES, include_dir=str(tmp_path)
+    )
+    assert out == {"obj": {"x": 1, "y": 9}}
+
+
+def test_quoted_merge_key_stays_literal_on_data_paths():
+    """A quoted `"<<"` is a literal key, never a merge, on the AST paths too."""
+    src = b'o:\n  "<<": 1\n'
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED)["o"] == {"<<": 1}
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES)["o"] == {"<<": 1}
+
+
+def test_merge_sequence_with_non_mergeable_element_keeps_only_leftover():
+    """A `<<` sequence mixing a mapping and a non-mergeable element merges the
+    mapping and keeps only the leftover under the literal `<<`, not the whole
+    list, so the merged keys are not also duplicated. All data paths agree with
+    the fast path (mirrors the fast `merge_into` leftover semantics)."""
+    src = b"base: &b\n  x: 1\no:\n  <<: [*b, plain]\n"
+    expected = {"x": 1, "<<": ["plain"]}
+    assert yamlrocks.loads(src)["o"] == expected
+    assert dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED)["o"]) == expected
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES)["o"] == expected
+    assert (
+        yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["o"] == expected
+    )


### PR DESCRIPTION
## Breaking change

None for correct usage. The annotated, includes, and round-trip `to_dict()` paths now apply `<<` merge keys, so a document using merge keys returns merged data on those paths instead of a literal `<<` entry. That matches the fast `loads()` path (and PyYAML/ruamel), so it fixes an inconsistency rather than introducing one. Round-trip `to_yaml()` is unchanged and still emits the literal `<<`.

## Proposed change

The fast `loads()` path applied `<<` merge keys, but every AST-backed path that returns data left them as a literal `<<` key: the annotated path (`OPT_ANNOTATED`), includes (`OPT_INCLUDES`), and round-trip `to_dict()`. So the same document read one way under `loads()` and another under `OPT_ANNOTATED`, and the Home Assistant packages pattern (`<<: !include base.yaml`) never merged.

The AST mapping conversions now detect a merge key (a plain `<<` scalar or a node tagged `!!merge`, never a quoted `"<<"`) and fold the merged mapping's entries in, inserting only keys not already present so an explicit key and an earlier merge win, exactly as the fast path does. A sequence of mappings merges each in order; a non-mergeable value stays under the literal `<<`. Mappings without a merge key keep the plain insert loop, so only documents that actually use `<<` pay for the merge-aware handling.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
