### PR TITLE
🐛 Order merged mapping keys by source position on the fast path

### DIFF
--- a/docs/src/content/docs/guides/loading.md
+++ b/docs/src/content/docs/guides/loading.md
@@ -186,7 +186,7 @@ use:
 """
 
 yamlrocks.loads(merge)
-# {'base': {'x': 1}, 'use': {'y': 2, 'x': 1}}
+# {'base': {'x': 1}, 'use': {'x': 1, 'y': 2}}
 ```
 
 Explicit keys win over merged ones, and earlier merges win over later ones,

--- a/docs/src/content/docs/guides/yaml-11-vs-12.md
+++ b/docs/src/content/docs/guides/yaml-11-vs-12.md
@@ -104,7 +104,7 @@ use:
 """
 
 yamlrocks.loads(source)
-# {'base': {'x': 1}, 'use': {'y': 2, 'x': 1}}
+# {'base': {'x': 1}, 'use': {'x': 1, 'y': 2}}
 ```
 
 ## Why 1.2 is the default

--- a/src/decode/merge.rs
+++ b/src/decode/merge.rs
@@ -1,7 +1,8 @@
 //! YAML merge-key (`<<`) resolution for the fast decode path.
 
 use std::borrow::Cow;
-use std::collections::HashSet;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use super::Value;
@@ -31,7 +32,7 @@ fn literal_merge_key() -> Value<'static> {
 }
 
 /// An injective string signature of a mapping key, so membership during a merge
-/// is O(1) via a `HashSet` rather than an O(n) linear scan (a single `<<` over a
+/// is O(1) via a hash map rather than an O(n) linear scan (a single `<<` over a
 /// large mapping was otherwise quadratic). It mirrors `Value`'s own equality,
 /// which is type-distinct: `Int(1)` and `Float(1.0)` are different keys. Strings
 /// are length-prefixed so no value can spoof another's signature.
@@ -128,28 +129,43 @@ fn apply_merge_keys_inner(value: &mut Value<'_>) {
             if !pairs.iter().any(|(k, _)| is_merge_key(k)) {
                 return;
             }
+            // Rebuild the mapping in source order. An explicit (non-merge) key is
+            // inserted at its position, overriding in place a value merged in
+            // earlier if the same key was already pulled in (explicit keys win). A
+            // `<<` expands its mapping at its own position, contributing only keys
+            // not already present, so an explicit key and an earlier merge both
+            // win. This keeps the fast path's key order identical to the annotated
+            // and round-trip paths, which build the same shape through Python dict
+            // insertion. `index` maps a key signature to its slot in `result` for
+            // O(1) membership, so a `<<` over a large mapping stays linear.
             let mut result: Vec<(Value<'_>, Value<'_>)> = Vec::with_capacity(pairs.len());
-            let mut merges: Vec<(Value<'_>, Value<'_>)> = Vec::new();
+            let mut index: HashMap<String, usize> = HashMap::new();
             for (key, val) in std::mem::take(pairs) {
                 if is_merge_key(&key) {
-                    merges.push((key, val));
+                    if let Some(unmerged) = merge_into(&mut result, &mut index, val) {
+                        // The `<<` value is not a mapping (or list of mappings) the
+                        // parser can fold, e.g. a custom tag such as
+                        // `<<: !include other.yaml` (a deferred marker resolved by
+                        // the host). Keep it under the literal `<<` key rather than
+                        // dropping it, so the host can run its own merge pass. (The
+                        // marker is internal; it must not escape into the data.)
+                        let sig = key_sig(&literal_merge_key());
+                        if let Entry::Vacant(slot) = index.entry(sig) {
+                            slot.insert(result.len());
+                            result.push((literal_merge_key(), unmerged));
+                        }
+                    }
                 } else {
-                    result.push((key, val));
-                }
-            }
-            // Track present keys by signature so a merge skips already-present keys
-            // in O(1); the explicit (non-merge) keys seed it.
-            let mut seen: HashSet<String> = result.iter().map(|(k, _)| key_sig(k)).collect();
-            for (_marker, merge) in merges {
-                if let Some(unmerged) = merge_into(&mut result, &mut seen, merge) {
-                    // The `<<` value is not a mapping (or list of mappings) the
-                    // parser can fold, e.g. a custom tag such as
-                    // `<<: !include other.yaml` (a deferred marker resolved by
-                    // the host). Keep the key as the literal string `<<` with its
-                    // resolved value rather than silently dropping it, so the host
-                    // can run its own merge pass over it. (The marker is internal;
-                    // it must not escape into the returned data.)
-                    result.push((literal_merge_key(), unmerged));
+                    let sig = key_sig(&key);
+                    match index.get(&sig) {
+                        // An explicit key already merged in: override its value in
+                        // place, keeping the position it first appeared at.
+                        Some(&i) => result[i].1 = val,
+                        None => {
+                            index.insert(sig, result.len());
+                            result.push((key, val));
+                        }
+                    }
                 }
             }
             *pairs = result;
@@ -186,15 +202,16 @@ pub(super) fn is_merge_key(key: &Value<'_>) -> bool {
 /// contributes nothing and is ignored.
 fn merge_into<'i>(
     result: &mut Vec<(Value<'i>, Value<'i>)>,
-    seen: &mut HashSet<String>,
+    index: &mut HashMap<String, usize>,
     merge: Value<'i>,
 ) -> Option<Value<'i>> {
     match merge {
         Value::Mapping(pairs) => {
             for (key, val) in pairs {
-                // `insert` returns false when the key is already present (an
-                // explicit key, or an earlier merge), so it is not overridden.
-                if seen.insert(key_sig(&key)) {
+                // A key already present (an explicit key, or an earlier merge) is
+                // not overridden; only a missing key is pulled in, at its position.
+                if let Entry::Vacant(slot) = index.entry(key_sig(&key)) {
+                    slot.insert(result.len());
                     result.push((key, val));
                 }
             }
@@ -205,7 +222,7 @@ fn merge_into<'i>(
             // can be preserved under `<<` rather than silently lost.
             let mut leftover = Vec::new();
             for item in items {
-                if let Some(unmerged) = merge_into(result, seen, item) {
+                if let Some(unmerged) = merge_into(result, index, item) {
                     leftover.push(unmerged);
                 }
             }

--- a/tests/core/test_merge_keys.py
+++ b/tests/core/test_merge_keys.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import yamlrocks
 
 
@@ -173,3 +175,30 @@ def test_merge_sequence_with_non_mergeable_element_keeps_only_leftover():
     assert (
         yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["o"] == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("src", "order"),
+    [
+        # A `<<` expands at its own position; explicit keys keep their spot.
+        (b"base: &b {x: 1}\nuse:\n  <<: *b\n  y: 2\n", ["x", "y"]),
+        (b"base: &b {x: 1}\nuse:\n  y: 2\n  <<: *b\n", ["y", "x"]),
+        # An explicit key overrides a merged one in place (keeps its position).
+        (b"base: &b {x: 1, z: 9}\nuse:\n  z: 0\n  <<: *b\n  y: 2\n", ["z", "x", "y"]),
+        # A list merge expands each source in order, at the `<<` position.
+        (
+            b"a: &a {p: 1}\nb: &b {q: 2}\nuse:\n  <<: [*a, *b]\n  r: 3\n",
+            ["p", "q", "r"],
+        ),
+    ],
+)
+def test_merge_key_order_is_source_order_on_every_path(src, order):
+    """Merged keys land at the `<<` position and explicit keys keep their written
+    spot, and the fast, annotated, and round-trip paths all agree on that order
+    (previously the fast path put explicit keys first, diverging from the others)."""
+    fast = list(yamlrocks.loads(src)["use"].keys())
+    annotated = list(dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED)["use"]))
+    round_trip = list(
+        yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["use"].keys()
+    )
+    assert fast == annotated == round_trip == order


### PR DESCRIPTION
## Breaking change

Key **order** only, never values. A merged mapping loaded through `loads()` now comes back in source order (an explicit key keeps its written position; a `<<` expands at its own position) instead of explicit-keys-first. Every value is identical to before, and to what the annotated / round-trip paths already returned. Code that relied on the old iteration or `dumps` order of a merged mapping would see a different order; code that indexes by key is unaffected. This deliberately does **not** match PyYAML's merged-keys-first ordering; internal consistency and a predictable source order were chosen over replicating that quirk.

## Proposed change

The fast `loads()` path rebuilt a mapping that used `<<` as explicit-keys-first then merged-keys-appended, so the same document loaded through `loads()` and through `OPT_ANNOTATED` (or round-trip `to_dict`) came back with a *different* key order. The annotated and round-trip paths build the mapping in source order via Python dict insertion; the fast path did not.

The fast path now walks the pairs in source order too: an explicit key keeps its written position (overriding in place a value merged in earlier, since explicit keys win), and a `<<` expands its mapping at its own position, contributing only keys not already present. A `key_sig -> slot` index keeps membership O(1), so a `<<` over a large mapping stays linear. All three paths now agree.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #186, #188
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
