### PR TITLE
✨ Expand JSON Schema keyword support (pattern, multipleOf, tuple items, and more)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +210,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +330,7 @@ dependencies = [
  "dunce",
  "itoa",
  "pyo3",
+ "regex",
  "smallvec",
  "stacker",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ dunce = "1"
 # generic `core::fmt` machinery (same digits, just a tighter specialized path).
 itoa = "1"
 pyo3 = { version = "0.29", features = ["extension-module", "py-clone"] }
+# JSON Schema `pattern`/`patternProperties` validation. The `regex` crate runs in
+# guaranteed linear time (no catastrophic backtracking), so an attacker-supplied
+# schema pattern cannot be turned into a ReDoS against the validator.
+regex = "1"
 smallvec = "1"
 # Grows the native stack on demand so recursive descent over deeply nested input
 # cannot overflow a small thread stack (musl/threadpool deployments) and abort the

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -10,7 +10,7 @@ change. Do not edit it by hand.
 
 ## Summary
 
-- MIT License: 32 crate(s)
+- MIT License: 36 crate(s)
 - Apache License 2.0: 3 crate(s)
 - Unicode License v3: 1 crate(s)
 
@@ -598,6 +598,43 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
+- [regex-automata 0.4.14](https://crates.io/crates/regex-automata)
+- [regex-syntax 0.8.11](https://crates.io/crates/regex-syntax)
+- [regex 1.12.4](https://crates.io/crates/regex)
+
+```
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License
+
+Used by:
+
 - [object 0.37.3](https://crates.io/crates/object)
 
 ```
@@ -981,6 +1018,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
+- [aho-corasick 1.1.4](https://crates.io/crates/aho-corasick)
 - [memchr 2.8.2](https://crates.io/crates/memchr)
 
 ```

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -4,13 +4,18 @@
 //! every error carry the source location of the offending node, so schema
 //! failures report a precise line and column.
 //!
-//! A practical subset of JSON Schema (draft 7-ish) is supported: `type`,
-//! `enum`, `const`, `properties`, `required`, `additionalProperties` (boolean),
-//! `items`, `minimum`/`maximum`, `exclusiveMinimum`/`exclusiveMaximum`,
-//! `minLength`/`maxLength`, `minItems`/`maxItems`, the `allOf`/`anyOf`/`oneOf`/
-//! `not` combinators, and `$ref` to local `#/...` pointers (including
-//! `#/$defs/...`). Other keywords are ignored; an unresolvable `$ref` is an
-//! error rather than silently permissive.
+//! A practical subset of JSON Schema (draft 7-ish) is supported: `type` (with a
+//! whole-number float accepted as `integer`), `enum`, `const`, `properties`,
+//! `patternProperties`, `required`, `additionalProperties` (boolean or schema),
+//! `propertyNames`, `minProperties`/`maxProperties`, `dependencies` (property and
+//! schema forms), `items` (single schema, or the draft-07 tuple form with
+//! `additionalItems`), `contains`, `minItems`/`maxItems`, `uniqueItems`,
+//! `minimum`/`maximum`, `exclusiveMinimum`/`exclusiveMaximum`, `multipleOf`,
+//! `minLength`/`maxLength`, `pattern`, the `allOf`/`anyOf`/`oneOf`/`not`
+//! combinators, and `$ref` to local `#/...` pointers (including `#/$defs/...`).
+//! Remaining keywords (`format`, `if`/`then`/`else`, ...) are ignored; an
+//! unresolvable `$ref` and an invalid `pattern` regex are errors rather than
+//! silently permissive.
 
 mod directive;
 
@@ -472,8 +477,15 @@ fn type_matches(name: &str, value: &Value) -> bool {
         "null" => matches!(value, Value::Null),
         "boolean" => matches!(value, Value::Bool(_)),
         // `BigInt` is an integer too large for `i64`; it is still an integer (and
-        // a number) for schema typing.
-        "integer" => matches!(value, Value::Int(_) | Value::BigInt(_)),
+        // a number) for schema typing. Per JSON Schema draft-07 a float with a
+        // zero fractional part is also an integer (`1.0`, `100.0`, `1e2`), so a
+        // YAML scalar written that way validates against `integer` (matching the
+        // `jsonschema` reference); a non-integral float like `2.5` does not.
+        "integer" => match value {
+            Value::Int(_) | Value::BigInt(_) => true,
+            Value::Float(f) => f.is_finite() && f.fract() == 0.0,
+            _ => false,
+        },
         "number" => matches!(value, Value::Int(_) | Value::Float(_) | Value::BigInt(_)),
         "string" => matches!(value, Value::String(_)),
         "array" => matches!(value, Value::Sequence(_)),
@@ -543,6 +555,23 @@ fn check_numeric(
             }
         }
     }
+    if let Some(mult) = get(schema, "multipleOf").and_then(as_f64) {
+        if mult > 0.0 && !is_multiple_of(num, mult) {
+            errors.push(err(
+                node,
+                path,
+                &format!("value {num} is not a multiple of {mult}"),
+            ));
+        }
+    }
+}
+
+/// Whether `num` is an integer multiple of `mult`, tolerant of float rounding so
+/// `6 / 2` and `0.3 / 0.1` are accepted. `mult` is assumed positive (the caller
+/// guards `mult > 0`, matching the JSON Schema requirement).
+fn is_multiple_of(num: f64, mult: f64) -> bool {
+    let ratio = num / mult;
+    (ratio - ratio.round()).abs() <= 1e-9 * ratio.abs().max(1.0)
 }
 
 fn check_string(
@@ -572,6 +601,25 @@ fn check_string(
             ));
         }
     }
+    if let Some(Value::String(pattern)) = get(schema, "pattern") {
+        match compile_pattern(pattern) {
+            Ok(re) if !re.is_match(s) => errors.push(err(
+                node,
+                path,
+                &format!("string does not match pattern /{pattern}/"),
+            )),
+            Err(message) => errors.push(err(node, path, &message)),
+            _ => {}
+        }
+    }
+}
+
+/// Compile a JSON Schema `pattern` into a `regex::Regex`. JSON Schema patterns
+/// are unanchored (a match anywhere satisfies them), which is the crate's default.
+/// An invalid pattern is surfaced as a schema error rather than silently ignored.
+fn compile_pattern(pattern: &str) -> Result<regex::Regex, String> {
+    regex::Regex::new(pattern)
+        .map_err(|_| format!("schema has an invalid regex pattern /{pattern}/"))
 }
 
 fn check_object(
@@ -602,8 +650,28 @@ fn check_object(
         }
     }
 
-    // properties + additionalProperties
+    // properties + patternProperties + additionalProperties
     let additional = get(schema, "additionalProperties");
+    let pattern_properties = match get(schema, "patternProperties") {
+        Some(Value::Mapping(entries)) => entries.as_slice(),
+        _ => &[],
+    };
+    // Compile each `patternProperties` regex once, up front, and reuse it across
+    // every key: compilation is far costlier than matching, so recompiling per
+    // key would be O(keys x patterns). An invalid pattern is reported once here,
+    // not once per key.
+    let compiled_patterns: Vec<(Result<regex::Regex, String>, &Value)> = pattern_properties
+        .iter()
+        .filter_map(|(pat, subschema)| match pat {
+            Value::String(pattern) => Some((compile_pattern(pattern), subschema)),
+            _ => None,
+        })
+        .collect();
+    for (compiled, _) in &compiled_patterns {
+        if let Err(message) = compiled {
+            errors.push(err(node, path, message));
+        }
+    }
     for (key, val) in pairs {
         let Some(key_name) = scalar_key_name(key) else {
             continue;
@@ -616,6 +684,16 @@ fn check_object(
                 validate_node(val, subschema, &child_path, ctx.child(), errors);
             }
         }
+        // patternProperties: a key matching a pattern is validated against that
+        // pattern's schema, and (like `properties`) is no longer "additional".
+        for (compiled, subschema) in &compiled_patterns {
+            if let Ok(re) = compiled {
+                if re.is_match(&key_name) {
+                    matched = true;
+                    validate_node(val, subschema, &child_path, ctx.child(), errors);
+                }
+            }
+        }
         if !matched {
             match additional {
                 Some(Value::Bool(false)) => errors.push(err(
@@ -625,6 +703,82 @@ fn check_object(
                 )),
                 Some(sub @ Value::Mapping(_)) => {
                     validate_node(val, sub, &child_path, ctx.child(), errors)
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // minProperties / maxProperties
+    let count = pairs.len() as i64;
+    if let Some(min) = get(schema, "minProperties").and_then(as_count_bound) {
+        if count < min {
+            errors.push(err(
+                node,
+                path,
+                &format!("object has fewer than minProperties {min}"),
+            ));
+        }
+    }
+    if let Some(max) = get(schema, "maxProperties").and_then(as_count_bound) {
+        if count > max {
+            errors.push(err(
+                node,
+                path,
+                &format!("object has more than maxProperties {max}"),
+            ));
+        }
+    }
+
+    // propertyNames: every key must validate against the subschema *as a string*.
+    // JSON Schema always treats a property name as a string, so validate the raw
+    // key lexeme wrapped in a string node rather than the resolved key (a `123:`
+    // key is the name "123", not the integer 123, so `type: string` passes and a
+    // `pattern` is actually applied to it).
+    if let Some(names_schema) = get(schema, "propertyNames") {
+        for (key, _) in pairs {
+            if let Some(name) = scalar_key_name(key) {
+                let child_path = format!("{path}.{name}");
+                let name_node = YamlNode::new(
+                    YamlNodeKind::Scalar(name.clone(), ScalarStyle::DoubleQuoted),
+                    key.span,
+                );
+                validate_node(&name_node, names_schema, &child_path, ctx.child(), errors);
+            }
+        }
+    }
+
+    // dependencies: a present property can require sibling properties (an array of
+    // names) or that the whole object validate against a schema (a schema
+    // dependency), per draft-07.
+    if let Some(Value::Mapping(deps)) = get(schema, "dependencies") {
+        for (dep_key, dep_val) in deps {
+            let Value::String(trigger) = dep_key else {
+                continue;
+            };
+            if !pairs.iter().any(|(k, _)| scalar_key_eq(k, trigger)) {
+                continue;
+            }
+            match dep_val {
+                // Property dependency: each named sibling must also be present.
+                Value::Sequence(required) => {
+                    for req in required {
+                        if let Value::String(name) = req {
+                            if !pairs.iter().any(|(k, _)| scalar_key_eq(k, name)) {
+                                errors.push(err(
+                                    node,
+                                    path,
+                                    &format!(
+                                        "property '{trigger}' requires '{name}' to also be present"
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                }
+                // Schema dependency: the whole object must match the schema.
+                Value::Mapping(_) | Value::Bool(_) => {
+                    validate_node(node, dep_val, path, ctx.child(), errors);
                 }
                 _ => {}
             }
@@ -662,10 +816,78 @@ fn check_array(
             ));
         }
     }
-    if let Some(items_schema) = get(schema, "items") {
-        for (i, item) in items.iter().enumerate() {
-            let child_path = format!("{path}[{i}]");
-            validate_node(item, items_schema, &child_path, ctx.child(), errors);
+    match get(schema, "items") {
+        // Tuple form: `items` is an array of schemas validated positionally
+        // (draft-07). Element `i` is checked against `items[i]`; elements past
+        // the tuple are checked against `additionalItems` (a schema to apply, or
+        // `false` to forbid extras), and allowed when it is absent.
+        Some(Value::Sequence(schemas)) => {
+            let additional = get(schema, "additionalItems");
+            for (i, item) in items.iter().enumerate() {
+                let child_path = format!("{path}[{i}]");
+                if let Some(subschema) = schemas.get(i) {
+                    validate_node(item, subschema, &child_path, ctx.child(), errors);
+                } else {
+                    match additional {
+                        Some(Value::Bool(false)) => errors.push(err(
+                            item,
+                            &child_path,
+                            &format!("array has more items than the {} allowed", schemas.len()),
+                        )),
+                        Some(sub @ (Value::Mapping(_) | Value::Bool(true))) => {
+                            validate_node(item, sub, &child_path, ctx.child(), errors)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        // Single-schema form: every element is validated against the one schema.
+        Some(items_schema) => {
+            for (i, item) in items.iter().enumerate() {
+                let child_path = format!("{path}[{i}]");
+                validate_node(item, items_schema, &child_path, ctx.child(), errors);
+            }
+        }
+        None => {}
+    }
+
+    // uniqueItems: no two elements may be equal. Elements are compared with
+    // `value_eq`, the same equality `enum`/`const` use (and the `jsonschema`
+    // reference): `1` equals `1.0`, and objects compare order-independently, so
+    // `[1, 1.0]` and `[{a: 1, b: 2}, {b: 2, a: 1}]` are flagged as duplicates. The
+    // resolved values are dropped iteratively to keep a deep tree from
+    // overflowing the stack on teardown.
+    if matches!(get(schema, "uniqueItems"), Some(Value::Bool(true))) {
+        let resolved: Vec<Value> = items
+            .iter()
+            .map(|item| resolve_deep(item, ctx.yaml_11))
+            .collect();
+        let duplicate = resolved
+            .iter()
+            .enumerate()
+            .any(|(i, a)| resolved[i + 1..].iter().any(|b| value_eq(a, b)));
+        for value in resolved {
+            crate::stack::drop_value_tree(value);
+        }
+        if duplicate {
+            errors.push(err(node, path, "array items are not unique"));
+        }
+    }
+
+    // contains: at least one element must validate against the subschema.
+    if let Some(contains) = get(schema, "contains") {
+        let any = items.iter().any(|item| {
+            let mut probe = Vec::new();
+            validate_node(item, contains, path, ctx.child(), &mut probe);
+            probe.is_empty()
+        });
+        if !any {
+            errors.push(err(
+                node,
+                path,
+                "no array item matches the 'contains' schema",
+            ));
         }
     }
 }
@@ -1017,5 +1239,36 @@ mod tests {
         // A quoted "<<" is a literal key, not a merge, so it stays and trips
         // additionalProperties: false.
         assert!(errors("prod:\n  \"<<\": 1\n", &schema2) > 0);
+    }
+
+    #[test]
+    fn tuple_items_validate_positionally() {
+        // `items` as an array checks element i against schema i (draft-07 tuple).
+        let schema = obj(vec![
+            ("type", s("array")),
+            (
+                "items",
+                Value::Sequence(vec![
+                    obj(vec![("type", s("integer"))]),
+                    obj(vec![("type", s("string"))]),
+                ]),
+            ),
+        ]);
+        assert_eq!(errors("[1, two]\n", &schema), 0);
+        assert!(errors("[one, two]\n", &schema) > 0); // first must be an integer
+                                                      // Extra items are allowed when `additionalItems` is absent.
+        assert_eq!(errors("[1, two, 3]\n", &schema), 0);
+
+        // `additionalItems: false` forbids elements past the tuple.
+        let strict = obj(vec![
+            ("type", s("array")),
+            (
+                "items",
+                Value::Sequence(vec![obj(vec![("type", s("integer"))])]),
+            ),
+            ("additionalItems", Value::Bool(false)),
+        ]);
+        assert_eq!(errors("[1]\n", &strict), 0);
+        assert!(errors("[1, 2]\n", &strict) > 0);
     }
 }

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -620,3 +620,76 @@ def test_merge_sequence_preserves_all_leftovers_for_validation():
     failing = {"properties": {"o": {"properties": {"<<": {"minItems": 3}}}}}
     with pytest.raises(yamlrocks.YAMLRocksSchemaError):
         yamlrocks.loads(src, schema=failing)
+
+
+def test_tuple_form_items_validates_positionally():
+    """`items` as an array of schemas validates each element against its position
+    (draft-07 tuple validation), instead of accepting anything."""
+    schema = {"type": "array", "items": [{"type": "integer"}, {"type": "string"}]}
+    assert yamlrocks.loads(b"[1, two]\n", schema=schema) == [1, "two"]
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(b"[one, two]\n", schema=schema)
+
+
+def test_tuple_form_items_additional_items_false_forbids_extras():
+    """`additionalItems: false` rejects elements past the declared tuple."""
+    schema = {
+        "type": "array",
+        "items": [{"type": "integer"}],
+        "additionalItems": False,
+    }
+    assert yamlrocks.loads(b"[1]\n", schema=schema) == [1]
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(b"[1, 2]\n", schema=schema)
+
+
+@pytest.mark.parametrize(
+    ("doc", "schema", "valid"),
+    [
+        (b"6", {"type": "integer", "multipleOf": 2}, True),
+        (b"7", {"type": "integer", "multipleOf": 2}, False),
+        (b"[1, 2, 3]", {"type": "array", "uniqueItems": True}, True),
+        (b"[1, 1, 2]", {"type": "array", "uniqueItems": True}, False),
+        # uniqueItems uses value equality: 1 == 1.0, and objects compare
+        # order-independently, so these are duplicates.
+        (b"[1, 1.0]", {"uniqueItems": True}, False),
+        (b"[{a: 1, b: 2}, {b: 2, a: 1}]", {"uniqueItems": True}, False),
+        (b'[1, "x"]', {"type": "array", "contains": {"type": "string"}}, True),
+        (b"[1, 2]", {"type": "array", "contains": {"type": "string"}}, False),
+        (b"{a: 1, b: 2}", {"minProperties": 2, "maxProperties": 2}, True),
+        (b"{a: 1}", {"minProperties": 2}, False),
+        (b"{a: 1, b: 2, c: 3}", {"maxProperties": 2}, False),
+        (b"{a: 1, b: 2}", {"dependencies": {"a": ["b"]}}, True),
+        (b"{a: 1}", {"dependencies": {"a": ["b"]}}, False),
+        (b"{ab: 1}", {"propertyNames": {"maxLength": 3}}, True),
+        (b"{abcd: 1}", {"propertyNames": {"maxLength": 3}}, False),
+        # A property name is always a string, even a numeric-looking key: `123`
+        # is the name "123", so `type: string` passes and a `pattern` applies.
+        (b"{123: x}", {"propertyNames": {"type": "string"}}, True),
+        (b"{123: x}", {"propertyNames": {"pattern": "^[a-z]+$"}}, False),
+        (b'v: "12345"', {"properties": {"v": {"pattern": "^[0-9]+$"}}}, True),
+        (b'v: "12a"', {"properties": {"v": {"pattern": "^[0-9]+$"}}}, False),
+        (b"{s_x: 1}", {"patternProperties": {"^s_": {"type": "integer"}}}, True),
+        (b"{s_x: hi}", {"patternProperties": {"^s_": {"type": "integer"}}}, False),
+        (b"1.0", {"type": "integer"}, True),  # integral float is an integer (draft-07)
+        (b"2.5", {"type": "integer"}, False),
+    ],
+)
+def test_extended_schema_keywords(doc, schema, valid):
+    """The extended keyword set (multipleOf, uniqueItems, contains,
+    min/maxProperties, dependencies, propertyNames, pattern, patternProperties,
+    and integral-float integers) is enforced, not silently ignored."""
+    if valid:
+        yamlrocks.loads(doc, schema=schema)
+    else:
+        with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+            yamlrocks.loads(doc, schema=schema)
+
+
+def test_schema_invalid_pattern_is_reported_not_ignored():
+    """A malformed regex in a schema pattern surfaces as a schema error rather
+    than being silently skipped."""
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError, match="regex"):
+        yamlrocks.loads(
+            b'v: "x"', schema={"properties": {"v": {"pattern": "[unclosed"}}}
+        )


### PR DESCRIPTION
## Breaking change

None. Documents that were already valid stay valid: this only enforces keywords that were previously ignored. A schema that relied on, say, `pattern` doing nothing will now actually validate it, but that is fixing a silent no-op, not changing conforming behavior.

## Proposed change

The schema validator handled a core subset (`type`, `enum`, `const`, `properties`, `required`, boolean `additionalProperties`, single-schema `items`, the numeric and length bounds, the combinators, and `$ref`). Everything else was silently ignored, so a schema using a common keyword validated nothing.

This adds a practical draft-07 keyword set:

- `type: integer` accepts a whole-number float (`1.0`, `1e2`), matching the `jsonschema` reference; a non-integral float still fails.
- `multipleOf`, tolerant of float rounding.
- `pattern` and `patternProperties`, compiled with the `regex` crate. It runs in guaranteed linear time, so an attacker-supplied schema pattern cannot be turned into a ReDoS against the validator; an invalid pattern is reported as a schema error rather than silently ignored.
- `additionalProperties` as a schema (not only boolean).
- `propertyNames`, `minProperties`/`maxProperties`, and `dependencies` (both the property-list and schema forms).
- the draft-07 tuple form of `items` with `additionalItems`, plus `contains` and `uniqueItems`.

Remaining keywords (`format`, `if`/`then`/`else`, ...) are still ignored, and the module docs say so. Adds the `regex` dependency (and regenerates `THIRD_PARTY_LICENSES.md`).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
