### PR TITLE
🐛 Check integer multipleOf exactly instead of via a lossy float

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -555,23 +555,45 @@ fn check_numeric(
             }
         }
     }
-    if let Some(mult) = get(schema, "multipleOf").and_then(as_f64) {
-        if mult > 0.0 && !is_multiple_of(num, mult) {
-            errors.push(err(
-                node,
-                path,
-                &format!("value {num} is not a multiple of {mult}"),
-            ));
+    if let Some(mult_value) = get(schema, "multipleOf") {
+        if let Some(mult) = as_f64(mult_value) {
+            if mult > 0.0 && !is_multiple_of(resolved, mult_value, num, mult) {
+                errors.push(err(
+                    node,
+                    path,
+                    &format!("value {num} is not a multiple of {mult}"),
+                ));
+            }
         }
     }
 }
 
-/// Whether `num` is an integer multiple of `mult`, tolerant of float rounding so
-/// `6 / 2` and `0.3 / 0.1` are accepted. `mult` is assumed positive (the caller
-/// guards `mult > 0`, matching the JSON Schema requirement).
-fn is_multiple_of(num: f64, mult: f64) -> bool {
-    let ratio = num / mult;
-    (ratio - ratio.round()).abs() <= 1e-9 * ratio.abs().max(1.0)
+/// A value's exact integer form, if it has one: a plain `Int`, or a `BigInt`
+/// whose digits fit `i128` (which covers every realistic integer). Used for an
+/// exact `multipleOf` check that a lossy `f64` conversion would get wrong.
+fn as_i128(value: &Value) -> Option<i128> {
+    match value {
+        Value::Int(i) => Some(*i as i128),
+        Value::BigInt(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+/// Whether `value` is an integer multiple of `mult_value`.
+///
+/// When both operands are integers the check is exact (integer modulo), so a
+/// large integer like `10000000000000001` is not mistaken for a multiple of `2`
+/// after losing precision as an `f64`. When either operand is a float the check
+/// is best-effort within floating-point precision: the value must sit within a
+/// few ULPs of the nearest multiple, so `0.3` counts as a multiple of `0.1`
+/// (binary rounding) while `3.0000001` does not. `mult` is positive (the caller
+/// guards `mult > 0`, per the JSON Schema requirement).
+fn is_multiple_of(value: &Value, mult_value: &Value, num: f64, mult: f64) -> bool {
+    if let (Some(v), Some(m)) = (as_i128(value), as_i128(mult_value)) {
+        return m != 0 && v % m == 0;
+    }
+    let nearest = (num / mult).round() * mult;
+    (num - nearest).abs() <= num.abs().max(mult) * f64::EPSILON * 8.0
 }
 
 fn check_string(

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -693,3 +693,26 @@ def test_schema_invalid_pattern_is_reported_not_ignored():
         yamlrocks.loads(
             b'v: "x"', schema={"properties": {"v": {"pattern": "[unclosed"}}}
         )
+
+
+def test_multiple_of_is_exact_for_integers():
+    """`multipleOf` on integers is exact, not a lossy float check: a large odd
+    integer is not mistaken for a multiple of an even one after `f64` rounding.
+    Big integers beyond `i64` are handled exactly too (via `i128`)."""
+    # Regression: this large odd integer used to pass `multipleOf: 2` because it
+    # lost precision as an f64.
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(b"10000000000000001\n", schema={"multipleOf": 2})
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(b"10000000000000002\n", schema={"multipleOf": 4})
+    # A big integer past i64 is still checked exactly.
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(b"100000000000000000000000001\n", schema={"multipleOf": 2})
+    # Genuine multiples still pass.
+    assert yamlrocks.loads(b"9\n", schema={"multipleOf": 3}) == 9
+    assert yamlrocks.loads(
+        b"100000000000000000000000000\n", schema={"multipleOf": 2}
+    ) == (100000000000000000000000000)
+    # A clearly non-integral float multiple is rejected.
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(b"3.0000001\n", schema={"multipleOf": 1.0})


### PR DESCRIPTION
## Breaking change

None that affects a correct schema: values only validate *more* correctly. A large integer that used to slip past `multipleOf` now fails, matching `jsonschema`. One deliberate, documented divergence from `jsonschema` is kept: a float like `0.3` is still accepted as a multiple of `0.1` (the user-friendly reading), where `jsonschema`'s exact-binary arithmetic rejects it.

## Proposed change

The `multipleOf` check divided two `f64`s and accepted the result within a relative tolerance (`1e-9 * ratio`). That tolerance grows without bound as the value grows, and a large integer loses precision the moment it becomes an `f64`, so an odd integer such as `10000000000000001` validated as a multiple of `2`.

When both the value and `multipleOf` are integers the check is now exact integer modulo, done on `i128` so it also covers big integers past `i64`. When either operand is a float it stays best-effort within floating-point precision, but the tolerance is scaled to the operands' magnitude (a few ULPs of the nearest multiple) rather than the ratio, so `3.0000001` is no longer a multiple of `1.0` while `0.3` still counts as a multiple of `0.1` (binary rounding). Verified against the `jsonschema` reference for the integer cases.

Found by a differential sweep against `jsonschema`.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #190
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
