### PR TITLE
📝 Scope the round-trip byte-for-byte promise to UTF-8

### DIFF
--- a/docs/src/content/docs/guides/round-trip.md
+++ b/docs/src/content/docs/guides/round-trip.md
@@ -65,6 +65,16 @@ This makes round-trip mode safe to drop into a save pipeline: loading and saving
 file the user did not change leaves it untouched, so version control stays quiet
 and diffs stay meaningful.
 
+:::note[Byte fidelity is a UTF-8 guarantee]
+The byte-for-byte promise is for UTF-8 input, which is what real configuration
+files use. YAMLRocks still reads UTF-16 and UTF-32 (the YAML spec requires it,
+detected by a byte order mark or the leading-byte pattern), but it decodes to
+text internally and re-emits as UTF-8. So loading a UTF-16 file gives you the
+right data, but re-emitting it produces the same text encoded as UTF-8, not the
+original UTF-16 bytes. Convert a file to UTF-8 first if you need byte-for-byte
+round-trip editing of it.
+:::
+
 ## Reading values
 
 A `YAMLRocksDocument` reads like the mapping it wraps. Scalar access returns plain Python

--- a/docs/src/content/docs/stability-roadmap.md
+++ b/docs/src/content/docs/stability-roadmap.md
@@ -20,7 +20,9 @@ These behaviors are treated as core. Regressions here are bugs.
 - **YAML 1.2 by default**: `yes`, `no`, `on`, and `off` are strings unless YAML
   1.1 mode is explicitly requested.
 - **Round-trip preservation**: a document loaded with `OPT_ROUND_TRIP` preserves
-  comments, anchors, and formatting; an unmodified document re-emits byte-for-byte.
+  comments, anchors, and formatting; an unmodified UTF-8 document re-emits
+  byte-for-byte. (UTF-16 and UTF-32 are read per the spec but re-emit as UTF-8,
+  so byte fidelity is a UTF-8 guarantee.)
 - **Real-world verification**: standalone YAML files in the public compatibility
   corpus parse and round-trip without loss.
 - **Structured errors**: YAMLRocks errors carry machine-readable location


### PR DESCRIPTION
## Breaking change

None. Documentation only, no behavior change.

## Proposed change

YAMLRocks reads UTF-16 and UTF-32 (the YAML 1.2 spec requires it, detected by a byte order mark or the leading-byte pattern), but it decodes to text internally and re-emits as UTF-8. So a UTF-16 file loads to the right data, yet re-emitting it under `OPT_ROUND_TRIP` produces that text as UTF-8, not the original UTF-16 bytes.

The byte-for-byte guarantee only ever meant UTF-8, which is what configuration files use in practice. This scopes the claim explicitly in the two places that make it, the round-trip guide and the stability roadmap, rather than imply an encoding-preserving round-trip that is not offered. It documents current behavior; nothing changes in code.

Context: the yamlrocks-vs-PyYAML round-trip differential surfaced UTF-16 inputs as non-byte-identical on re-emit. That is expected (transcoding to UTF-8), so the fix is to state the guarantee's scope, not to change the round-trip.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the yamlrocks-vs-PyYAML differential oracle
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.