### PR TITLE
✅ Pin that a self-referential alias is rejected, not cyclic

### DIFF
--- a/tests/core/test_anchors.py
+++ b/tests/core/test_anchors.py
@@ -118,3 +118,17 @@ def test_deleting_unrelated_key_with_preexisting_dangling_alias_is_allowed():
     doc = yamlrocks.loads(b"a: 1\nb: *ghost\nc: 3\n", option=yamlrocks.OPT_ROUND_TRIP)
     del doc["c"]
     assert doc.to_yaml() == b"a: 1\nb: *ghost\n"
+
+
+def test_recursive_self_referential_alias_is_rejected():
+    """A self-referential anchor (`&a` then `- *a`, a list containing itself) is
+    rejected rather than building a cyclic structure. yamlrocks requires an anchor
+    to be defined before it is referenced, which also bounds the
+    infinite-structure/DoS surface; PyYAML/ruamel build the cycle, we do not."""
+    import pytest
+
+    with pytest.raises(yamlrocks.YAMLRocksError, match="alias"):
+        yamlrocks.loads(b"&a\n- *a\n")
+    # A mapping that references its own anchor as a value is rejected too.
+    with pytest.raises(yamlrocks.YAMLRocksError, match="alias"):
+        yamlrocks.loads(b"a: &x\n  b: *x\n")


### PR DESCRIPTION
## Breaking change

None. This is a test-only change that pins existing behavior.

## Proposed change

A self-referential anchor (`&a` then `- *a`, a list that contains itself, or a mapping whose value aliases its own anchor) is rejected with an "unknown alias" error rather than building a cyclic Python structure. yamlrocks requires an anchor to be defined before it is referenced, which also bounds the infinite-structure/DoS surface. PyYAML and ruamel build the cycle; we do not.

This adds a regression test so a future change to alias resolution cannot silently start constructing cycles. No production code changes.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
