### PR TITLE
🐛 Read a tagged empty block-sequence entry as an empty node

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -481,7 +481,7 @@ impl<'input> Decoder<'input> {
                     // (matching PyYAML's `safe_load_all`), so document count is a
                     // reliable signal (e.g. distinguishing a config from
                     // frontmatter-plus-empty-config).
-                    let value = self.decode_node(events)?.unwrap_or(Value::Null);
+                    let value = self.decode_node(events, false)?.unwrap_or(Value::Null);
                     documents.push(value);
                     self.expect_document_boundary(events)?;
                     directives_allowed = false;
@@ -563,7 +563,7 @@ impl<'input> Decoder<'input> {
                 _ => {
                     // Implicit document.
                     let start_pos = self.pos;
-                    if let Some(value) = self.decode_node(events)? {
+                    if let Some(value) = self.decode_node(events, false)? {
                         documents.push(value);
                         self.expect_document_boundary(events)?;
                     }
@@ -607,11 +607,19 @@ impl<'input> Decoder<'input> {
         }
     }
 
-    /// Decode a node, enforcing the recursion-depth limit around the actual
-    /// work in [`decode_node_inner`].
+    /// Decode a node, enforcing the recursion-depth limit around the actual work
+    /// in [`decode_node_inner`]. `allow_indentless_seq` is set only when the node
+    /// sits in a mapping-value position, where a block sequence may be written at
+    /// the
+    /// key's own indent with no `SequenceStart` of its own (`k:\n- a`). In every
+    /// other position (a sequence entry, a key, the document root) a bare
+    /// `SequenceEntry` belongs to an enclosing sequence, so it must not be
+    /// absorbed here: a tagged empty entry like `- !!str` followed by a sibling
+    /// `-` is an empty scalar, not a nested sequence.
     fn decode_node(
         &mut self,
         events: &mut [Event<'input>],
+        allow_indentless_seq: bool,
     ) -> Result<Option<Value<'input>>, DecodeError> {
         self.depth += 1;
         if self.depth > MAX_DEPTH {
@@ -632,9 +640,9 @@ impl<'input> Decoder<'input> {
         // incremented above, so the root sits at 1 and the `== 1` arm guards
         // it immediately, then every eighth level after (9, 17, ...).
         let result = if self.depth & 7 == 1 {
-            crate::stack::guard(|| self.decode_node_inner(events))
+            crate::stack::guard(|| self.decode_node_inner(events, allow_indentless_seq))
         } else {
-            self.decode_node_inner(events)
+            self.decode_node_inner(events, allow_indentless_seq)
         };
         self.depth -= 1;
         result
@@ -643,6 +651,7 @@ impl<'input> Decoder<'input> {
     fn decode_node_inner(
         &mut self,
         events: &mut [Event<'input>],
+        allow_indentless_seq: bool,
     ) -> Result<Option<Value<'input>>, DecodeError> {
         if self.pos >= events.len() {
             return Ok(None);
@@ -702,9 +711,9 @@ impl<'input> Decoder<'input> {
                 EventKind::Scalar(..)
                     | EventKind::MappingStart { .. }
                     | EventKind::SequenceStart { .. }
-                    | EventKind::SequenceEntry
                     | EventKind::Alias(..)
-            );
+            ) || (allow_indentless_seq
+                && matches!(events[self.pos].kind, EventKind::SequenceEntry));
             if !is_node {
                 let resolved = match self.schema.classify("", ScalarStyle::Plain, Some(tag)) {
                     ScalarKind::Null => Value::Null,
@@ -844,9 +853,11 @@ impl<'input> Decoder<'input> {
                 self.anchors.get(name).expect("anchor present").0.clone()
             }
 
-            EventKind::SequenceEntry => {
+            EventKind::SequenceEntry if allow_indentless_seq => {
                 // A block sequence value may sit at the same indent as its key
-                // (no preceding SequenceStart), so build it here.
+                // (no preceding SequenceStart), so build it here. Only in a
+                // mapping-value position: elsewhere a bare `SequenceEntry` is a
+                // sibling of an enclosing sequence and falls through below.
                 let sequence = self.decode_block_sequence(events)?;
                 Value::Sequence(sequence)
             }
@@ -861,7 +872,12 @@ impl<'input> Decoder<'input> {
             // collection-end markers are likewise not nodes, returning without
             // consuming lets the enclosing collection see its own terminator
             // rather than silently swallowing it.
-            EventKind::Key { .. }
+            // A bare `SequenceEntry` reaches here only when it is *not* a
+            // mapping-value indentless sequence (the guarded arm above): it is a
+            // sibling of an enclosing sequence, so this node is empty. Leave the
+            // marker unconsumed for that sequence's loop.
+            EventKind::SequenceEntry
+            | EventKind::Key { .. }
             | EventKind::Value
             | EventKind::StreamEnd
             | EventKind::DocumentEnd
@@ -879,7 +895,7 @@ impl<'input> Decoder<'input> {
 
             _ => {
                 self.pos += 1;
-                return self.decode_node(events);
+                return self.decode_node(events, allow_indentless_seq);
             }
         };
 
@@ -970,12 +986,12 @@ impl<'input> Decoder<'input> {
                     // An explicit `?` key (which reaches here with a `Key`
                     // marker) may be a block collection; only a bare key in the
                     // arm below, produced by mis-indented content, may not.
-                    let key = self.decode_node(events)?.unwrap_or(Value::Null);
+                    let key = self.decode_node(events, false)?.unwrap_or(Value::Null);
                     if self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value)
                     {
                         self.pos += 1;
                     }
-                    let val = self.decode_node(events)?.unwrap_or(Value::Null);
+                    let val = self.decode_node(events, true)?.unwrap_or(Value::Null);
                     self.reject_complex_key(&key, key_span)?;
                     self.check_duplicate_key(&mut seen, &key, key_span)?;
                     pairs.push((key, val));
@@ -992,7 +1008,7 @@ impl<'input> Decoder<'input> {
                     // structured differently by the scanner and handled as before.
                     let bare_scalar_key = matches!(events[self.pos].kind, EventKind::Scalar(..));
                     self.reject_block_collection_key(events, flow)?;
-                    let key = self.decode_node(events)?.unwrap_or(Value::Null);
+                    let key = self.decode_node(events, false)?.unwrap_or(Value::Null);
                     let has_value = self.pos < events.len()
                         && matches!(events[self.pos].kind, EventKind::Value);
                     if has_value {
@@ -1009,7 +1025,7 @@ impl<'input> Decoder<'input> {
                     // one; otherwise decoding here would wrongly consume the next
                     // entry as this key's value.
                     let val = if has_value {
-                        self.decode_node(events)?.unwrap_or(Value::Null)
+                        self.decode_node(events, true)?.unwrap_or(Value::Null)
                     } else {
                         Value::Null
                     };
@@ -1105,11 +1121,11 @@ impl<'input> Decoder<'input> {
         {
             let key_span = events[self.pos].span;
             self.pos += 1;
-            let key = self.decode_node(events)?.unwrap_or(Value::Null);
+            let key = self.decode_node(events, false)?.unwrap_or(Value::Null);
             if self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value) {
                 self.pos += 1;
             }
-            let val = self.decode_node(events)?.unwrap_or(Value::Null);
+            let val = self.decode_node(events, false)?.unwrap_or(Value::Null);
             self.reject_complex_key(&key, key_span)?;
             return Ok(Some(Value::Mapping(vec![(key, val)])));
         }
@@ -1124,7 +1140,7 @@ impl<'input> Decoder<'input> {
             {
                 Value::Null
             } else {
-                match self.decode_node(events)? {
+                match self.decode_node(events, false)? {
                     Some(key) => key,
                     None => return Ok(None),
                 }
@@ -1133,7 +1149,7 @@ impl<'input> Decoder<'input> {
         // key `[&c c: d]`): a `:` follows the node.
         if flow && self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value) {
             self.pos += 1;
-            let val = self.decode_node(events)?.unwrap_or(Value::Null);
+            let val = self.decode_node(events, false)?.unwrap_or(Value::Null);
             self.reject_complex_key(&key, key_span)?;
             return Ok(Some(Value::Mapping(vec![(key, val)])));
         }
@@ -1173,7 +1189,7 @@ impl<'input> Decoder<'input> {
                         )
                     {
                         items.push(Value::Null);
-                    } else if let Some(value) = self.decode_node(events)? {
+                    } else if let Some(value) = self.decode_node(events, false)? {
                         items.push(value);
                     }
                 }

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -563,7 +563,7 @@ impl<'input> Composer<'input> {
                     // Anchors are document-scoped: a `*alias` cannot reach an
                     // `&anchor` from an earlier document.
                     self.anchors_seen.clear();
-                    if let Some(mut node) = self.compose_node(events)? {
+                    if let Some(mut node) = self.compose_node(events, false)? {
                         // An explicit `---` produces this event; record it so the
                         // marker is preserved on re-emission.
                         node.explicit_start = true;
@@ -597,7 +597,7 @@ impl<'input> Composer<'input> {
                     // A document with no leading `---` still starts fresh: its
                     // anchors must not leak from a previous document.
                     self.anchors_seen.clear();
-                    if let Some(mut node) = self.compose_node(events)? {
+                    if let Some(mut node) = self.compose_node(events, false)? {
                         // The parser requires a `---` after any directive, so a
                         // document reaching this arm normally has none pending.
                         // Attach and mark explicit defensively: emitting the
@@ -620,7 +620,17 @@ impl<'input> Composer<'input> {
         Ok(documents)
     }
 
-    fn compose_node(&mut self, events: &[Event]) -> Result<Option<YamlNode>, ScanError> {
+    /// Compose one node. `allow_indentless_seq` is set only in a mapping-value
+    /// position, where a block sequence may sit at the key's own indent with no
+    /// `SequenceStart` of its own (`k:\n- a`). Elsewhere (a sequence entry, a
+    /// key, the root) a bare `SequenceEntry` belongs to an enclosing sequence, so
+    /// a tagged empty entry (`- !!str` before a sibling `-`) is an empty scalar,
+    /// not a nested sequence. Mirrors the fast decoder's `decode_node`.
+    fn compose_node(
+        &mut self,
+        events: &[Event],
+        allow_indentless_seq: bool,
+    ) -> Result<Option<YamlNode>, ScanError> {
         self.depth += 1;
         if self.depth > MAX_DEPTH {
             let span = events.get(self.pos).map(|e| e.span).unwrap_or_default();
@@ -633,12 +643,16 @@ impl<'input> Composer<'input> {
         // Grow the native stack if it is running low, so deeply nested input
         // (bounded above by `MAX_DEPTH`) cannot overflow a small thread stack
         // before the cap fires. See [`crate::stack`].
-        let result = crate::stack::guard(|| self.compose_node_inner(events));
+        let result = crate::stack::guard(|| self.compose_node_inner(events, allow_indentless_seq));
         self.depth -= 1;
         result
     }
 
-    fn compose_node_inner(&mut self, events: &[Event]) -> Result<Option<YamlNode>, ScanError> {
+    fn compose_node_inner(
+        &mut self,
+        events: &[Event],
+        allow_indentless_seq: bool,
+    ) -> Result<Option<YamlNode>, ScanError> {
         if self.pos >= events.len() {
             return Ok(None);
         }
@@ -732,7 +746,7 @@ impl<'input> Composer<'input> {
                 YamlNode::new(YamlNodeKind::Alias(name.clone()), span)
             }
 
-            EventKind::SequenceEntry => {
+            EventKind::SequenceEntry if allow_indentless_seq => {
                 let items = self.compose_block_sequence(events)?;
                 YamlNode::new(YamlNodeKind::Sequence(items), span)
             }
@@ -740,8 +754,12 @@ impl<'input> Composer<'input> {
             // Terminators: return without consuming so the enclosing collection
             // loop can observe them. A bare `Key` means an empty value followed
             // by a sibling key (a nested mapping is always preceded by
-            // `MappingStart`), so it is a null value, not a new mapping.
-            EventKind::Key { .. }
+            // `MappingStart`), so it is a null value, not a new mapping. A bare
+            // `SequenceEntry` reaches here only outside a mapping-value position
+            // (the guarded arm above), where it is a sibling of an enclosing
+            // sequence: this node is empty, so leave the marker for that loop.
+            EventKind::SequenceEntry
+            | EventKind::Key { .. }
             | EventKind::StreamEnd
             | EventKind::DocumentEnd
             | EventKind::DocumentStart
@@ -763,7 +781,7 @@ impl<'input> Composer<'input> {
 
             _ => {
                 self.pos += 1;
-                return self.compose_node(events);
+                return self.compose_node(events, allow_indentless_seq);
             }
         };
 
@@ -837,7 +855,7 @@ impl<'input> Composer<'input> {
                     let explicit = *explicit;
                     self.pos += 1;
                     let mut key = self
-                        .compose_node(events)?
+                        .compose_node(events, false)?
                         .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()));
                     // Remember an author-written `?` so re-emission after an edit
                     // keeps the explicit-key form instead of collapsing it.
@@ -847,7 +865,7 @@ impl<'input> Composer<'input> {
                         self.pos += 1;
                     }
                     let val = self
-                        .compose_node(events)?
+                        .compose_node(events, true)?
                         .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()));
                     pairs.push((key, val));
                 }
@@ -873,7 +891,7 @@ impl<'input> Composer<'input> {
                         ));
                     }
                     let key = self
-                        .compose_node(events)?
+                        .compose_node(events, false)?
                         .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()));
                     let has_value = self.pos < events.len()
                         && matches!(events[self.pos].kind, EventKind::Value);
@@ -892,7 +910,7 @@ impl<'input> Composer<'input> {
                     // null value; composing one here would wrongly absorb the next
                     // entry as this key's value.
                     let val = if has_value {
-                        self.compose_node(events)?
+                        self.compose_node(events, true)?
                             .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()))
                     } else {
                         YamlNode::new(YamlNodeKind::Null, Span::default())
@@ -989,14 +1007,14 @@ impl<'input> Composer<'input> {
             let pair_span = events[self.pos].span;
             self.pos += 1;
             let mut key = self
-                .compose_node(events)?
+                .compose_node(events, false)?
                 .unwrap_or_else(|| null(pair_span));
             key.explicit_key = explicit;
             if self.pos < events.len() && matches!(events[self.pos].kind, EventKind::Value) {
                 self.pos += 1;
             }
             let val = self
-                .compose_node(events)?
+                .compose_node(events, false)?
                 .unwrap_or_else(|| null(pair_span));
             return Ok(Some(
                 YamlNode::new(YamlNodeKind::Mapping(vec![(key, val)]), pair_span)
@@ -1011,7 +1029,7 @@ impl<'input> Composer<'input> {
             let pair_span = events[self.pos].span;
             self.pos += 1;
             let val = self
-                .compose_node(events)?
+                .compose_node(events, false)?
                 .unwrap_or_else(|| null(pair_span));
             return Ok(Some(
                 YamlNode::new(
@@ -1022,7 +1040,7 @@ impl<'input> Composer<'input> {
             ));
         }
 
-        let Some(key) = self.compose_node(events)? else {
+        let Some(key) = self.compose_node(events, false)? else {
             return Ok(None);
         };
         // An implicit single-pair mapping with no `Key` marker (`[&c c: d]`): a
@@ -1031,7 +1049,7 @@ impl<'input> Composer<'input> {
             let pair_span = key.span;
             self.pos += 1;
             let val = self
-                .compose_node(events)?
+                .compose_node(events, false)?
                 .unwrap_or_else(|| null(pair_span));
             return Ok(Some(
                 YamlNode::new(YamlNodeKind::Mapping(vec![(key, val)]), pair_span)
@@ -1069,7 +1087,7 @@ impl<'input> Composer<'input> {
         {
             return Ok(Some(YamlNode::new(YamlNodeKind::Null, dash_span)));
         }
-        self.compose_node(events)
+        self.compose_node(events, false)
     }
 
     fn compose_block_sequence(&mut self, events: &[Event]) -> Result<Vec<YamlNode>, ScanError> {

--- a/tests/core/test_loads.py
+++ b/tests/core/test_loads.py
@@ -505,3 +505,56 @@ def test_control_character_error_points_at_the_character():
     with pytest.raises(yamlrocks.YAMLRocksParseError) as exc:
         yamlrocks.loads(b"a: b\nc: x\x01y\n")
     assert (exc.value.line, exc.value.column) == (2, 5)
+
+
+# -- A tag on an empty block-sequence entry is an empty node, not a nest --------
+# `- !!str` followed by a sibling `-` is an empty (tagged) scalar entry, and the
+# next `-` is a sibling of the same sequence, not a nested sequence the tag
+# absorbs. The scanner emits one BlockSequenceStart; there is no nested one, so
+# nesting the siblings was wrong. Distinct from an indentless sequence in a
+# mapping-value position (`k:\n- a`), which must still nest under the key.
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        (b"- !!str\n- x\n", ["", "x"]),
+        (b"- !!str\n- a\n- b\n", ["", "a", "b"]),
+        (b"- !!null\n- x\n", [None, "x"]),
+        (b"-\n- y\n", [None, "y"]),  # the untagged form was always correct
+        # YAML test suite FH7J, which ships only an event stream (no in.json), so
+        # its value went unchecked by the compliance harness.
+        (
+            b"- !!str\n-\n  !!null : a\n  b: !!str\n- !!str : !!null\n",
+            ["", {None: "a", "b": ""}, {"": None}],
+        ),
+    ],
+)
+def test_tagged_empty_sequence_entry_is_a_sibling_not_a_nest(src, expected):
+    """A tag on an empty `-` entry yields an empty node; the next `-` is a
+    sibling, on the fast path."""
+    assert yamlrocks.loads(src) == expected
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        (b"k:\n- a\n- b\n", {"k": ["a", "b"]}),
+        (b"k: !!seq\n- a\n- b\n", {"k": ["a", "b"]}),
+    ],
+)
+def test_indentless_sequence_as_mapping_value_still_nests(src, expected):
+    """A block sequence at the key's own indent is still the key's value: the
+    fix must not turn an indentless value sequence into siblings."""
+    assert yamlrocks.loads(src) == expected
+
+
+def test_tagged_empty_sequence_entry_round_trips_and_keeps_structure():
+    """The round-trip and annotated paths share the composer, so pin the
+    structure there too: re-emit byte-for-byte, and the sequence has the empty
+    entry plus its sibling rather than a spurious nested sequence."""
+    src = b"- !!str\n- x\n"
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_yaml() == src
+    annotated = yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED)
+    assert len(annotated) == 2
+    assert annotated[1] == "x"


### PR DESCRIPTION
## Breaking change

None. It corrects wrong output: input that decoded to correct data before is unchanged.

## Proposed change

A tag on an empty block-sequence entry, followed by a sibling `-`, was mis-parsed: `- !!str\n- x` decoded to `[['x']]` instead of `['', 'x']`. The tagged empty entry was dropped and the sibling `-` absorbed into a nested sequence. It hit the fast, round-trip, and annotated paths alike.

Both the decoder (`decode/mod.rs`) and the composer (`roundtrip/composer.rs`) unconditionally treated a bare `SequenceEntry` following a node property as the start of a nested/indentless sequence. That is only correct in a mapping-value position, where a block sequence may sit at the key's own indent (`k:\n- a`); inside an already-open sequence the scanner emits no nested `BlockSequenceStart`, so the `-` is a sibling and the tagged node is empty.

The fix gates the indentless-sequence reading behind an `allow_indentless_seq` flag, threaded through `decode_node`/`compose_node` and set `true` only at the two mapping-value call sites in each file. Everywhere else a bare `SequenceEntry` after a property is now an empty node, leaving the marker for the enclosing sequence to consume. The two paths are fixed identically so they stay in lockstep.

This is YAML test suite case FH7J, which ships only an event stream and no `in.json`, so the compliance harness verified it parsed and round-tripped but never that the decoded value was right. A yamlrocks-vs-PyYAML value differential surfaced it.

Verified: `- !!str\n- x` yields `['', 'x']`; FH7J yields its canonical `['', {None: 'a', 'b': ''}, {'': None}]`; indentless value sequences (`k:\n- a`, `k: !!seq\n- a`) still nest under the key; round-trip re-emits byte-for-byte.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the yamlrocks-vs-PyYAML differential oracle that surfaced it
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.