### PR TITLE
🐛 Validate anchors and aliases on the composer paths too

### DIFF
--- a/src/roundtrip/anchors.rs
+++ b/src/roundtrip/anchors.rs
@@ -431,13 +431,36 @@ mod tests {
 
     #[test]
     fn cyclic_anchor_terminates_via_depth_cap() {
-        // A self-referential anchor (`&x` whose value contains `*x`) would recurse
-        // forever without the alias-hop depth cap. This is cheap (the cap stops it
-        // after MAX_ALIAS_DEPTH hops); the larger alias-bomb class is bounded by
-        // the shared node budget in `build_anchor_map`, not exercised here because
-        // doing so would allocate up to that budget.
-        let map = build_anchor_map(&roots("a: &x\n  self: *x\n"));
+        // A self-referential anchor (`&x` whose value contains `*x`) is rejected at
+        // compose time now (an `*alias` must name an anchor already defined in the
+        // document), so a document can no longer build a cyclic AST. The alias-hop
+        // depth cap remains as defense-in-depth for a cycle constructed directly:
+        // build one by hand and confirm expansion terminates rather than recursing
+        // forever. The larger alias-bomb class is bounded by the shared node budget
+        // in `build_anchor_map`, not exercised here because it would allocate up to
+        // that budget.
+        let zero = Span {
+            file_id: 0,
+            line: 0,
+            column: 0,
+            offset: 0,
+        };
+        let mut node = YamlNode::new(
+            YamlNodeKind::Mapping(vec![(
+                YamlNode::new(
+                    YamlNodeKind::Scalar("self".to_owned(), crate::scanner::ScalarStyle::Plain),
+                    zero,
+                ),
+                YamlNode::new(YamlNodeKind::Alias("x".to_owned()), zero),
+            )]),
+            zero,
+        );
+        node.anchor = Some("x".to_owned());
+        let map = build_anchor_map(&[node]);
         assert!(map.contains_key("x"));
+
+        // And the composer refuses the same structure from a document.
+        assert!(compose("a: &x\n  self: *x\n").is_err());
     }
 
     #[test]

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -502,6 +502,11 @@ struct Composer<'input> {
     pending_anchor: Option<String>,
     pending_comments: Vec<String>,
     depth: usize,
+    /// Names of the `&anchor`s defined so far in the current document, so an
+    /// `*alias` can be rejected when it names an anchor that has not been defined
+    /// (an unknown or forward reference), matching the fast decoder and PyYAML.
+    /// Anchors do not cross documents, so this is cleared at each document start.
+    anchors_seen: HashSet<String>,
 }
 
 impl<'input> Composer<'input> {
@@ -514,6 +519,7 @@ impl<'input> Composer<'input> {
             pending_anchor: None,
             pending_comments: Vec::new(),
             depth: 0,
+            anchors_seen: HashSet::new(),
         }
     }
 
