### PR TITLE
📝 Document the expanded JSON Schema keyword support

### DIFF
--- a/docs/src/content/docs/guides/schema-validation.md
+++ b/docs/src/content/docs/guides/schema-validation.md
@@ -250,28 +250,59 @@ yamlrocks.loads(b"3.14", schema=schema)
 #                         the anyOf schemas at $ (line 1, column 1)
 ```
 
+## Patterns
+
+`pattern` constrains a string with a regular expression, and `patternProperties`
+applies a schema to every key that matches a pattern. The regex engine runs in
+guaranteed linear time, so an untrusted schema pattern cannot stall the
+validator, and an invalid pattern is reported as a schema error rather than
+silently skipped.
+
+```python
+import yamlrocks
+
+schema = {
+    "type": "object",
+    "properties": {"name": {"type": "string", "pattern": "^[a-z][a-z0-9-]*$"}},
+    "patternProperties": {"^port_": {"type": "integer"}},
+}
+
+source = """
+name: web-app
+port_http: 80
+port_https: 443
+"""
+
+yamlrocks.loads(source, schema=schema)
+# {'name': 'web-app', 'port_http': 80, 'port_https': 443}
+```
+
+A property name is always treated as a string, so `propertyNames` and a
+`patternProperties` key match a numeric-looking key like `123` as the text
+`"123"`.
+
 ## Supported keywords
 
 YAMLRocks implements a practical, draft-7-ish subset of JSON Schema, enough to
 express the constraints configuration files actually need, without pulling in a
 full validator. The supported keywords are:
 
-| Group       | Keywords                                                                     |
-| ----------- | ---------------------------------------------------------------------------- |
-| Types       | `type` (`null`, `boolean`, `integer`, `number`, `string`, `array`, `object`) |
-| Values      | `enum`, `const`                                                              |
-| Objects     | `properties`, `required`, `additionalProperties` (boolean or schema)         |
-| Arrays      | `items`, `minItems`, `maxItems`                                              |
-| Numbers     | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`                 |
-| Strings     | `minLength`, `maxLength`                                                     |
-| Combinators | `allOf`, `anyOf`, `oneOf`, `not`                                             |
-| References  | `$ref` (local `#/...` pointers, including `#/$defs/...`)                     |
+| Group       | Keywords                                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Types       | `type` (`null`, `boolean`, `integer`, `number`, `string`, `array`, `object`; a whole-number float counts as `integer`)                                       |
+| Values      | `enum`, `const`                                                                                                                                              |
+| Objects     | `properties`, `patternProperties`, `required`, `additionalProperties` (boolean or schema), `propertyNames`, `minProperties`, `maxProperties`, `dependencies` |
+| Arrays      | `items` (single schema or the draft-7 tuple form), `additionalItems`, `minItems`, `maxItems`, `contains`, `uniqueItems`                                      |
+| Numbers     | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`                                                                                   |
+| Strings     | `minLength`, `maxLength`, `pattern`                                                                                                                          |
+| Combinators | `allOf`, `anyOf`, `oneOf`, `not`                                                                                                                             |
+| References  | `$ref` (local `#/...` pointers, including `#/$defs/...`)                                                                                                     |
 
 :::note[Unknown keywords are ignored]
 This is a deliberately small subset. Keywords YAMLRocks does not implement (such as
-`pattern` or `format`) are skipped rather than rejected, so a richer schema
-written for another validator still works here; it just validates against the
-keywords listed above. If you need a feature that is missing, validate with a
+`format`, or `if`/`then`/`else`) are skipped rather than rejected, so a richer
+schema written for another validator still works here; it just validates against
+the keywords listed above. If you need a feature that is missing, validate with a
 dedicated JSON Schema library after `loads` returns.
 :::
 


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

The schema-validation guide still described the old keyword subset and, in the "unknown keywords are ignored" note, listed `pattern` as unsupported, which is no longer true after #190.

This updates the guide to match the validator:

- Adds a "Patterns" section with a working `pattern` / `patternProperties` example, plus the note that a property name is always treated as a string.
- Rewrites the supported-keywords table to include the full set: `patternProperties`, `propertyNames`, `minProperties`/`maxProperties`, `dependencies`, the draft-7 tuple form of `items` with `additionalItems`, `contains`, `uniqueItems`, `multipleOf`, `pattern`, and integral-float integers.
- Fixes the "unknown keywords" note to name only keywords that really are ignored (`format`, `if`/`then`/`else`).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #190
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
