### PR TITLE
🐛 Report __file__ on an annotated load(path) without includes

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1114,7 +1114,15 @@ fn loads_via_ast(
         (nodes, file_map, file_sources)
     } else {
         let nodes = composer::compose(input).map_err(|e| errors::parse_error(py, &e, None))?;
-        (nodes, Vec::new(), Vec::new())
+        // Register the root document's path (from `load(path)`, passed as
+        // `root_path`) so annotated nodes report `__file__` even without
+        // `!include` resolution. The composer stamps root nodes with file_id 0,
+        // which lines up with index 0 of the file map. The source is unused here
+        // (only includes, skipped below, read it), so keep it `None`.
+        match root_path {
+            Some(path) => (nodes, vec![path], vec![None]),
+            None => (nodes, Vec::new(), Vec::new()),
+        }
     };
 
     // The root gate above validates the root document, but the round-trip

--- a/tests/roundtrip/test_annotated.py
+++ b/tests/roundtrip/test_annotated.py
@@ -48,8 +48,9 @@ def test_list_is_real_list_subclass():
     assert items.__line__ == 2
 
 
-def test_config_file_is_none_without_includes():
-    """__file__ is None when loaded without includes."""
+def test_config_file_is_none_for_in_memory_bytes():
+    """__file__ is None when there is no source path: in-memory bytes with no
+    root_path have nowhere to point."""
     data = yamlrocks.loads(b"a: 1\n", option=ANN)
     assert data.__file__ is None
 
@@ -136,6 +137,16 @@ def test_root_reports_real_path_via_load(tmp_path):
     assert data.__file__ == str(cfg)
     assert data["server"].__file__ == str(cfg)
     assert next(iter(data)).__file__ == str(cfg)
+
+
+def test_root_reports_real_path_via_load_without_includes(tmp_path):
+    """The top-level file's path reaches annotated nodes even without
+    ``OPT_INCLUDES``: ``load(path)`` alone is enough for ``__file__``."""
+    cfg = tmp_path / "configuration.yaml"
+    cfg.write_text("name: home\nserver:\n  host: localhost\n")
+    data = yamlrocks.load(str(cfg), option=ANN)
+    assert data["name"].__file__ == str(cfg)
+    assert next(iter(data["server"])).__file__ == str(cfg)
 
 
 # -- Annotated mode runs the same structural validation as the default path -----


### PR DESCRIPTION
## Breaking change

None. This fills in an attribute that was previously `None`. `__file__` on annotated nodes now reports the real path for `load(path)` even without `OPT_INCLUDES`; nothing that worked before changes.

## Proposed change

`load(path, option=OPT_ANNOTATED)` returned annotated scalars whose `__file__` was `None`, even though `load()` passes the real path down as `root_path`. It only worked when `OPT_INCLUDES` was also set: the include resolver seeds the file map with the root path, while the plain compose path threw `root_path` away and returned an empty file map, so `paths` was empty and every top-level node's `__file__` resolved to `None`.

The fix seeds the file map with `root_path` in the non-include branch of `loads_via_ast`. The composer stamps root nodes with `file_id` 0, so index 0 of the map lines up and `__file__` resolves. In-memory `loads(bytes)` with no path stays `None`, and the include path is untouched.

The existing coverage hid the gap: the only `load()` test always passed `OPT_INCLUDES`. This adds a test for `load(path)` without includes, and rewords the "none without includes" test, whose real premise is "no source path is known" (in-memory bytes).

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.