### PR TITLE
🐛 Use the last value of a duplicate key in a merge source

### DIFF
--- a/src/decode/merge.rs
+++ b/src/decode/merge.rs
@@ -193,6 +193,27 @@ pub(super) fn is_merge_key(key: &Value<'_>) -> bool {
     matches!(key, Value::Tagged(tag, _) if tag == MERGE_TAG)
 }
 
+/// Collapse duplicate keys in a mapping's pairs to last-wins, keeping each key at
+/// the position it first appeared, so the pairs read as the mapping's data value
+/// (a repeated key resolves to its last value, exactly as building a Python dict
+/// would). Only used for a `<<` merge source, where a duplicate would otherwise
+/// be resolved first-wins. Runs only when a `<<` is present, over the (typically
+/// small) merge source, so the extra pass is off the hot path.
+fn dedup_last_wins<'i>(pairs: Vec<(Value<'i>, Value<'i>)>) -> Vec<(Value<'i>, Value<'i>)> {
+    let mut seen: HashMap<String, usize> = HashMap::with_capacity(pairs.len());
+    let mut out: Vec<(Value<'i>, Value<'i>)> = Vec::with_capacity(pairs.len());
+    for (key, val) in pairs {
+        match seen.entry(key_sig(&key)) {
+            Entry::Occupied(slot) => out[*slot.get()].1 = val,
+            Entry::Vacant(slot) => {
+                slot.insert(out.len());
+                out.push((key, val));
+            }
+        }
+    }
+    out
+}
+
 /// Merge a `<<` value (a mapping, or a sequence of mappings) into `result`,
 /// adding only keys that are not already present.
 ///
@@ -207,7 +228,12 @@ fn merge_into<'i>(
 ) -> Option<Value<'i>> {
     match merge {
         Value::Mapping(pairs) => {
-            for (key, val) in pairs {
+            // A merge source that repeats a key contributes that key's *last*
+            // value (the value the mapping has as data), so collapse duplicates
+            // last-wins before merging. Without this the first duplicate would win
+            // here, so `<<: *a` with `&a {x: 1, x: 2}` merged `x: 1` while the same
+            // anchor materializes as `{x: 2}` everywhere else (and in PyYAML).
+            for (key, val) in dedup_last_wins(pairs) {
                 // A key already present (an explicit key, or an earlier merge) is
                 // not overridden; only a missing key is pulled in, at its position.
                 if let Entry::Vacant(slot) = index.entry(key_sig(&key)) {

--- a/tests/core/test_merge_keys.py
+++ b/tests/core/test_merge_keys.py
@@ -202,3 +202,18 @@ def test_merge_key_order_is_source_order_on_every_path(src, order):
         yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["use"].keys()
     )
     assert fast == annotated == round_trip == order
+
+
+def test_duplicate_key_in_merge_source_uses_last_value():
+    """A `<<` source mapping that repeats a key contributes that key's LAST value
+    (the value it has as data), not the first, matching how the same anchor
+    materializes on its own and every other path (and PyYAML). An explicit key in
+    the target still wins over the merged one."""
+    # `&a {x: 1, x: 2}` is `{x: 2}` as data, so merging it gives x = 2, not 1.
+    assert yamlrocks.loads(b"a: &a {x: 1, x: 2}\nc:\n  <<: *a\n")["c"] == {"x": 2}
+    # Block-style anchor with a repeated key behaves the same.
+    assert yamlrocks.loads(b"a: &a\n  x: 1\n  x: 2\nc:\n  <<: *a\n")["c"] == {"x": 2}
+    # An explicit target key still overrides the (deduped) merged value.
+    assert yamlrocks.loads(b"a: &a {x: 1, x: 2}\nc:\n  x: 9\n  <<: *a\n")["c"] == {
+        "x": 9
+    }


### PR DESCRIPTION
## Breaking change

None. Values only become *more* correct: a `<<` merge whose source repeats a key now yields that key's last value on the fast path, matching every other path and PyYAML. No document that used a well-formed (no-duplicate) merge source changes.

## Proposed change

A `<<` merge whose source mapping repeats a key merged that key's **first** value on the fast path, because `merge_into` walked the source's raw pairs and pulled in only a missing key. But a mapping with a repeated key resolves to its **last** value as data, so `&a {x: 1, x: 2}` is `{x: 2}` on its own and via a plain alias, yet `<<: *a` produced `x: 1` — only through the fast path. Every other path (annotated, includes, round-trip) and PyYAML give `x: 2`.

The fast merge now collapses a source mapping's duplicate keys last-wins before merging, so the merged value matches the mapping's own data value. An explicit key in the target still wins over the merged one, and the dedup runs only when a `<<` is present, over the (small) merge source, so it stays off the hot path.

Found by a differential cross-path consistency sweep.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #193
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
