### PR TITLE
🐛 Drop a null merge value on the composer paths, matching the fast path

### DIFF
--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -167,6 +167,8 @@ pub(crate) fn mapping_has_merge_key(pairs: &[(YamlNode, YamlNode)]) -> bool {
 /// - A sequence merges each element and returns only the elements that could not
 ///   be merged, as a list (`None` if all merged), so a mergeable element is not
 ///   also duplicated under `<<`. Mirrors the fast path's `merge_into`.
+/// - A null value contributes nothing and returns `None` (dropped), so an empty
+///   `<<:` leaves no key.
 /// - Anything else (a scalar or custom-tagged node) is returned as-is to
 ///   preserve under `<<`, exactly as the fast path does.
 ///
@@ -176,7 +178,13 @@ pub(crate) fn merge_converted_into<'py>(
     dict: &Bound<'py, PyDict>,
     source: &Bound<'py, PyAny>,
 ) -> PyResult<Option<Bound<'py, PyAny>>> {
-    if let Ok(src) = source.cast::<PyDict>() {
+    if source.is_none() {
+        // A null merge value (`<<: ~`, an empty `<<:`, or a `null` element of a
+        // merge list) contributes nothing and leaves no `<<` key, matching the
+        // fast path (`Value::Null => None` in `decode::merge`). Without this it
+        // fell through to the preserve arm below and kept a literal `<<: None`.
+        Ok(None)
+    } else if let Ok(src) = source.cast::<PyDict>() {
         for (k, v) in src.iter() {
             if !dict.contains(&k)? {
                 dict.set_item(k, v)?;

--- a/tests/core/test_merge_keys.py
+++ b/tests/core/test_merge_keys.py
@@ -217,3 +217,25 @@ def test_duplicate_key_in_merge_source_uses_last_value():
     assert yamlrocks.loads(b"a: &a {x: 1, x: 2}\nc:\n  x: 9\n  <<: *a\n")["c"] == {
         "x": 9
     }
+
+
+def test_null_merge_value_is_dropped_on_every_path():
+    """A null `<<` value (`<<: ~`, an empty `<<:`, or a null element of a merge
+    list) contributes nothing and leaves no `<<` key, on every data path. The
+    composer paths used to keep a literal `<<: None`, diverging from the fast
+    path; they now agree."""
+    for src, expected in [
+        (b"base:\n  a: 1\n  <<: ~\n", {"a": 1}),
+        (b"base:\n  a: 1\n  <<:\n", {"a": 1}),
+        (b"a: &a {x: 1}\nbase:\n  <<: [*a, ~]\n", {"x": 1}),
+    ]:
+        assert yamlrocks.loads(src)["base"] == expected
+        assert (
+            dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED)["base"])
+            == expected
+        )
+        assert yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES)["base"] == expected
+        assert (
+            yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["base"]
+            == expected
+        )


### PR DESCRIPTION
## Breaking change

Output-shape only, for the uncommon case of a null merge value. `<<: ~` (or an empty `<<:`, or a null element in a merge list) no longer leaves a literal `<<: None` key on the annotated / includes / round-trip paths; it is dropped, exactly as the fast path already did. No other value changes.

## Proposed change

A null `<<` value (`<<: ~`, an empty `<<:`, or a null element of a merge list) contributes nothing on the fast path and leaves no `<<` key. The composer paths (annotated, includes, round-trip `to_dict`) instead kept a literal `<<: None`, so the same document came back two different ways.

`merge_converted_into` now drops a null merge value up front, exactly as the fast decoder's `Value::Null => None` arm does, so every path agrees. A non-null value that still cannot be merged (a scalar or custom-tagged node) is preserved under `<<` as before.

Found by a differential cross-path consistency sweep.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #186
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