@@ -554,6 +560,9 @@ impl<'input> Composer<'input> {
                 EventKind::DocumentStart => {
                     let marker_span = events[self.pos].span;
                     self.pos += 1;
+                    // Anchors are document-scoped: a `*alias` cannot reach an
+                    // `&anchor` from an earlier document.
+                    self.anchors_seen.clear();
                     if let Some(mut node) = self.compose_node(events)? {
                         // An explicit `---` produces this event; record it so the
                         // marker is preserved on re-emission.
@@ -585,6 +594,9 @@ impl<'input> Composer<'input> {
                 }
                 _ => {
                     let start_pos = self.pos;
+                    // A document with no leading `---` still starts fresh: its
+                    // anchors must not leak from a previous document.
+                    self.anchors_seen.clear();
                     if let Some(mut node) = self.compose_node(events)? {
                         // The parser requires a `---` after any directive, so a
                         // document reaching this arm normally has none pending.
@@ -642,6 +654,14 @@ impl<'input> Composer<'input> {
                     self.pos += 1;
                 }
                 EventKind::Anchor(name) => {
+                    // A node can carry only one anchor; a second with no
+                    // intervening node (`&a\n&b value`) is invalid.
+                    if self.pending_anchor.is_some() {
+                        return Err(ScanError::new(
+                            "a node cannot have two anchors".to_owned(),
+                            events[self.pos].span,
+                        ));
+                    }
                     self.pending_anchor = Some(name.clone());
                     self.pos += 1;
                 }
@@ -694,6 +714,20 @@ impl<'input> Composer<'input> {
             }
 
             EventKind::Alias(name) => {
+                // An alias is a bare reference: it cannot carry its own anchor or
+                // tag (`&b *a` / `!t *a` are invalid), and it must name an anchor
+                // already defined in this document (an unknown or forward
+                // reference is an error, not a silent null). Mirrors the fast
+                // decoder and PyYAML.
+                if anchor.is_some() || tag.is_some() {
+                    return Err(ScanError::new(
+                        "an alias node cannot have an anchor or tag".to_owned(),
+                        span,
+                    ));
+                }
+                if !self.anchors_seen.contains(name) {
+                    return Err(ScanError::new(format!("unknown alias: *{name}"), span));
+                }
                 self.pos += 1;
                 YamlNode::new(YamlNodeKind::Alias(name.clone()), span)
             }
@@ -733,6 +767,12 @@ impl<'input> Composer<'input> {
             }
         };
 
+        // Record this node's anchor only now, after its children are composed, so
+        // a self-referential alias (`&a [*a]`) is still an unknown reference when
+        // the inner `*a` is reached, matching the fast decoder.
+        if let Some(name) = &anchor {
+            self.anchors_seen.insert(name.clone());
+        }
         node.anchor = anchor;
         node.tag = tag;
         node.comments = comments;

--- a/tests/core/test_anchors.py
+++ b/tests/core/test_anchors.py
@@ -108,16 +108,45 @@ def test_deleting_a_nested_anchor_target_still_referenced_raises():
     assert yamlrocks.loads(doc.to_yaml())["ref"] == 1
 
 
-def test_deleting_unrelated_key_with_preexisting_dangling_alias_is_allowed():
-    """A delete is only blocked for an alias it *newly* orphans.
+def test_unknown_alias_is_rejected_on_every_load_path():
+    """An `*alias` that names no anchor is an error on every path, not a silent
+    null. The round-trip and includes paths run through the composer, which used
+    to skip this check and quietly resolve an undefined (or forward) reference to
+    `None`; they now reject it like the fast and annotated paths (and PyYAML)."""
+    import pytest
 
-    The round-trip path does not validate alias targets at load time, so a
-    document can already carry a dangling `*alias`. Deleting an unrelated key must
-    not be blamed for that pre-existing break.
-    """
-    doc = yamlrocks.loads(b"a: 1\nb: *ghost\nc: 3\n", option=yamlrocks.OPT_ROUND_TRIP)
-    del doc["c"]
-    assert doc.to_yaml() == b"a: 1\nb: *ghost\n"
+    for opt in (
+        0,
+        yamlrocks.OPT_ANNOTATED,
+        yamlrocks.OPT_ROUND_TRIP,
+        yamlrocks.OPT_INCLUDES,
+    ):
+        with pytest.raises(yamlrocks.YAMLRocksError, match="unknown alias"):
+            yamlrocks.loads(b"a: 1\nb: *ghost\n", option=opt)
+    # A forward reference (`*x` before `&x`) is likewise rejected, and an anchor
+    # does not leak across documents.
+    with pytest.raises(yamlrocks.YAMLRocksError, match="unknown alias"):
+        yamlrocks.loads(b"---\na: &x 1\n---\nb: *x\n", option=yamlrocks.OPT_ROUND_TRIP)
+
+
+def test_malformed_anchor_or_tag_is_rejected_on_every_load_path():
+    """An alias cannot carry its own anchor/tag, and a node cannot have two
+    anchors. The composer paths enforce this like the fast decoder (and PyYAML),
+    instead of silently accepting the malformed node."""
+    import pytest
+
+    for opt in (
+        0,
+        yamlrocks.OPT_ANNOTATED,
+        yamlrocks.OPT_ROUND_TRIP,
+        yamlrocks.OPT_INCLUDES,
+    ):
+        with pytest.raises(yamlrocks.YAMLRocksError, match="anchor or tag"):
+            yamlrocks.loads(b"a: &a 1\nb: &b *a\n", option=opt)
+        with pytest.raises(yamlrocks.YAMLRocksError, match="anchor or tag"):
+            yamlrocks.loads(b"a: &a 1\nb: !!str *a\n", option=opt)
+        with pytest.raises(yamlrocks.YAMLRocksError, match="two anchors"):
+            yamlrocks.loads(b"a: &a\n  &b 1\n", option=opt)
 
 
 def test_recursive_self_referential_alias_is_rejected():


### PR DESCRIPTION
## Breaking change

Documents that were **already invalid** now raise on the round-trip and includes paths instead of being silently accepted (an undefined `*alias` used to resolve to `None` there; a malformed anchor/tag was accepted). No valid document changes behavior. This aligns the composer paths with the fast/annotated paths and PyYAML, so it removes an inconsistency rather than adding one.

## Proposed change

The fast decoder rejects three malformed anchor/alias constructs; the round-trip composer (which backs `OPT_ROUND_TRIP` and `OPT_INCLUDES`) did not, so the same document was a hard error on the fast and annotated paths but silently accepted on the composer paths:

- an unknown or forward `*alias` (`b: *ghost`) resolved to a silent `None` instead of erroring, so a typo in an alias name became data loss;
- an alias carrying its own anchor or tag (`&b *a`, `!!str *a`) was accepted;
- a node with two anchors (`&a\n&b value`) was accepted.

The composer now enforces all three, matching the fast decoder and PyYAML. It tracks the anchors defined so far in the current document (recording each only after its children compose, so a self-reference is still an unknown reference) and clears that set at every document boundary, so an anchor cannot leak across documents either. Valid aliases are unaffected; all load paths now agree.

Found by a differential cross-path consistency sweep.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #185, #187
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
