### PR TITLE
📝 Document merging an included file with the << merge key

### DIFF
--- a/docs/src/content/docs/guides/includes.md
+++ b/docs/src/content/docs/guides/includes.md
@@ -158,6 +158,36 @@ Either way the walk skips hidden entries (any file or directory whose name begin
 with `.`), and when `OPT_SECRETS` is active it also skips a `secrets.yaml` (it is
 configuration for the [`!secret`](/guides/tags/) feature, not content to include).
 
+## Merging an included file with `<<`
+
+A [merge key](/guides/loading/#anchors-aliases-and-merge-keys) can take an
+`!include` as its value: `<<: !include defaults.yaml` folds the included mapping
+into the current one, and locally written keys still win. This is the shared
+"defaults" idiom (Home Assistant's packages pattern), and it works because the
+merge runs after the include resolves:
+
+```python
+import os
+import tempfile
+import yamlrocks
+
+config = tempfile.mkdtemp()
+
+with open(os.path.join(config, "defaults.yaml"), "wb") as handle:
+    handle.write(b"retries: 3\ntimeout: 30\n")
+
+with open(os.path.join(config, "service.yaml"), "wb") as handle:
+    handle.write(b"service:\n  <<: !include defaults.yaml\n  timeout: 60\n")
+
+data = yamlrocks.load(
+    os.path.join(config, "service.yaml"),
+    option=yamlrocks.OPT_INCLUDES,
+)
+
+# The included defaults are merged in; the local `timeout` overrides.
+assert data["service"] == {"retries": 3, "timeout": 60}
+```
+
 ## Editing includes and writing them back
 
 The real power of native includes shows up when you combine `OPT_INCLUDES` with


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

The includes guide covered the `!include_dir_merge_*` tags but not the common `<<: !include defaults.yaml` pattern, where a merge key takes an include as its value and folds the included mapping into the current one (locally written keys still win). It is the shared-defaults idiom (Home Assistant's packages pattern), and the behavior the includes path gained in #186.

Adds a short, runnable section showing it, next to the other include forms.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #186
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
