### PR TITLE
🐛 Strip underscore separators from a big int in the schema numeric checks

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -574,7 +574,9 @@ fn check_numeric(
 fn as_i128(value: &Value) -> Option<i128> {
     match value {
         Value::Int(i) => Some(*i as i128),
-        Value::BigInt(s) => s.parse().ok(),
+        // A `BigInt` keeps its source lexeme, so a YAML 1.1 literal retains its
+        // `_` digit separators; strip them before parsing (see `as_f64`).
+        Value::BigInt(s) => s.replace('_', "").parse().ok(),
         _ => None,
     }
 }
@@ -1064,8 +1066,11 @@ fn as_f64(value: &Value) -> Option<f64> {
         Value::Int(i) => Some(*i as f64),
         Value::Float(f) => Some(*f),
         // A big integer is compared lossily against `minimum`/`maximum`, matching
-        // how a JSON Schema validator coerces it to a number for bound checks.
-        Value::BigInt(s) => s.parse::<f64>().ok(),
+        // how a JSON Schema validator coerces it to a number for bound checks. Its
+        // lexeme keeps any YAML 1.1 `_` digit separators, so strip them first;
+        // otherwise the parse fails and the whole numeric check is skipped (the
+        // value would slip past `minimum`/`maximum`/`multipleOf` entirely).
+        Value::BigInt(s) => s.replace('_', "").parse::<f64>().ok(),
         _ => None,
     }
 }

--- a/tests/features/test_schema.py
+++ b/tests/features/test_schema.py
@@ -716,3 +716,29 @@ def test_multiple_of_is_exact_for_integers():
     # A clearly non-integral float multiple is rejected.
     with pytest.raises(yamlrocks.YAMLRocksSchemaError):
         yamlrocks.loads(b"3.0000001\n", schema={"multipleOf": 1.0})
+
+
+def test_numeric_checks_handle_yaml_1_1_underscore_big_ints():
+    """A YAML 1.1 big-int literal keeps its `_` separators in the resolved value,
+    so the numeric checks must strip them before parsing. Otherwise the parse
+    failed and the whole numeric check (multipleOf, minimum, ...) was silently
+    skipped, letting an odd big integer pass `multipleOf: 2`."""
+    opt = yamlrocks.OPT_YAML_1_1
+    # Odd big int with separators is not a multiple of 2; even one is.
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(
+            b"20_000_000_000_000_000_001\n", option=opt, schema={"multipleOf": 2}
+        )
+    assert (
+        yamlrocks.loads(
+            b"20_000_000_000_000_000_000\n", option=opt, schema={"multipleOf": 2}
+        )
+        == 20000000000000000000
+    )
+    # A bound check on the same literal is enforced, not skipped.
+    with pytest.raises(yamlrocks.YAMLRocksSchemaError):
+        yamlrocks.loads(
+            b"20_000_000_000_000_000_001\n",
+            option=opt,
+            schema={"minimum": 99999999999999999999999},
+        )


### PR DESCRIPTION
## Breaking change

None. It makes the schema numeric keywords apply to a big-integer value that has YAML 1.1 `_` digit separators, where they were previously skipped. Values only become more correctly validated.

## Proposed change

A YAML 1.1 big-int literal keeps its `_` digit separators in the resolved value (`20_000_000_000_000_000_001`). The schema numeric helpers parsed that lexeme directly: `as_f64` failed on the underscores and returned `None`, so `check_numeric` bailed out at its first line and skipped *every* numeric keyword, and `as_i128` failed too, so even the exact `multipleOf` path was unreachable. The net effect was that an odd big integer with separators passed `multipleOf: 2` (and slipped past `minimum`/`maximum`).

Both helpers now strip `_` before parsing, matching how the value itself resolves, so the numeric checks run and are exact again. Follow-up to #196.

Found while addressing the same underscore issue flagged in the `OPT_SORT_KEYS` review (#197).

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #196, #197
- Link to a separate documentation pull request: None

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
