### PR TITLE
🐛 Quote an edited flow-unsafe scalar inside a flow collection

### DIFF
--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -64,6 +64,13 @@ struct RoundTripEmitter {
     /// How a synthetic (edited-in) null is rendered. Loaded nulls ignore this and
     /// re-emit in their original form.
     null_style: NullStyle,
+    /// Depth of flow collections (`{}`/`[]`) currently open. When non-zero, a
+    /// plain scalar that contains a flow indicator (`,` `[` `]` `{` `}` `: `) must
+    /// be quoted: those characters are ordinary text in block context (a loaded
+    /// plain scalar may hold them) but would end the entry or collection early
+    /// inside flow. An edited-in value assigned into a flow collection is the case
+    /// that reaches here as a bare plain scalar.
+    flow_depth: usize,
 }
 
 impl RoundTripEmitter {
@@ -71,6 +78,7 @@ impl RoundTripEmitter {
         Self {
             buf: Vec::with_capacity(256),
             null_style,
+            flow_depth: 0,
         }
     }
 
@@ -437,6 +445,14 @@ impl RoundTripEmitter {
             ScalarStyle::Plain if value.starts_with('\u{feff}') => {
                 crate::emit_util::push_double_quoted(&mut self.buf, value);
             }
+            // Inside a flow collection a bare `,`/`[`/`]`/`{`/`}`/`: ` would end
+            // the entry or collection early, so a plain scalar carrying one must
+            // be quoted. This only bites an edited-in value: a loaded plain scalar
+            // never contains a bare flow indicator (the scanner would not produce
+            // it). See [`plain_unsafe_in_flow`].
+            ScalarStyle::Plain if self.flow_depth > 0 && plain_unsafe_in_flow(value) => {
+                crate::emit_util::push_double_quoted(&mut self.buf, value);
+            }
             ScalarStyle::Plain => self.buf.extend_from_slice(value.as_bytes()),
             ScalarStyle::SingleQuoted => crate::emit_util::push_single_quoted(&mut self.buf, value),
             ScalarStyle::DoubleQuoted => crate::emit_util::push_double_quoted(&mut self.buf, value),
@@ -481,6 +497,7 @@ impl RoundTripEmitter {
 
     fn emit_flow_sequence(&mut self, items: &[YamlNode], indent: usize) {
         self.buf.push(b'[');
+        self.flow_depth += 1;
         for (i, item) in items.iter().enumerate() {
             if i > 0 {
                 self.buf.extend_from_slice(b", ");
@@ -488,11 +505,13 @@ impl RoundTripEmitter {
             self.emit_anchor_tag(item);
             self.emit_inline_content(item, indent);
         }
+        self.flow_depth -= 1;
         self.buf.push(b']');
     }
 
     fn emit_flow_mapping(&mut self, pairs: &[(YamlNode, YamlNode)], indent: usize) {
         self.buf.push(b'{');
+        self.flow_depth += 1;
         for (i, (key, val)) in pairs.iter().enumerate() {
             if i > 0 {
                 self.buf.extend_from_slice(b", ");
@@ -503,6 +522,7 @@ impl RoundTripEmitter {
             self.emit_anchor_tag(val);
             self.emit_inline_content(val, indent);
         }
+        self.flow_depth -= 1;
         self.buf.push(b'}');
     }
 
@@ -712,6 +732,18 @@ fn is_empty_scalar(node: &YamlNode) -> bool {
         YamlNodeKind::Scalar(value, ScalarStyle::Plain) => value.is_empty(),
         _ => false,
     }
+}
+
+/// Whether a plain scalar's content would be misread inside a flow collection.
+/// The flow indicators `,` `[` `]` `{` `}` end an entry or the collection, and a
+/// `: ` (colon then space) or a trailing `:` starts a mapping value, so a plain
+/// scalar containing any of them must be quoted when emitted in flow context.
+fn plain_unsafe_in_flow(value: &str) -> bool {
+    value
+        .bytes()
+        .any(|b| matches!(b, b',' | b'[' | b']' | b'{' | b'}'))
+        || value.contains(": ")
+        || value.ends_with(':')
 }
 
 /// Whether a mapping key cannot be written as an inline implicit key and must

--- a/tests/roundtrip/test_edge_cases.py
+++ b/tests/roundtrip/test_edge_cases.py
@@ -361,3 +361,19 @@ def test_round_trip_assign_by_resolved_key_updates_the_entry():
         True: 9,
         False: 7,
     }
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["x,y", "arr[0]", "has, comma", "k: v", "a{b}c", "trailing:"],
+)
+def test_edit_into_flow_collection_quotes_indicators(value):
+    """A value assigned into a flow collection (`[...]`/`{...}`) that contains a
+    flow indicator (`,[]{}` or `: `) is quoted, so it round-trips as one string
+    instead of splitting the entry or breaking the parse."""
+    doc = yamlrocks.loads(b"seq: [1, 2]\nmap: {x: 1}\n", option=RT)
+    doc["seq"][0] = value
+    doc["map"]["x"] = value
+    out = doc.to_yaml()
+    reloaded = yamlrocks.loads(out)
+    assert reloaded == {"seq": [value, 2], "map": {"x": value}}


### PR DESCRIPTION
## Breaking change

None. This only changes how an *edited-in* scalar is emitted inside a flow collection (it is now quoted when it must be); an unmodified document still re-emits byte-for-byte.

## Proposed change

A value assigned into a flow collection (`[...]`/`{...}`) that contained a flow indicator was emitted as a bare plain scalar, so `doc["seq"][0] = "a,b"` produced `[a,b, 2]`, which reparses as two entries (and `[`/`{`/`: ` break the parse outright).

The round-trip emitter now tracks how many flow collections are open and quotes a plain scalar carrying a flow indicator (`,` `[` `]` `{` `}`, or a `: ` / trailing `:`) while inside one. This only affects an edited-in value: a loaded plain scalar never contains a bare flow indicator (the scanner would not produce one), so an unmodified document still re-emits byte-for-byte.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
