### PR TITLE
🐛 Resolve a tag on an empty node in the AST-to-Python path

### DIFF
--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -33,6 +33,18 @@ pub fn node_to_python_with(
 /// PyYAML (so `d['base'] is d['ref']`), instead of an independent copy.
 pub(crate) type ObjectCache = HashMap<String, Py<PyAny>>;
 
+/// Convert a resolved scalar value into its Python object.
+fn resolved_to_py(py: Python<'_>, resolved: ResolvedValue) -> Py<PyAny> {
+    match resolved {
+        ResolvedValue::Null => py.None(),
+        ResolvedValue::Bool(b) => b.into_pyobject(py).unwrap().to_owned().into_any().unbind(),
+        ResolvedValue::Int(i) => i.into_pyobject(py).unwrap().into_any().unbind(),
+        ResolvedValue::BigInt(s) => crate::ffi::py_int_from_decimal(py, &s),
+        ResolvedValue::Float(f) => PyFloat::new(py, f).into_any().unbind(),
+        ResolvedValue::String(s) => PyString::new(py, &s).into_any().unbind(),
+    }
+}
+
 /// Resolve a node to a Python value, sharing object identity across aliases via
 /// `cache`. An `&anchor`'s converted object is recorded under its name; a later
 /// `*alias` returns that same object (a new reference to it). Because a valid
@@ -72,19 +84,16 @@ fn node_to_python_cached_inner(
     }
 
     let obj = match &node.kind {
-        YamlNodeKind::Null => py.None(),
+        // An empty node can still carry a tag (`k: !!str` is "", `!!int` a typed
+        // error, and so on), so resolve the tag against empty content the way the
+        // fast decoder does. An untagged null, or a tag that resolves to null,
+        // stays `None`.
+        YamlNodeKind::Null => match node.tag.as_deref() {
+            Some(tag) => resolved_to_py(py, schema.resolve("", ScalarStyle::Plain, Some(tag))),
+            None => py.None(),
+        },
         YamlNodeKind::Scalar(value, style) => {
-            let resolved = schema.resolve(value, *style, node.tag.as_deref());
-            match resolved {
-                ResolvedValue::Null => py.None(),
-                ResolvedValue::Bool(b) => {
-                    b.into_pyobject(py).unwrap().to_owned().into_any().unbind()
-                }
-                ResolvedValue::Int(i) => i.into_pyobject(py).unwrap().into_any().unbind(),
-                ResolvedValue::BigInt(s) => crate::ffi::py_int_from_decimal(py, &s),
-                ResolvedValue::Float(f) => PyFloat::new(py, f).into_any().unbind(),
-                ResolvedValue::String(s) => PyString::new(py, &s).into_any().unbind(),
-            }
+            resolved_to_py(py, schema.resolve(value, *style, node.tag.as_deref()))
         }
         YamlNodeKind::Sequence(items) => {
             let list = PyList::empty(py);

--- a/tests/roundtrip/test_annotated.py
+++ b/tests/roundtrip/test_annotated.py
@@ -660,3 +660,28 @@ def test_source_target_survives_pickle(tmp_path):
 def test_bare_constructed_has_no_source_target():
     assert yamlrocks.YAMLRocksAnnotatedStr("x").__source_target__ is None
     assert yamlrocks.YAMLRocksAnnotatedDict().__source_target__ is None
+
+
+# -- An empty node keeps its tag's resolution on the AST paths ------------------
+# An empty scalar can still carry a tag (`k: !!str` is ""), so the annotated and
+# to_dict paths must resolve the tag against empty content like the fast decoder,
+# not drop it and return None.
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        (b"k: !!str\n", ""),
+        (b"k: !!null\n", None),
+        (b"k: !!str ''\n", ""),
+    ],
+)
+def test_empty_tagged_scalar_matches_fast_path(src, expected):
+    """An empty tagged scalar resolves the same on the annotated, to_dict, and
+    fast paths (regression: annotated returned None for an empty `!!str`)."""
+    fast = yamlrocks.loads(src)["k"]
+    assert fast == expected
+    assert yamlrocks.loads(src, option=ANN)["k"] == expected
+    assert (
+        yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["k"] == expected
+    )


### PR DESCRIPTION
## Breaking change

None. It corrects wrong output: `None` becomes the tag's resolved value where the fast path already produced it.

## Proposed change

An empty scalar can still carry a tag (`k: !!str` is `""`), but the AST-to-Python conversion (`node_to_python_cached`) mapped every `Null`-kind node straight to `None`, dropping the tag. So annotated mode (`OPT_ANNOTATED`) and a round-trip document's `to_dict()` returned `None` for `k: !!str`, where the fast `loads()` path (correctly) returns `""`.

The fix resolves the tag against empty content the way the fast decoder does (`schema.resolve("", Plain, tag)`) when a `Null` node carries a tag; an untagged null, or a tag that resolves to null, stays `None`. The `ResolvedValue`-to-Python conversion is factored into a small `resolved_to_py` helper shared by the empty-tagged and scalar arms, so every AST-based path (annotated, `to_dict`, includes) agrees with `loads()`.

Verified: `k: !!str` yields `""` and `k: !!null` yields `None` on the fast, annotated, and `to_dict` paths alike.

Surfaced by the yamlrocks-vs-PyYAML value differential while fixing the tagged-empty-sequence-entry bug (a separate PR).

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the yamlrocks-vs-PyYAML differential oracle and the tagged-empty-sequence-entry fix
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.