### PR TITLE
📊 Add comparison pages for the rest of the YAML ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ many times faster YAMLRocks is:
 | Serialize (`dumps`)                          |       ~15-19x faster | ~155-210x faster |
 | Split config (`!include`, hundreds of files) |          ~18x faster |              n/a |
 
+Across the wider field of Python YAML libraries, on both reading and writing:
+
+![Parsing throughput across Python YAML libraries: YAMLRocks is the fastest, ahead of yaml-rs, fast-yaml, py-yaml12, ryaml, PyYAML's C loader, and far ahead of the pure-Python libraries.](docs/public/benchmarks/load.svg)
+
+![Serializing throughput across Python YAML libraries: YAMLRocks is the fastest, ahead of yaml-rs, fast-yaml, py-yaml12, ryaml, PyYAML's C dumper, and the pure-Python libraries.](docs/public/benchmarks/dump.svg)
+
+See the [comparisons][comparisons] for head-to-head benchmarks and feature
+tables against each library. Numbers are machine-dependent; reproduce them with
+`python bench/compare.py`.
+
 It is safe against the common YAML attack classes, free-threaded (nogil) ready,
 and ships with JSON Schema validation, a PyYAML-compatible shim, rich standard-library
 type support, and the `!secret` and `!env_var` config tags.
@@ -298,5 +308,6 @@ SOFTWARE.
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/frenck/YAMLRocks/badge
 [scorecard]: https://scorecard.dev/viewer/?uri=github.com/frenck/YAMLRocks
 [semver]: http://semver.org/spec/v2.0.0.html
+[comparisons]: https://yaml.rocks/comparisons/
 [stability-roadmap]: https://yaml.rocks/stability-roadmap/
 [uv]: https://docs.astral.sh/uv/

--- a/bench/charts.py
+++ b/bench/charts.py
@@ -14,6 +14,7 @@ like the tables; regenerate on the machine you want to quote.
 
 from __future__ import annotations
 
+import importlib.metadata
 from pathlib import Path
 from typing import Any
 
@@ -31,7 +32,9 @@ TEXT = "#e6edf3"
 MUTED = "#9aa3ad"
 GRID = "#2a2e38"
 CYAN = "#24fefd"  # YAMLRocks (the brand highlight)
-GREY = "#5b626d"  # every other library
+GREY = "#5b626d"  # a competitor library
+GREY2 = "#41464f"  # a second competitor on a multi-competitor chart (e.g. PyYAML)
+COMPETITOR_COLORS = [GREY, GREY2]
 
 OUT = Path(__file__).resolve().parent.parent / "docs" / "public" / "benchmarks"
 
@@ -50,6 +53,36 @@ plt.rcParams.update(
         "axes.edgecolor": GRID,
     }
 )
+
+
+# The PyPI distribution behind each `compare.py` label, so a chart can print the
+# exact version measured (benchmark numbers are version-specific). YAMLRocks is
+# deliberately omitted: it is built here from an untagged working tree, so a
+# version string would be misleading.
+_DIST = {
+    "yaml_rs": "yaml-rs",
+    "fast-yaml": "fastyaml-rs",
+    "ryaml": "ryaml",
+    "py-yaml12": "py-yaml12",
+    "yamlium": "yamlium",
+    "strictyaml": "strictyaml",
+    "oyaml": "oyaml",
+    "ruamel.yaml": "ruamel.yaml",
+    "PyYAML (C)": "PyYAML",
+    "PyYAML (pure)": "PyYAML",
+}
+
+
+def _labelled(label: str, display: str | None = None) -> str:
+    """`display` (or `label`) with the installed version appended, when known."""
+    name = display if display is not None else label
+    dist = _DIST.get(label)
+    if dist:
+        try:
+            return f"{name} {importlib.metadata.version(dist)}"
+        except importlib.metadata.PackageNotFoundError:
+            pass
+    return name
 
 
 def _fmt(us: float) -> str:
@@ -81,7 +114,7 @@ def _chart(rows: list[dict[str, Any]], key: str, title: str, filename: str) -> N
     rows = sorted(
         (row for row in rows if row.get(key) is not None), key=lambda row: row[key]
     )
-    labels = [row["label"] for row in rows]
+    labels = [_labelled(row["label"]) for row in rows]
     values = [row[key] for row in rows]
     colors = [CYAN if row["label"] == "YAMLRocks" else GREY for row in rows]
 
@@ -119,13 +152,164 @@ def _chart(rows: list[dict[str, Any]], key: str, title: str, filename: str) -> N
     path.write_text(cleaned + "\n")
 
 
+# Each page's chart: the output filename and the competitor(s) to draw against
+# YAMLRocks, as `(label in compare.py, display name)`. Order mirrors the sidebar.
+# Most are a single rival; PyYAML shows both its C loader and its pure-Python
+# loader, since the page discusses both. The "Nx faster" headline is measured
+# against the first competitor listed (for PyYAML, the C loader, the fair path).
+_HEAD_TO_HEAD = [
+    (
+        "vs-pyyaml.svg",
+        [("PyYAML (C)", "PyYAML (C loader)"), ("PyYAML (pure)", "PyYAML (pure)")],
+    ),
+    ("vs-ruamel.svg", [("ruamel.yaml", "ruamel.yaml")]),
+    ("vs-yaml-rs.svg", [("yaml_rs", "yaml-rs")]),
+    ("vs-fast-yaml.svg", [("fast-yaml", "fast-yaml")]),
+    ("vs-ryaml.svg", [("ryaml", "ryaml")]),
+    ("vs-py-yaml12.svg", [("py-yaml12", "py-yaml12")]),
+    ("vs-yamlium.svg", [("yamlium", "yamlium")]),
+    ("vs-strictyaml.svg", [("strictyaml", "strictyaml")]),
+    ("vs-oyaml.svg", [("oyaml", "oyaml")]),
+]
+
+# The two operations each head-to-head chart shows, top to bottom.
+_METRICS = [("Reading (loads)", "load_us"), ("Writing (dumps)", "dump_us")]
+
+
+def _head_to_head(
+    rows: list[dict[str, Any]],
+    competitors: list[tuple[str, str]],
+    filename: str,
+) -> None:
+    """A head-to-head time chart of YAMLRocks against one or more competitors, on
+    reading and writing. Each bar is the time to process the payload set once,
+    labelled with that time; YAMLRocks is the brand cyan, competitors grey.
+
+    Shorter is faster, the convention every benchmark chart uses. YAMLRocks' bar
+    leads with how many times faster it is (against the first competitor listed)
+    and its time; each competitor's bar carries its time. On a linear axis a much
+    slower library reads as a much longer bar, which is the honest picture.
+    `competitors` is a list of `(label in compare.py, display name)`.
+    """
+    by_label = {row["label"]: row for row in rows}
+    us = by_label.get("YAMLRocks")
+    them = [(by_label.get(label), display) for label, display in competitors]
+    if us is None or any(row is None for row, _ in them):
+        missing = [
+            c for c, (row, _) in zip(competitors, them, strict=True) if row is None
+        ]
+        print(f"skipping {filename}: not measured ({missing})")
+        return
+
+    # Only the operations YAMLRocks and every competitor support (strictyaml has
+    # no dumper). `primary` is the first competitor, the one the multiple is
+    # measured against (for PyYAML, the C loader).
+    metrics = [
+        (name, key)
+        for name, key in _METRICS
+        if us.get(key) is not None and all(row.get(key) is not None for row, _ in them)
+    ]
+    primary = them[0][0]
+    bars = [(us, CYAN, True)] + [
+        (row, COMPETITOR_COLORS[j % len(COMPETITOR_COLORS)], False)
+        for j, (row, _) in enumerate(them)
+    ]
+    n = len(bars)
+    longest = max(row[key] for row, _, _ in bars for _, key in metrics)
+
+    def _mult(ratio: float) -> str:
+        return f"{ratio:.1f}" if ratio < 10 else f"{ratio:.0f}"
+
+    # With one rival, YAMLRocks carries the "Nx faster" headline. With several
+    # (PyYAML's two loaders), the multiple goes on each rival as "Nx slower", so
+    # every gap is stated; YAMLRocks is then just the fastest reference.
+    multi = len(them) > 1
+
+    fig, ax = plt.subplots(figsize=(8.2, 0.95 * n * len(metrics) / 2 + 1.2))
+    span = 0.82
+    height = span / n * 0.86
+    for i, (_, key) in enumerate(metrics):
+        for j, (row, color, is_us) in enumerate(bars):
+            y = i - span / 2 + span * (j + 0.5) / n
+            ax.barh(y, row[key], height=height, color=color, zorder=3)
+            if is_us:
+                label = (
+                    _fmt(us[key])
+                    if multi
+                    else f"{_mult(primary[key] / us[key])}x faster · {_fmt(us[key])}"
+                )
+                lc, weight = CYAN, "bold"
+            else:
+                label = (
+                    f"{_fmt(row[key])} · {_mult(row[key] / us[key])}x slower"
+                    if multi
+                    else _fmt(row[key])
+                )
+                lc, weight = MUTED, "normal"
+            ax.text(
+                row[key] + longest * 0.012,
+                y,
+                label,
+                va="center",
+                ha="left",
+                color=lc,
+                fontsize=8.5 if is_us else 8,
+                fontweight=weight,
+            )
+
+    ax.set_yticks(range(len(metrics)))
+    ax.set_yticklabels([name for name, _ in metrics])
+    ax.invert_yaxis()
+    # Room to the right for the "Nx faster" label on YAMLRocks' (shorter) bar.
+    ax.set_xlim(left=0, right=longest * 1.9)
+    # The legend sits below the chart, centered, so a wide multi-library row
+    # (PyYAML's two loaders plus YAMLRocks) never runs into the top-left title.
+    ax.legend(
+        handles=[mpl.patches.Patch(color=CYAN, label="YAMLRocks")]
+        + [
+            mpl.patches.Patch(
+                color=COMPETITOR_COLORS[j % len(COMPETITOR_COLORS)],
+                label=_labelled(label, display),
+            )
+            for j, (label, display) in enumerate(competitors)
+        ],
+        loc="upper center",
+        bbox_to_anchor=(0.5, -0.12),
+        ncol=n,
+        frameon=False,
+        fontsize=9,
+        labelcolor=TEXT,
+    )
+    title_rival = them[0][1] if len(them) == 1 else "PyYAML"
+    # No xlabel: it would collide with the legend below, and the bar labels
+    # already carry the times, with the multiples telling the direction.
+    _style(ax, f"YAMLRocks vs {title_rival}", "")
+    # The times are on the bars, so the x-axis ticks and grid are just noise.
+    ax.set_xticks([])
+    ax.xaxis.grid(visible=False)
+
+    path = OUT / filename
+    fig.savefig(path, format="svg", bbox_inches="tight")
+    plt.close(fig)
+    cleaned = "\n".join(line.rstrip() for line in path.read_text().splitlines())
+    path.write_text(cleaned + "\n")
+
+
 def main() -> None:
-    """Render the load and dump charts into the docs assets."""
+    """Render the field charts and the per-page head-to-head charts."""
     OUT.mkdir(parents=True, exist_ok=True)
     rows = compare.measure()
     _chart(rows, "load_us", "Parsing (loads), across libraries", "load.svg")
     _chart(rows, "dump_us", "Serializing (dumps), across libraries", "dump.svg")
+    for filename, competitors in _HEAD_TO_HEAD:
+        _head_to_head(rows, competitors, filename)
     print(f"wrote charts to {OUT}")
+    # Echo the measured numbers so the doc tables and the index leaderboard can be
+    # updated from the very same run the charts were drawn from (no drift).
+    print(f"\n{'library':<14} {'load':>10} {'dump':>10}")
+    for row in rows:
+        dump = "-" if row["dump_us"] is None else _fmt(row["dump_us"])
+        print(f"{row['label']:<14} {_fmt(row['load_us']):>10} {dump:>10}")
 
 
 if __name__ == "__main__":

--- a/bench/compare.py
+++ b/bench/compare.py
@@ -138,6 +138,15 @@ def _contenders() -> list[Contender]:
         pass
 
     try:
+        import fast_yaml  # the "fastyaml-rs" distribution
+
+        out.append(
+            Contender("fast-yaml", "rust", fast_yaml.safe_load, fast_yaml.safe_dump)
+        )
+    except Exception:
+        pass
+
+    try:
         import yaml12  # the "py-yaml12" distribution
 
         out.append(

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -111,9 +111,16 @@ export default defineConfig({
           label: "Comparisons",
           items: [
             { label: "How YAMLRocks compares", slug: "comparisons" },
+            { label: "Performance", slug: "guides/performance" },
             { label: "vs PyYAML", slug: "comparisons/vs-pyyaml" },
             { label: "vs ruamel.yaml", slug: "comparisons/vs-ruamel" },
-            { label: "Performance", slug: "guides/performance" },
+            { label: "vs yaml-rs", slug: "comparisons/vs-yaml-rs" },
+            { label: "vs fast-yaml", slug: "comparisons/vs-fast-yaml" },
+            { label: "vs ryaml", slug: "comparisons/vs-ryaml" },
+            { label: "vs py-yaml12", slug: "comparisons/vs-py-yaml12" },
+            { label: "vs yamlium", slug: "comparisons/vs-yamlium" },
+            { label: "vs strictyaml", slug: "comparisons/vs-strictyaml" },
+            { label: "vs oyaml", slug: "comparisons/vs-oyaml" },
           ],
         },
         {

--- a/docs/public/benchmarks/dump.svg
+++ b/docs/public/benchmarks/dump.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="547.49125pt" height="393.677016pt" viewBox="0 0 547.49125 393.677016" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576.113125pt" height="421.397016pt" viewBox="0 0 576.113125 421.397016" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-03T17:06:34.630769</dc:date>
+    <dc:date>2026-07-04T10:47:56.640445</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,33 +21,33 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 393.677016
-L 547.49125 393.677016
-L 547.49125 0
+   <path d="M 0 421.397016
+L 576.113125 421.397016
+L 576.113125 0
 L 0 0
 z
 " style="fill: #13151c"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 82.73125 358.173969
-L 540.29125 358.173969
-L 540.29125 31.077969
-L 82.73125 31.077969
+    <path d="M 111.353125 385.893969
+L 568.913125 385.893969
+L 568.913125 31.077969
+L 111.353125 31.077969
 z
 " style="fill: #13151c"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 111.062518 358.173969
-L 111.062518 31.077969
-" clip-path="url(#pd92e90343d)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 143.178514 385.893969
+L 143.178514 31.077969
+" clip-path="url(#p8f64772141)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(102.262518 371.073969)">
+      <g style="fill: #9aa3ad" transform="translate(134.378514 398.793969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -58,14 +58,14 @@ L 111.062518 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 267.354243 358.173969
-L 267.354243 31.077969
-" clip-path="url(#pd92e90343d)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 297.756375 385.893969
+L 297.756375 31.077969
+" clip-path="url(#p8f64772141)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(258.554243 370.973969)">
+      <g style="fill: #9aa3ad" transform="translate(288.956375 398.693969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -76,14 +76,14 @@ L 267.354243 31.077969
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 423.645968 358.173969
-L 423.645968 31.077969
-" clip-path="url(#pd92e90343d)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 452.334235 385.893969
+L 452.334235 31.077969
+" clip-path="url(#p8f64772141)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(414.845968 370.973969)">
+      <g style="fill: #9aa3ad" transform="translate(443.534235 398.693969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -95,341 +95,358 @@ L 423.645968 31.077969
     <g id="xtick_4">
      <g id="line2d_7">
       <defs>
-       <path id="m02c599c591" d="M 0 0
+       <path id="m3039d6b0cc" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m02c599c591" x="86.852624" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="119.234101" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m02c599c591" x="95.916285" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="128.198372" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m02c599c591" x="103.911001" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="136.105419" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m02c599c591" x="158.111016" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="189.711087" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m02c599c591" x="185.632622" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="216.930897" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m02c599c591" x="205.159513" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="236.24366" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m02c599c591" x="220.305746" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="251.223802" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m02c599c591" x="232.681119" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="263.46347" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m02c599c591" x="243.144349" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="273.811961" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m02c599c591" x="252.20801" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="282.776232" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m02c599c591" x="260.202726" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="290.68328" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m02c599c591" x="314.40274" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="344.288947" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m02c599c591" x="341.924347" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="371.508757" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m02c599c591" x="361.451238" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="390.82152" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m02c599c591" x="376.597471" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="405.801662" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m02c599c591" x="388.972844" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="418.04133" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m02c599c591" x="399.436074" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="428.389821" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m02c599c591" x="408.499735" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="437.354092" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m02c599c591" x="416.494451" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="445.26114" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m02c599c591" x="470.694465" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="498.866808" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m02c599c591" x="498.216072" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="526.086618" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m02c599c591" x="517.742963" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="545.39938" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m02c599c591" x="532.889196" y="358.173969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m3039d6b0cc" x="560.379523" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_4">
-     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="311.51125" y="384.314906" transform="rotate(-0 311.51125 384.314906)">time to process the payload set once (log scale, lower is faster)</text>
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="340.133125" y="412.034906" transform="rotate(-0 340.133125 412.034906)">time to process the payload set once (log scale, lower is faster)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_30"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="62.021518" transform="rotate(-0 79.23125 62.021518)">YAMLRocks</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="62.951854" transform="rotate(-0 107.853125 62.951854)">YAMLRocks</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_31"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="96.122435" transform="rotate(-0 79.23125 96.122435)">yaml_rs</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="96.137039" transform="rotate(-0 107.853125 96.137039)">yaml_rs 0.1.4</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_32"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="130.223353" transform="rotate(-0 79.23125 130.223353)">py-yaml12</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="129.322225" transform="rotate(-0 107.853125 129.322225)">py-yaml12 0.1.0</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_33"/>
      <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="164.32427" transform="rotate(-0 79.23125 164.32427)">ryaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="162.50741" transform="rotate(-0 107.853125 162.50741)">fast-yaml 0.6.3</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_34"/>
      <g id="text_9">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="198.425187" transform="rotate(-0 79.23125 198.425187)">yamlium</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="195.692595" transform="rotate(-0 107.853125 195.692595)">ryaml 0.5.1</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_35"/>
      <g id="text_10">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="232.525714" transform="rotate(-0 79.23125 232.525714)">PyYAML (C)</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="228.87778" transform="rotate(-0 107.853125 228.87778)">yamlium 0.2.5</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_36"/>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="266.626632" transform="rotate(-0 79.23125 266.626632)">PyYAML (pure)</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="262.062575" transform="rotate(-0 107.853125 262.062575)">PyYAML (C) 6.0.3</text>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_37"/>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="300.72794" transform="rotate(-0 79.23125 300.72794)">oyaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="295.24776" transform="rotate(-0 107.853125 295.24776)">PyYAML (pure) 6.0.3</text>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_38"/>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="334.828857" transform="rotate(-0 79.23125 334.828857)">ruamel.yaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="328.433336" transform="rotate(-0 107.853125 328.433336)">oyaml 1.0</text>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_39"/>
+     <g id="text_14">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="361.618521" transform="rotate(-0 107.853125 361.618521)">ruamel.yaml 0.19.1</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 82.73125 358.173969
-L 540.29125 358.173969
+    <path d="M 111.353125 385.893969
+L 568.913125 385.893969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -156649.537613 45.945969
-L 100.760261 45.945969
-L 100.760261 70.498629
-L -156649.537613 70.498629
+    <path d="M -154898.415333 47.205969
+L 129.423363 47.205969
+L 129.423363 71.099302
+L -154898.415333 71.099302
 z
-" clip-path="url(#pd92e90343d)" style="fill: #24fefd"/>
+" clip-path="url(#p8f64772141)" style="fill: #24fefd"/>
    </g>
    <g id="patch_5">
-    <path d="M -156649.537613 80.046886
-L 116.273552 80.046886
-L 116.273552 104.599547
-L -156649.537613 104.599547
+    <path d="M -154898.415333 80.391154
+L 147.709683 80.391154
+L 147.709683 104.284487
+L -154898.415333 104.284487
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
-    <path d="M -156649.537613 114.147804
-L 125.455941 114.147804
-L 125.455941 138.700464
-L -156649.537613 138.700464
+    <path d="M -154898.415333 113.576339
+L 157.174739 113.576339
+L 157.174739 137.469672
+L -154898.415333 137.469672
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_7">
-    <path d="M -156649.537613 148.248721
-L 181.827909 148.248721
-L 181.827909 172.801382
-L -156649.537613 172.801382
+    <path d="M -154898.415333 146.761524
+L 174.333355 146.761524
+L 174.333355 170.654858
+L -154898.415333 170.654858
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -156649.537613 182.349638
-L 269.471236 182.349638
-L 269.471236 206.902299
-L -156649.537613 206.902299
+    <path d="M -154898.415333 179.946709
+L 213.766222 179.946709
+L 213.766222 203.840043
+L -154898.415333 203.840043
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
-    <path d="M -156649.537613 216.450556
-L 295.235861 216.450556
-L 295.235861 241.003216
-L -156649.537613 241.003216
+    <path d="M -154898.415333 213.131895
+L 298.238255 213.131895
+L 298.238255 237.025228
+L -154898.415333 237.025228
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_10">
-    <path d="M -156649.537613 250.551473
-L 414.435509 250.551473
-L 414.435509 275.104134
-L -156649.537613 275.104134
+    <path d="M -154898.415333 246.31708
+L 324.667378 246.31708
+L 324.667378 270.210413
+L -154898.415333 270.210413
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_11">
-    <path d="M -156649.537613 284.652391
-L 414.774428 284.652391
-L 414.774428 309.205051
-L -156649.537613 309.205051
+    <path d="M -154898.415333 279.502265
+L 442.993033 279.502265
+L 442.993033 303.395598
+L -154898.415333 303.395598
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="patch_12">
-    <path d="M -156649.537613 318.753308
-L 461.340489 318.753308
-L 461.340489 343.305969
-L -156649.537613 343.305969
+    <path d="M -154898.415333 312.68745
+L 443.3202 312.68745
+L 443.3202 336.580784
+L -154898.415333 336.580784
 z
-" clip-path="url(#pd92e90343d)" style="fill: #5b626d"/>
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
-   <g id="text_14">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="110.246832" y="60.170541" transform="rotate(-0 110.246832 60.170541)">859 µs</text>
+   <g id="patch_13">
+    <path d="M -154898.415333 345.872635
+L 490.828122 345.872635
+L 490.828122 369.765969
+L -154898.415333 369.765969
+z
+" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
    </g>
    <g id="text_15">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="125.760122" y="94.271459" transform="rotate(-0 125.760122 94.271459)">1.1 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="138.805905" y="61.100878" transform="rotate(-0 138.805905 61.100878)">815 µs</text>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="134.942511" y="128.372376" transform="rotate(-0 134.942511 128.372376)">1.2 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="157.092225" y="94.286063" transform="rotate(-0 157.092225 94.286063)">1.1 ms</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="191.314479" y="162.473294" transform="rotate(-0 191.314479 162.473294)">2.8 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="166.557281" y="127.471248" transform="rotate(-0 166.557281 127.471248)">1.2 ms</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="278.957806" y="196.574211" transform="rotate(-0 278.957806 196.574211)">10.3 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="183.715897" y="160.656433" transform="rotate(-0 183.715897 160.656433)">1.6 ms</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="304.722432" y="230.675128" transform="rotate(-0 304.722432 230.675128)">15.1 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="223.148764" y="193.841618" transform="rotate(-0 223.148764 193.841618)">2.9 ms</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="423.922079" y="264.776046" transform="rotate(-0 423.922079 264.776046)">87.3 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="307.620798" y="227.026804" transform="rotate(-0 307.620798 227.026804)">10.1 ms</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="424.260998" y="298.876963" transform="rotate(-0 424.260998 298.876963)">87.7 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="334.049921" y="260.211989" transform="rotate(-0 334.049921 260.211989)">14.9 ms</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="470.827059" y="332.977881" transform="rotate(-0 470.827059 332.977881)">174.3 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="452.375576" y="293.397174" transform="rotate(-0 452.375576 293.397174)">87.0 ms</text>
    </g>
    <g id="text_23">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="82.73125" y="17.077969" transform="rotate(-0 82.73125 17.077969)">Serializing (dumps), across libraries</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="452.702742" y="326.582359" transform="rotate(-0 452.702742 326.582359)">87.4 ms</text>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="500.210665" y="359.767544" transform="rotate(-0 500.210665 359.767544)">177.4 ms</text>
+   </g>
+   <g id="text_25">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="111.353125" y="17.077969" transform="rotate(-0 111.353125 17.077969)">Serializing (dumps), across libraries</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd92e90343d">
-   <rect x="82.73125" y="31.077969" width="457.56" height="327.096"/>
+  <clipPath id="p8f64772141">
+   <rect x="111.353125" y="31.077969" width="457.56" height="354.816"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/public/benchmarks/load.svg
+++ b/docs/public/benchmarks/load.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="547.49125pt" height="421.397016pt" viewBox="0 0 547.49125 421.397016" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576.113125pt" height="449.117016pt" viewBox="0 0 576.113125 449.117016" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-03T17:06:34.491158</dc:date>
+    <dc:date>2026-07-04T10:47:56.483674</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,33 +21,33 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 421.397016
-L 547.49125 421.397016
-L 547.49125 0
+   <path d="M 0 449.117016
+L 576.113125 449.117016
+L 576.113125 0
 L 0 0
 z
 " style="fill: #13151c"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 82.73125 385.893969
-L 540.29125 385.893969
-L 540.29125 31.077969
-L 82.73125 31.077969
+    <path d="M 111.353125 413.613969
+L 568.913125 413.613969
+L 568.913125 31.077969
+L 111.353125 31.077969
 z
 " style="fill: #13151c"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 208.07815 385.893969
-L 208.07815 31.077969
-" clip-path="url(#p45a3cc76dd)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 236.281644 413.613969
+L 236.281644 31.077969
+" clip-path="url(#p240ed87935)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(199.27815 398.693969)">
+      <g style="fill: #9aa3ad" transform="translate(227.481644 426.413969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -58,14 +58,14 @@ L 208.07815 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 337.682708 385.893969
-L 337.682708 31.077969
-" clip-path="url(#p45a3cc76dd)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 366.069986 413.613969
+L 366.069986 31.077969
+" clip-path="url(#p240ed87935)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(328.882708 398.693969)">
+      <g style="fill: #9aa3ad" transform="translate(357.269986 426.413969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -76,14 +76,14 @@ L 337.682708 31.077969
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 467.287266 385.893969
-L 467.287266 31.077969
-" clip-path="url(#p45a3cc76dd)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 495.858328 413.613969
+L 495.858328 31.077969
+" clip-path="url(#p240ed87935)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- $\mathdefault{10^{6}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(458.487266 398.793969)">
+      <g style="fill: #9aa3ad" transform="translate(487.058328 426.513969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -95,379 +95,396 @@ L 467.287266 31.077969
     <g id="xtick_4">
      <g id="line2d_7">
       <defs>
-       <path id="meb00f83ae2" d="M 0 0
+       <path id="m2e623312eb" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#meb00f83ae2" x="117.488452" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="145.563486" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#meb00f83ae2" x="140.310681" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="168.418078" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#meb00f83ae2" x="156.503311" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="184.63367" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#meb00f83ae2" x="169.063291" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="197.21146" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#meb00f83ae2" x="179.325541" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="207.488262" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#meb00f83ae2" x="188.00215" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="216.177175" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#meb00f83ae2" x="195.518171" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="223.703854" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#meb00f83ae2" x="202.147771" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="230.342855" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#meb00f83ae2" x="247.09301" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="275.351828" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#meb00f83ae2" x="269.915239" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="298.20642" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#meb00f83ae2" x="286.107869" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="314.422012" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#meb00f83ae2" x="298.667849" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="326.999802" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#meb00f83ae2" x="308.930099" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="337.276604" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#meb00f83ae2" x="317.606708" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="345.965517" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#meb00f83ae2" x="325.122729" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="353.492196" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#meb00f83ae2" x="331.752329" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="360.131197" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#meb00f83ae2" x="376.697568" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="405.14017" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#meb00f83ae2" x="399.519798" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="427.994762" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#meb00f83ae2" x="415.712427" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="444.210354" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#meb00f83ae2" x="428.272407" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="456.788144" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#meb00f83ae2" x="438.534657" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="467.064946" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#meb00f83ae2" x="447.211266" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="475.753859" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#meb00f83ae2" x="454.727287" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="483.280538" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_27">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#meb00f83ae2" x="461.356887" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="489.919539" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_28">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#meb00f83ae2" x="506.302126" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="534.928512" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_29">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#meb00f83ae2" x="529.124356" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m2e623312eb" x="557.783104" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_4">
-     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="311.51125" y="412.034906" transform="rotate(-0 311.51125 412.034906)">time to process the payload set once (log scale, lower is faster)</text>
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="340.133125" y="439.754906" transform="rotate(-0 340.133125 439.754906)">time to process the payload set once (log scale, lower is faster)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_33"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="62.951854" transform="rotate(-0 79.23125 62.951854)">YAMLRocks</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="63.943695" transform="rotate(-0 107.853125 63.943695)">YAMLRocks</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_34"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="96.137039" transform="rotate(-0 79.23125 96.137039)">yaml_rs</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="96.383993" transform="rotate(-0 107.853125 96.383993)">yaml_rs 0.1.4</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_35"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="129.322225" transform="rotate(-0 79.23125 129.322225)">py-yaml12</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="128.824292" transform="rotate(-0 107.853125 128.824292)">fast-yaml 0.6.3</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_36"/>
      <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="162.50741" transform="rotate(-0 79.23125 162.50741)">ryaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="161.26459" transform="rotate(-0 107.853125 161.26459)">py-yaml12 0.1.0</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_37"/>
      <g id="text_9">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="195.692204" transform="rotate(-0 79.23125 195.692204)">PyYAML (C)</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="193.704889" transform="rotate(-0 107.853125 193.704889)">ryaml 0.5.1</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_38"/>
      <g id="text_10">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="228.87778" transform="rotate(-0 79.23125 228.87778)">yamlium</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="226.144797" transform="rotate(-0 107.853125 226.144797)">PyYAML (C) 6.0.3</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_39"/>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="262.062965" transform="rotate(-0 79.23125 262.062965)">oyaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="258.585486" transform="rotate(-0 107.853125 258.585486)">yamlium 0.2.5</text>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_40"/>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="295.24776" transform="rotate(-0 79.23125 295.24776)">PyYAML (pure)</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="291.025394" transform="rotate(-0 107.853125 291.025394)">PyYAML (pure) 6.0.3</text>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_41"/>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="328.433336" transform="rotate(-0 79.23125 328.433336)">ruamel.yaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="323.466083" transform="rotate(-0 107.853125 323.466083)">oyaml 1.0</text>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_42"/>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="79.23125" y="361.618521" transform="rotate(-0 79.23125 361.618521)">strictyaml</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="355.906382" transform="rotate(-0 107.853125 355.906382)">ruamel.yaml 0.19.1</text>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_43"/>
+     <g id="text_15">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="388.34668" transform="rotate(-0 107.853125 388.34668)">strictyaml 1.7.3</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 82.73125 385.893969
-L 540.29125 385.893969
+    <path d="M 111.353125 413.613969
+L 568.913125 413.613969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -129914.898177 47.205969
-L 101.402215 47.205969
-L 101.402215 71.099302
-L -129914.898177 71.099302
+    <path d="M -130071.213787 48.465969
+L 130.019669 48.465969
+L 130.019669 71.822984
+L -130071.213787 71.822984
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #24fefd"/>
+" clip-path="url(#p240ed87935)" style="fill: #24fefd"/>
    </g>
    <g id="patch_5">
-    <path d="M -129914.898177 80.391154
-L 113.986892 80.391154
-L 113.986892 104.284487
-L -129914.898177 104.284487
+    <path d="M -130071.213787 80.906267
+L 141.038646 80.906267
+L 141.038646 104.263282
+L -130071.213787 104.263282
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
-    <path d="M -129914.898177 113.576339
-L 149.269894 113.576339
-L 149.269894 137.469672
-L -129914.898177 137.469672
+    <path d="M -130071.213787 113.346566
+L 159.179882 113.346566
+L 159.179882 136.703581
+L -130071.213787 136.703581
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_7">
-    <path d="M -129914.898177 146.761524
-L 158.525223 146.761524
-L 158.525223 170.654858
-L -129914.898177 170.654858
+    <path d="M -130071.213787 145.786864
+L 177.803687 145.786864
+L 177.803687 169.143879
+L -130071.213787 169.143879
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -129914.898177 179.946709
-L 235.371995 179.946709
-L 235.371995 203.840043
-L -129914.898177 203.840043
+    <path d="M -130071.213787 178.227163
+L 186.259473 178.227163
+L 186.259473 201.584178
+L -130071.213787 201.584178
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
-    <path d="M -129914.898177 213.131895
-L 309.132334 213.131895
-L 309.132334 237.025228
-L -129914.898177 237.025228
+    <path d="M -130071.213787 210.667461
+L 263.34488 210.667461
+L 263.34488 234.024476
+L -130071.213787 234.024476
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_10">
-    <path d="M -129914.898177 246.31708
-L 361.076584 246.31708
-L 361.076584 270.210413
-L -129914.898177 270.210413
+    <path d="M -130071.213787 243.10776
+L 336.911822 243.10776
+L 336.911822 266.464775
+L -130071.213787 266.464775
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_11">
-    <path d="M -129914.898177 279.502265
-L 361.695829 279.502265
-L 361.695829 303.395598
-L -129914.898177 303.395598
+    <path d="M -130071.213787 275.548058
+L 389.021582 275.548058
+L 389.021582 298.905073
+L -130071.213787 298.905073
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_12">
-    <path d="M -129914.898177 312.68745
-L 385.96991 312.68745
-L 385.96991 336.580784
-L -129914.898177 336.580784
+    <path d="M -130071.213787 307.988357
+L 389.456668 307.988357
+L 389.456668 331.345372
+L -130071.213787 331.345372
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="patch_13">
-    <path d="M -129914.898177 345.872635
-L 474.82151 345.872635
-L 474.82151 369.765969
-L -129914.898177 369.765969
+    <path d="M -130071.213787 340.428655
+L 413.948083 340.428655
+L 413.948083 363.78567
+L -130071.213787 363.78567
 z
-" clip-path="url(#p45a3cc76dd)" style="fill: #5b626d"/>
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
-   <g id="text_15">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="109.268932" y="61.100878" transform="rotate(-0 109.268932 61.100878)">1.5 ms</text>
+   <g id="patch_14">
+    <path d="M -130071.213787 372.868954
+L 503.350547 372.868954
+L 503.350547 396.225969
+L -130071.213787 396.225969
+z
+" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="121.853608" y="94.286063" transform="rotate(-0 121.853608 94.286063)">1.9 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.897541" y="62.092718" transform="rotate(-0 137.897541 62.092718)">1.5 ms</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="157.136611" y="127.471248" transform="rotate(-0 157.136611 127.471248)">3.5 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="148.916518" y="94.533017" transform="rotate(-0 148.916518 94.533017)">1.8 ms</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="166.39194" y="160.656433" transform="rotate(-0 166.39194 160.656433)">4.1 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="167.057754" y="126.973315" transform="rotate(-0 167.057754 126.973315)">2.5 ms</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="243.238712" y="193.841618" transform="rotate(-0 243.238712 193.841618)">16.2 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="185.681559" y="159.413614" transform="rotate(-0 185.681559 159.413614)">3.5 ms</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="316.999051" y="227.026804" transform="rotate(-0 316.999051 227.026804)">60.2 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="194.137345" y="191.853912" transform="rotate(-0 194.137345 191.853912)">4.1 ms</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="368.943301" y="260.211989" transform="rotate(-0 368.943301 260.211989)">151.5 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="271.222752" y="224.294211" transform="rotate(-0 271.222752 224.294211)">16.2 ms</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="369.562546" y="293.397174" transform="rotate(-0 369.562546 293.397174)">153.2 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="344.789694" y="256.734509" transform="rotate(-0 344.789694 256.734509)">59.6 ms</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="393.836627" y="326.582359" transform="rotate(-0 393.836627 326.582359)">235.8 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="396.899454" y="289.174808" transform="rotate(-0 396.899454 289.174808)">150.3 ms</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="482.688227" y="359.767544" transform="rotate(-0 482.688227 359.767544)">1.14 s</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="397.33454" y="321.615106" transform="rotate(-0 397.33454 321.615106)">151.4 ms</text>
    </g>
    <g id="text_25">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="82.73125" y="17.077969" transform="rotate(-0 82.73125 17.077969)">Parsing (loads), across libraries</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="421.825955" y="354.055405" transform="rotate(-0 421.825955 354.055405)">233.8 ms</text>
+   </g>
+   <g id="text_26">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="511.228419" y="386.495703" transform="rotate(-0 511.228419 386.495703)">1.14 s</text>
+   </g>
+   <g id="text_27">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="111.353125" y="17.077969" transform="rotate(-0 111.353125 17.077969)">Parsing (loads), across libraries</text>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p45a3cc76dd">
-   <rect x="82.73125" y="31.077969" width="457.56" height="354.816"/>
+  <clipPath id="p240ed87935">
+   <rect x="111.353125" y="31.077969" width="457.56" height="382.536"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/public/benchmarks/vs-fast-yaml.svg
+++ b/docs/public/benchmarks/vs-fast-yaml.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.839134</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 234.933452 38.889969
+L 234.933452 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#p1535d50d2c)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="237.823305" y="56.725854" transform="rotate(-0 237.823305 56.725854)">1.7x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#p1535d50d2c)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">2.5 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 168.4271 127.531748
+L 168.4271 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#p1535d50d2c)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="171.316953" y="145.367633" transform="rotate(-0 171.316953 145.367633)">2.0x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 241.796195 163.874877
+L 241.796195 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#p1535d50d2c)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="244.686048" y="181.580548" transform="rotate(-0 244.686048 181.580548)">1.6 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs fast-yaml</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 227.05875 238.504243
+L 245.05875 238.504243
+L 245.05875 232.204242
+L 227.05875 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="252.25875" y="238.504243" transform="rotate(-0 252.25875 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 320.198906 238.504243
+L 338.198906 238.504243
+L 338.198906 232.204242
+L 320.198906 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="345.398906" y="238.504243" transform="rotate(-0 345.398906 238.504243)">fast-yaml 0.6.3</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p1535d50d2c">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-oyaml.svg
+++ b/docs/public/benchmarks/vs-oyaml.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.997947</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 93.792311 38.889969
+L 93.792311 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#pb0cdcce935)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="96.682164" y="56.725854" transform="rotate(-0 96.682164 56.725854)">100x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#pb0cdcce935)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">151.4 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 92.673866 127.531748
+L 92.673866 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#pb0cdcce935)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.563719" y="145.367633" transform="rotate(-0 95.563719 145.367633)">107x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 230.434095 163.874877
+L 230.434095 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#pb0cdcce935)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="233.323948" y="181.580548" transform="rotate(-0 233.323948 181.580548)">87.4 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs oyaml</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 238.593516 238.504243
+L 256.593516 238.504243
+L 256.593516 232.204242
+L 238.593516 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="263.793516" y="238.504243" transform="rotate(-0 263.793516 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 331.733672 238.504243
+L 349.733672 238.504243
+L 349.733672 232.204242
+L 331.733672 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="356.933672" y="238.504243" transform="rotate(-0 356.933672 238.504243)">oyaml 1.0</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb0cdcce935">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-py-yaml12.svg
+++ b/docs/public/benchmarks/vs-py-yaml12.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.905290</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 194.541525 38.889969
+L 194.541525 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#pfe0bf97a6a)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="197.431378" y="56.725854" transform="rotate(-0 197.431378 56.725854)">2.3x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#pfe0bf97a6a)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">3.5 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 146.747956 127.531748
+L 146.747956 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#pfe0bf97a6a)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="149.637809" y="145.367633" transform="rotate(-0 149.637809 145.367633)">1.5x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 175.093125 163.874877
+L 175.093125 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#pfe0bf97a6a)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="177.982978" y="181.580548" transform="rotate(-0 177.982978 181.580548)">1.2 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs py-yaml12</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 224.341172 238.504243
+L 242.341172 238.504243
+L 242.341172 232.204242
+L 224.341172 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="249.541172" y="238.504243" transform="rotate(-0 249.541172 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 317.481328 238.504243
+L 335.481328 238.504243
+L 335.481328 232.204242
+L 317.481328 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="342.681328" y="238.504243" transform="rotate(-0 342.681328 238.504243)">py-yaml12 0.1.0</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pfe0bf97a6a">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-pyyaml.svg
+++ b/docs/public/benchmarks/vs-pyyaml.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="310.454512pt" viewBox="0 0 556.138125 310.454512" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.730493</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 310.454512
+L 556.138125 310.454512
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 255.609969
+L 548.938125 255.609969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="89.861888" transform="rotate(-0 87.878125 89.861888)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="204.424487" transform="rotate(-0 87.878125 204.424487)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 255.609969
+L 548.938125 255.609969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 41.283969
+L 93.811018 41.283969
+L 93.811018 68.213817
+L 91.378125 68.213817
+z
+" clip-path="url(#pf583515795)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="96.70087" y="56.956901" transform="rotate(-0 96.70087 56.956901)">1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 72.597746
+L 117.282554 72.597746
+L 117.282554 99.527594
+L 91.378125 99.527594
+z
+" clip-path="url(#pf583515795)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="120.172407" y="88.141107" transform="rotate(-0 120.172407 88.141107)">16.2 ms · 11x slower</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 103.911522
+L 332.199178 103.911522
+L 332.199178 130.841371
+L 91.378125 130.841371
+z
+" clip-path="url(#pf583515795)" style="fill: #41464f"/>
+   </g>
+   <g id="text_5">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="119.454884" transform="rotate(-0 335.08903 119.454884)">150.3 ms · 99x slower</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 155.846567
+L 92.683907 155.846567
+L 92.683907 182.776415
+L 91.378125 182.776415
+z
+" clip-path="url(#pf583515795)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_6">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.573759" y="171.519499" transform="rotate(-0 95.573759 171.519499)">815 µs</text>
+   </g>
+   <g id="patch_8">
+    <path d="M 91.378125 187.160344
+L 115.308489 187.160344
+L 115.308489 214.090192
+L 91.378125 214.090192
+z
+" clip-path="url(#pf583515795)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_7">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="118.198342" y="202.703705" transform="rotate(-0 118.198342 202.703705)">14.9 ms · 18x slower</text>
+   </g>
+   <g id="patch_9">
+    <path d="M 91.378125 218.474121
+L 230.830332 218.474121
+L 230.830332 245.403969
+L 91.378125 245.403969
+z
+" clip-path="url(#pf583515795)" style="fill: #41464f"/>
+   </g>
+   <g id="text_8">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="233.720184" y="234.017482" transform="rotate(-0 233.720184 234.017482)">87.0 ms · 107x slower</text>
+   </g>
+   <g id="text_9">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs PyYAML</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_10">
+     <path d="M 140.219297 297.492402
+L 158.219297 297.492402
+L 158.219297 291.192402
+L 140.219297 291.192402
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_10">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="165.419297" y="297.492402" transform="rotate(-0 165.419297 297.492402)">YAMLRocks</text>
+    </g>
+    <g id="patch_11">
+     <path d="M 233.359453 297.492402
+L 251.359453 297.492402
+L 251.359453 291.192402
+L 233.359453 291.192402
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_11">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="258.559453" y="297.492402" transform="rotate(-0 258.559453 297.492402)">PyYAML (C loader) 6.0.3</text>
+    </g>
+    <g id="patch_12">
+     <path d="M 384.309141 297.492402
+L 402.309141 297.492402
+L 402.309141 291.192402
+L 384.309141 291.192402
+z
+" style="fill: #41464f; stroke: #41464f; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_12">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="409.509141" y="297.492402" transform="rotate(-0 409.509141 297.492402)">PyYAML (pure) 6.0.3</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pf583515795">
+   <rect x="91.378125" y="31.077969" width="457.56" height="224.532"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-ruamel.svg
+++ b/docs/public/benchmarks/vs-ruamel.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.769830</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 92.941517 38.889969
+L 92.941517 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#pd7d10d9576)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.83137" y="56.725854" transform="rotate(-0 95.83137 56.725854)">154x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#pd7d10d9576)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">233.8 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 92.217228 127.531748
+L 92.217228 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#pd7d10d9576)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.107081" y="145.367633" transform="rotate(-0 95.107081 145.367633)">218x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 274.115196 163.874877
+L 274.115196 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#pd7d10d9576)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="277.005049" y="181.580548" transform="rotate(-0 277.005049 181.580548)">177.4 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs ruamel.yaml</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 216.898594 238.504243
+L 234.898594 238.504243
+L 234.898594 232.204242
+L 216.898594 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="242.098594" y="238.504243" transform="rotate(-0 242.098594 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 310.03875 238.504243
+L 328.03875 238.504243
+L 328.03875 232.204242
+L 310.03875 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="335.23875" y="238.504243" transform="rotate(-0 335.23875 238.504243)">ruamel.yaml 0.19.1</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd7d10d9576">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-ryaml.svg
+++ b/docs/public/benchmarks/vs-ryaml.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.872240</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 180.170376 38.889969
+L 180.170376 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#pdd2bba842d)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="183.060229" y="56.725854" transform="rotate(-0 183.060229 56.725854)">2.7x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#pdd2bba842d)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">4.1 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 139.034677 127.531748
+L 139.034677 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#pdd2bba842d)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="141.92453" y="145.367633" transform="rotate(-0 141.92453 145.367633)">3.5x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 258.778382 163.874877
+L 258.778382 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#pdd2bba842d)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="261.668235" y="181.580548" transform="rotate(-0 261.668235 181.580548)">2.9 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs ryaml</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 235.20375 238.504243
+L 253.20375 238.504243
+L 253.20375 232.204242
+L 235.20375 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="260.40375" y="238.504243" transform="rotate(-0 260.40375 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 328.343906 238.504243
+L 346.343906 238.504243
+L 346.343906 232.204242
+L 328.343906 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="353.543906" y="238.504243" transform="rotate(-0 353.543906 238.504243)">ryaml 0.5.1</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pdd2bba842d">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-strictyaml.svg
+++ b/docs/public/benchmarks/vs-strictyaml.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="553.617813pt" height="192.478192pt" viewBox="0 0 553.617813 192.478192" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.968379</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 192.478192
+L 553.617813 192.478192
+L 553.617813 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 88.857813 150.273969
+L 546.417812 150.273969
+L 546.417812 31.077969
+L 88.857813 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="85.357813" y="94.475187" transform="rotate(-0 85.357813 94.475187)">Reading (loads)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 88.857813 150.273969
+L 546.417812 150.273969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 88.857813 36.495969
+L 89.177875 36.495969
+L 89.177875 86.597904
+L 88.857813 86.597904
+z
+" clip-path="url(#p4c529ee2f1)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_2">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="92.067728" y="63.755276" transform="rotate(-0 92.067728 63.755276)">752x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 88.857813 94.754033
+L 329.678865 94.754033
+L 329.678865 144.855969
+L 88.857813 144.855969
+z
+" clip-path="url(#p4c529ee2f1)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_3">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="332.568718" y="121.883126" transform="rotate(-0 332.568718 121.883126)">1.14 s</text>
+   </g>
+   <g id="text_4">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="88.857813" y="17.077969" transform="rotate(-0 88.857813 17.077969)">YAMLRocks vs strictyaml</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_6">
+     <path d="M 223.086484 179.516082
+L 241.086484 179.516082
+L 241.086484 173.216082
+L 223.086484 173.216082
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_5">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="248.286484" y="179.516082" transform="rotate(-0 248.286484 179.516082)">YAMLRocks</text>
+    </g>
+    <g id="patch_7">
+     <path d="M 316.226641 179.516082
+L 334.226641 179.516082
+L 334.226641 173.216082
+L 316.226641 173.216082
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="341.426641" y="179.516082" transform="rotate(-0 341.426641 179.516082)">strictyaml 1.7.3</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p4c529ee2f1">
+   <rect x="88.857813" y="31.077969" width="457.56" height="119.196"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-yaml-rs.svg
+++ b/docs/public/benchmarks/vs-yaml-rs.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.804532</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 289.437252 38.889969
+L 289.437252 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#p2461946bfe)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="292.327105" y="56.725854" transform="rotate(-0 292.327105 56.725854)">1.2x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#p2461946bfe)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">1.8 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 197.680364 127.531748
+L 197.680364 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#p2461946bfe)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="200.570217" y="145.367633" transform="rotate(-0 200.570217 145.367633)">1.3x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 230.963801 163.874877
+L 230.963801 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#p2461946bfe)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="233.853654" y="181.580548" transform="rotate(-0 233.853654 181.580548)">1.1 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs yaml-rs</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 231.236016 238.504243
+L 249.236016 238.504243
+L 249.236016 232.204242
+L 231.236016 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="256.436016" y="238.504243" transform="rotate(-0 256.436016 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 324.376172 238.504243
+L 342.376172 238.504243
+L 342.376172 232.204242
+L 324.376172 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="349.576172" y="238.504243" transform="rotate(-0 349.576172 238.504243)">yaml-rs 0.1.4</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2461946bfe">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/public/benchmarks/vs-yamlium.svg
+++ b/docs/public/benchmarks/vs-yamlium.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="556.138125pt" height="251.466352pt" viewBox="0 0 556.138125 251.466352" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-04T10:47:56.939731</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 251.466352
+L 556.138125 251.466352
+L 556.138125 0
+L 0 0
+z
+" style="fill: #13151c"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+L 548.938125 31.077969
+L 91.378125 31.077969
+z
+" style="fill: #13151c"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="76.488298" transform="rotate(-0 87.878125 76.488298)">Reading (loads)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="87.878125" y="165.130077" transform="rotate(-0 87.878125 165.130077)">Writing (dumps)</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.378125 202.941969
+L 548.938125 202.941969
+" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 91.378125 38.889969
+L 97.510391 38.889969
+L 97.510391 70.14506
+L 91.378125 70.14506
+z
+" clip-path="url(#p5363715f76)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_3">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="100.400244" y="56.725854" transform="rotate(-0 100.400244 56.725854)">39x faster · 1.5 ms</text>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.378125 75.233098
+L 332.199178 75.233098
+L 332.199178 106.48819
+L 91.378125 106.48819
+z
+" clip-path="url(#p5363715f76)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_4">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">59.6 ms</text>
+   </g>
+   <g id="patch_6">
+    <path d="M 91.378125 127.531748
+L 94.669433 127.531748
+L 94.669433 158.786839
+L 91.378125 158.786839
+z
+" clip-path="url(#p5363715f76)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_5">
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="97.559286" y="145.367633" transform="rotate(-0 97.559286 145.367633)">12x faster · 815 µs</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 91.378125 163.874877
+L 132.066579 163.874877
+L 132.066579 195.129969
+L 91.378125 195.129969
+z
+" clip-path="url(#p5363715f76)" style="fill: #5b626d"/>
+   </g>
+   <g id="text_6">
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="134.956432" y="181.580548" transform="rotate(-0 134.956432 181.580548)">10.1 ms</text>
+   </g>
+   <g id="text_7">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs yamlium</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 228.568359 238.504243
+L 246.568359 238.504243
+L 246.568359 232.204242
+L 228.568359 232.204242
+z
+" style="fill: #24fefd; stroke: #24fefd; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="253.768359" y="238.504243" transform="rotate(-0 253.768359 238.504243)">YAMLRocks</text>
+    </g>
+    <g id="patch_9">
+     <path d="M 321.708516 238.504243
+L 339.708516 238.504243
+L 339.708516 232.204242
+L 321.708516 232.204242
+z
+" style="fill: #5b626d; stroke: #5b626d; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_9">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="346.908516" y="238.504243" transform="rotate(-0 346.908516 238.504243)">yamlium 0.2.5</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5363715f76">
+   <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/src/content/docs/comparisons/index.md
+++ b/docs/src/content/docs/comparisons/index.md
@@ -1,6 +1,6 @@
 ---
 title: How YAMLRocks compares
-description: YAMLRocks versus PyYAML and ruamel.yaml at a glance, with benchmarks.
+description: YAMLRocks versus every major Python YAML library at a glance, with benchmarks.
 ---
 
 The Python YAML ecosystem has long forced a choice: **PyYAML** (fast with the C
@@ -42,15 +42,50 @@ hardware. Run `python bench/bench.py` on your own machine to reproduce them. The
 [performance guide](/guides/performance/) explains where the speed comes from
 and how to measure your own workload.
 
+## The whole field
+
+The Python YAML ecosystem is larger than PyYAML and ruamel. There are newer
+Rust-backed parsers and pure-Python contenders too. YAMLRocks leads the field on
+both load and dump. Indicative wall-clock times from `python bench/compare.py`
+(release build, whole payload set, fastest first):
+
+| Library       |  Impl  |     load |      dump |
+| ------------- | :----: | -------: | --------: |
+| **YAMLRocks** |  Rust  |  ~1.5 ms |   ~815 µs |
+| yaml-rs       |  Rust  |  ~1.8 ms |   ~1.1 ms |
+| fast-yaml     |  Rust  |  ~2.5 ms |   ~1.6 ms |
+| py-yaml12     |  Rust  |  ~3.5 ms |   ~1.2 ms |
+| ryaml         |  Rust  |  ~4.1 ms |   ~2.9 ms |
+| PyYAML (C)    |   C    | ~16.2 ms |  ~14.9 ms |
+| yamlium       | Python | ~59.6 ms |  ~10.1 ms |
+| PyYAML (pure) | Python |  ~150 ms |    ~87 ms |
+| oyaml         | Python |  ~151 ms |    ~87 ms |
+| ruamel.yaml   | Python |  ~234 ms |   ~177 ms |
+| strictyaml    | Python |  ~1.14 s | no dumper |
+
+Speed is only half of it. The Rust rivals differ in what they get right: yaml-rs,
+py-yaml12, and ryaml leave `<<` merge keys unresolved, and yaml-rs, py-yaml12, and
+fast-yaml misread a bare `0777` as the integer `777`. YAMLRocks is the fastest,
+and the only one verified against the entire official YAML test suite.
+
 ## How to choose
 
-- Coming from **PyYAML** and want the same safe-by-default loading, but faster,
-  on YAML 1.2, with comments and includes? Read [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/).
+- Coming from **PyYAML** (or **oyaml**, which is just PyYAML with ordered dicts)?
+  Read [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/) and
+  [vs oyaml](/comparisons/vs-oyaml/).
 - Coming from **ruamel.yaml** for its round-trip fidelity, but tired of pure
   Python speed? Read [YAMLRocks vs ruamel.yaml](/comparisons/vs-ruamel/).
+- Comparing the newer **Rust** parsers? Read
+  [vs yaml-rs](/comparisons/vs-yaml-rs/),
+  [vs fast-yaml](/comparisons/vs-fast-yaml/),
+  [vs ryaml](/comparisons/vs-ryaml/), and
+  [vs py-yaml12](/comparisons/vs-py-yaml12/).
+- Looking at pure-Python **round-trip or safety** libraries? Read
+  [vs yamlium](/comparisons/vs-yamlium/) and
+  [vs strictyaml](/comparisons/vs-strictyaml/).
 
-Both pages carry full benchmark tables, feature matrices, side-by-side code,
-migration notes, and an honest "when to stick with the other library" section.
+Every page carries a benchmark, a feature matrix, side-by-side code, and an
+honest account of where the other library fits.
 
 ## See also
 

--- a/docs/src/content/docs/comparisons/vs-fast-yaml.md
+++ b/docs/src/content/docs/comparisons/vs-fast-yaml.md
@@ -1,0 +1,103 @@
+---
+title: YAMLRocks vs fast-yaml
+description: A detailed comparison of YAMLRocks and fast-yaml, with benchmarks and the capabilities that set them apart.
+---
+
+[fast-yaml](https://github.com/bug-ops/fast-yaml) (the `fastyaml-rs` package) is a
+Rust-backed YAML 1.2 parser built on the saphyr crate, with a PyYAML-style
+`safe_load`/`safe_dump` API and built-in linting. It is a capable, fast reader,
+and of the newer Rust parsers it gets the most right. But it is still a one-way
+parser: it does not edit YAML, resolve includes, or validate against a schema,
+and YAMLRocks is both more complete and faster.
+
+## Feature comparison
+
+| Feature                       |   fast-yaml   |         YAMLRocks          |
+| ----------------------------- | :-----------: | :------------------------: |
+| Comment-preserving round-trip |      No       |    Yes (byte-for-byte)     |
+| Native `!include` + writeback |      No       |            Yes             |
+| JSON Schema validation        |      No       |    Yes (line-numbered)     |
+| Source line/column            |      No       |    Yes (annotated mode)    |
+| Custom tag handling           |  Unverified   |            Yes             |
+| Verified vs the YAML suite    |  Not stated   |        Yes, in full        |
+| Merge keys (`<<`)             |      Yes      |            Yes             |
+| Anchors/aliases resolved      |      Yes      |            Yes             |
+| Multi-document streams        |      Yes      |            Yes             |
+| Implementation                | Rust (saphyr) | Rust (own scanner/emitter) |
+| Speed (parse / dump)          |   baseline    |    ~1.6x / ~2.0x faster    |
+
+## A parser, or a toolkit
+
+fast-yaml reads YAML into Python and lints it. YAMLRocks does that and the rest of
+what a real configuration workflow needs:
+
+- **Comment-preserving round-trip.** Load with `OPT_ROUND_TRIP`, change a value,
+  and re-emit with comments, anchors, and formatting intact; an unmodified
+  document comes back byte-for-byte. fast-yaml explicitly does not preserve
+  comments, so it can read a file but not edit one.
+- **Native `!include`** with file-aware write-back across a split configuration.
+- **JSON Schema validation** with line-numbered errors.
+- **Annotated mode** with the source line and column on every node.
+- **Custom tag handling**, and **safe-by-default** loading.
+
+See [round-trip editing](/guides/round-trip/), [includes](/guides/includes/),
+[schema validation](/guides/schema-validation/), and
+[annotated mode](/guides/annotated/).
+
+## Speed
+
+Both are Rust extensions built on strict YAML 1.2. YAMLRocks is faster on both
+directions.
+
+![YAMLRocks vs fast-yaml on reading and writing: YAMLRocks is faster on both loads and dumps.](/benchmarks/vs-fast-yaml.svg)
+
+| Operation | fast-yaml | YAMLRocks | YAMLRocks is |
+| --------- | --------: | --------: | -----------: |
+| Reading   |   ~2.5 ms |   ~1.5 ms | ~1.6x faster |
+| Writing   |   ~1.6 ms |   ~815 µs | ~2.0x faster |
+
+:::note[Reproduce it]
+Wall-clock times from one machine and payload set. Run `python bench/compare.py`
+to measure both on your own hardware.
+:::
+
+## Correctness, verified rather than assumed
+
+fast-yaml is the most correct of the newer Rust parsers, it resolves merge keys,
+where yaml-rs, ryaml, and py-yaml12 leave `<<` as a literal key. That makes the
+remaining difference the interesting one: YAMLRocks checks its parsing against the
+entire official YAML test suite on every change (load, round-trip, and canonical
+result), and fast-yaml still misreads a leading-zero integer:
+
+```python
+import yamlrocks
+
+# `0777` is a string in YAML 1.2 (the octal form is `0o777`), not the number 777.
+yamlrocks.loads(b"mode: 0777")
+# {'mode': '0777'}
+# fast-yaml returns {'mode': 777}.
+```
+
+The point is not one scalar; it is that "verified against the whole suite" is a
+guarantee fast-yaml does not make, and the edges are where that shows.
+
+## Where fast-yaml is a reasonable pick
+
+fast-yaml is a fast, dual-licensed (MIT/Apache-2.0) 1.2 parser with a familiar
+`safe_load`/`safe_dump` surface and a handy built-in linter. If you want a quick,
+drop-in-flavored reader for trusted YAML and never write edited files back, it is
+a reasonable choice, and more faithful than its Rust peers.
+
+## When to choose YAMLRocks
+
+Choose YAMLRocks when YAML is something you edit, include, validate, and depend
+on: comment-preserving round-trip, native includes, schema validation, and source
+locations, on a parser that is verified correct against the full YAML test suite
+and is faster too.
+
+## See also
+
+- [YAMLRocks vs yaml-rs](/comparisons/vs-yaml-rs/),
+  [vs ryaml](/comparisons/vs-ryaml/), and
+  [vs py-yaml12](/comparisons/vs-py-yaml12/): the other Rust-backed parsers.
+- [Performance](/guides/performance/): the benchmark methodology.

--- a/docs/src/content/docs/comparisons/vs-oyaml.md
+++ b/docs/src/content/docs/comparisons/vs-oyaml.md
@@ -1,0 +1,59 @@
+---
+title: YAMLRocks vs oyaml
+description: Why oyaml is just PyYAML with ordered dicts, and why that no longer buys you anything.
+---
+
+[oyaml](https://pypi.org/project/oyaml/) is not a separate YAML implementation. It
+is a small shim that imports PyYAML, registers ordered-dict representers and
+constructors, and re-exports PyYAML's entire API. You use it as `import oyaml as
+yaml`. Its one job was preserving mapping key order, which mattered before Python
+3.7. Since then, dicts are ordered by the language and modern PyYAML already keeps
+insertion order, so oyaml adds essentially nothing.
+
+## What oyaml actually is
+
+Everything oyaml does, PyYAML does. Its speed, its YAML 1.1 semantics, its comment
+handling (none), its safety story, all of it is PyYAML's, because it _is_ PyYAML
+underneath. So the real comparison is [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/),
+and it applies here unchanged.
+
+| Feature                    | oyaml (= PyYAML) |      YAMLRocks       |
+| -------------------------- | :--------------: | :------------------: |
+| Distinct implementation    |   No (PyYAML)    | Yes (Rust extension) |
+| Preserves key order        | Yes (its point)  |         Yes          |
+| YAML 1.2 by default        |        No        |         Yes          |
+| Comment preservation       |        No        |         Yes          |
+| Round-trip (byte-for-byte) |        No        |         Yes          |
+| Native `!include`          |        No        |         Yes          |
+| JSON Schema validation     |        No        |         Yes          |
+| Speed (parse)              |     baseline     |     ~100x faster     |
+| Speed (dump)               |     baseline     |     ~105x faster     |
+
+![YAMLRocks vs oyaml on reading and writing: YAMLRocks is about two orders of magnitude faster, because oyaml is PyYAML underneath.](/benchmarks/vs-oyaml.svg)
+
+## Order preservation is free now
+
+YAMLRocks preserves mapping key order as a matter of course, the same as any modern
+dict. There is nothing to add a shim for.
+
+```python
+import yamlrocks
+
+yamlrocks.loads(b"z: 1\na: 2\nm: 3\n")
+# {'z': 1, 'a': 2, 'm': 3}   source order, always
+```
+
+## When to choose YAMLRocks
+
+There is no scenario where oyaml is preferable to plain PyYAML on a supported
+Python, and none where it beats YAMLRocks. If you are on oyaml today, you are on
+PyYAML with a patch that no longer does anything; move straight to YAMLRocks for
+YAML 1.2, comment-preserving round-trip, native includes, schema validation, and
+one to two orders of magnitude more speed.
+
+## See also
+
+- [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/): the comparison that actually
+  applies to oyaml.
+- [Migrating from PyYAML](/getting-started/migrating-from-pyyaml/).
+- [Performance](/guides/performance/).

--- a/docs/src/content/docs/comparisons/vs-py-yaml12.md
+++ b/docs/src/content/docs/comparisons/vs-py-yaml12.md
@@ -1,0 +1,97 @@
+---
+title: YAMLRocks vs py-yaml12
+description: A detailed comparison of YAMLRocks and py-yaml12, with benchmarks and the capabilities that set them apart.
+---
+
+[py-yaml12](https://pypi.org/project/py-yaml12/) is a Rust-backed YAML 1.2 parser
+(built on the saphyr crate) with genuinely good first-class custom-tag handling.
+It is a clean data parser, and its tag support is a real strength. But it is a
+one-way parser: it does not edit YAML, resolve includes, or validate against a
+schema, and YAMLRocks is both more complete and faster.
+
+## Feature comparison
+
+| Feature                       |     py-yaml12     |         YAMLRocks          |
+| ----------------------------- | :---------------: | :------------------------: |
+| Comment-preserving round-trip |        No         |    Yes (byte-for-byte)     |
+| Native `!include` + writeback |        No         |            Yes             |
+| JSON Schema validation        |        No         |    Yes (line-numbered)     |
+| Source line/column            |        No         |    Yes (annotated mode)    |
+| Custom tag handling           | Yes (first-class) |            Yes             |
+| Verified vs the YAML suite    |    Claims full    |        Yes, in full        |
+| Multi-document streams        |        Yes        |            Yes             |
+| Merge keys (`<<`)             |        No         |            Yes             |
+| Implementation                |   Rust (saphyr)   | Rust (own scanner/emitter) |
+| Speed (parse / dump)          |     baseline      |    ~2.3x / ~1.5x faster    |
+
+## A parser, or a toolkit
+
+py-yaml12's tag handling is legitimately nice: a `Yaml(value, tag)` wrapper and
+`handlers=` callables transform tagged nodes at parse time. YAMLRocks matches that
+(a `tags=` registry and a `tag_handler`) and then adds the whole
+configuration-editing layer py-yaml12 has no answer for:
+
+- **Comment-preserving round-trip.** Edit a value and re-emit with comments,
+  anchors, and formatting intact; unmodified documents come back byte-for-byte.
+  py-yaml12 reads data but cannot write an edited file back.
+- **Native `!include`** with file-aware write-back across split configurations.
+- **JSON Schema validation** with line-numbered errors.
+- **Annotated mode** with the source line and column on every node.
+
+See [custom tags](/guides/tags/), [round-trip editing](/guides/round-trip/),
+[includes](/guides/includes/), and [schema validation](/guides/schema-validation/).
+
+## Speed
+
+Both are Rust extensions built for correctness and speed. YAMLRocks is faster on
+both directions.
+
+![YAMLRocks vs py-yaml12 on reading and writing: YAMLRocks is faster on both loads and dumps.](/benchmarks/vs-py-yaml12.svg)
+
+| Operation | py-yaml12 | YAMLRocks | YAMLRocks is |
+| --------- | --------: | --------: | -----------: |
+| Reading   |   ~3.5 ms |   ~1.5 ms | ~2.3x faster |
+| Writing   |   ~1.2 ms |   ~815 µs | ~1.5x faster |
+
+:::note[Reproduce it]
+Wall-clock times from one machine and payload set. Run `python bench/compare.py`
+to measure on your own hardware.
+:::
+
+## Correctness, verified rather than assumed
+
+Both aim at YAML 1.2, and py-yaml12 states it targets the test suite. YAMLRocks
+runs that suite in CI on every change (load, round-trip, and canonical result all
+checked), and it also resolves merge keys and the 1.2 scalar edges py-yaml12 does
+not:
+
+```python
+import yamlrocks
+
+# Merge keys: YAMLRocks folds the base in; py-yaml12 leaves `<<` as a literal key.
+yamlrocks.loads(b"base: &b\n  timeout: 30\nsvc:\n  <<: *b\n  name: api\n")
+# {'base': {'timeout': 30}, 'svc': {'timeout': 30, 'name': 'api'}}
+
+# `0777` is a string in YAML 1.2; py-yaml12 returns the number 777.
+yamlrocks.loads(b"mode: 0777")
+# {'mode': '0777'}
+```
+
+## Where py-yaml12 is a reasonable pick
+
+For turning trusted YAML 1.2 data into Python objects with rich custom tags,
+py-yaml12 is a solid, MIT-licensed choice, and its tag API is genuinely good. If
+you never edit YAML, resolve includes, or need schema validation, it fits.
+
+## When to choose YAMLRocks
+
+Choose YAMLRocks when you want that same clean 1.2 parsing and tag handling plus
+the editing toolkit around it, comment-preserving round-trip, includes, schema
+validation, source locations, verified correctness including merge keys, and more
+speed.
+
+## See also
+
+- [YAMLRocks vs yaml-rs](/comparisons/vs-yaml-rs/) and
+  [vs ryaml](/comparisons/vs-ryaml/): the other Rust-backed parsers.
+- [Custom tags](/guides/tags/) and [performance](/guides/performance/).

--- a/docs/src/content/docs/comparisons/vs-pyyaml.md
+++ b/docs/src/content/docs/comparisons/vs-pyyaml.md
@@ -148,6 +148,8 @@ to be [yamllint](https://yamllint.readthedocs.io/)-clean by default.
 
 ## Performance
 
+![YAMLRocks vs PyYAML's C loader on reading and writing: YAMLRocks is about ten times faster on both.](/benchmarks/vs-pyyaml.svg)
+
 Indicative figures from `python bench/bench.py` (release build), showing how many
 times **faster YAMLRocks is** than PyYAML. The C loader (`libyaml`) is the harder
 target; the pure-Python loader is what most environments fall back to.

--- a/docs/src/content/docs/comparisons/vs-ruamel.md
+++ b/docs/src/content/docs/comparisons/vs-ruamel.md
@@ -32,6 +32,8 @@ exhaustive comment surgery, covered honestly below.
 
 ## Speed: Rust vs pure Python
 
+![YAMLRocks vs ruamel.yaml on reading and writing: YAMLRocks is one to two orders of magnitude faster on both.](/benchmarks/vs-ruamel.svg)
+
 ruamel.yaml is implemented entirely in Python, which makes it flexible but slow.
 YAMLRocks does the same work in Rust and materializes results across the PyO3
 boundary, so the same parse or dump is one to two orders of magnitude faster.

--- a/docs/src/content/docs/comparisons/vs-ryaml.md
+++ b/docs/src/content/docs/comparisons/vs-ryaml.md
@@ -1,0 +1,97 @@
+---
+title: YAMLRocks vs ryaml
+description: A detailed comparison of YAMLRocks and ryaml, with benchmarks and the capabilities that set them apart.
+---
+
+[ryaml](https://pypi.org/project/ryaml/) is a Rust-backed YAML reader with a
+deliberately small, `json`-module-style API. It is a fine way to turn a trusted
+file into Python data, but that is all it does, and it is alpha software. YAMLRocks
+is the full configuration toolkit, comment-preserving round-trip, native
+includes, schema validation, source locations, and verified-correct parsing, and
+it is several times faster.
+
+## Feature comparison
+
+| Feature                       |        ryaml         |         YAMLRocks          |
+| ----------------------------- | :------------------: | :------------------------: |
+| Comment-preserving round-trip |          No          |    Yes (byte-for-byte)     |
+| Native `!include` + writeback |          No          |            Yes             |
+| JSON Schema validation        |          No          |    Yes (line-numbered)     |
+| Source line/column            |          No          |    Yes (annotated mode)    |
+| Custom tag handling           |          No          |            Yes             |
+| Verified vs the YAML suite    |      Not stated      |        Yes, in full        |
+| Merge keys (`<<`)             |          No          |            Yes             |
+| Anchors/aliases resolved      |         Yes          |            Yes             |
+| Implementation                | Rust (libyaml-safer) | Rust (own scanner/emitter) |
+| Speed (parse / dump)          |       baseline       |    ~2.7x / ~3.6x faster    |
+| Maturity                      |     0.5.x, alpha     |    Battle-tested corpus    |
+
+## A parser, or a toolkit
+
+ryaml reads YAML into Python and stops. YAMLRocks does that and the rest of what a
+real configuration workflow needs:
+
+- **Comment-preserving round-trip.** Edit a value and re-emit with comments,
+  anchors, and layout intact; an unmodified document is byte-for-byte identical.
+  ryaml drops comments and formatting, so it can read a file but not edit one.
+- **Native `!include`** with file-aware write-back across a split configuration.
+- **JSON Schema validation** with line-numbered errors.
+- **Annotated mode** with the source line and column on every node.
+- **Custom tag handling**, and **safe-by-default** loading that never builds
+  arbitrary Python objects.
+
+See [round-trip editing](/guides/round-trip/), [includes](/guides/includes/),
+[schema validation](/guides/schema-validation/), and
+[annotated mode](/guides/annotated/).
+
+## Speed
+
+Both are Rust extensions, so this is Rust vs Rust. YAMLRocks is well ahead on both.
+
+![YAMLRocks vs ryaml on reading and writing: YAMLRocks is several times faster on both loads and dumps.](/benchmarks/vs-ryaml.svg)
+
+| Operation |   ryaml | YAMLRocks | YAMLRocks is |
+| --------- | ------: | --------: | -----------: |
+| Reading   | ~4.1 ms |   ~1.5 ms | ~2.7x faster |
+| Writing   | ~2.9 ms |   ~815 µs | ~3.6x faster |
+
+:::note[Reproduce it]
+Wall-clock times from one machine and payload set. Run `python bench/compare.py`
+to measure on your own hardware.
+:::
+
+## Correctness, verified rather than assumed
+
+YAMLRocks's parsing is checked against the entire official YAML test suite on
+every change. ryaml publishes no such guarantee, describes itself as YAML 1.1 yet
+resolves `no` and `0o17` the 1.2 way, and does not implement merge keys:
+
+```python
+import yamlrocks
+
+# Merge keys: YAMLRocks folds the base in; ryaml leaves `<<` as a literal key.
+yamlrocks.loads(b"base: &b\n  timeout: 30\nsvc:\n  <<: *b\n  name: api\n")
+# {'base': {'timeout': 30}, 'svc': {'timeout': 30, 'name': 'api'}}
+```
+
+The point is not one missing feature; it is that YAMLRocks commits to a schema and
+proves it, so you always know which reading you get.
+
+## Where ryaml is a reasonable pick
+
+ryaml is a small, MIT-licensed, `json`-style reader. For quickly loading trusted
+YAML 1.2 data with no writing and no merge keys, it is easy to reach for. It is
+alpha (0.5.x) with a thin surface by design.
+
+## When to choose YAMLRocks
+
+Choose YAMLRocks when YAML is something you edit, validate, and depend on:
+round-trip with comments, includes, schema validation, and source locations, on
+a verified-correct parser that is also several times faster.
+
+## See also
+
+- [YAMLRocks vs yaml-rs](/comparisons/vs-yaml-rs/) and
+  [vs py-yaml12](/comparisons/vs-py-yaml12/): the other Rust-backed parsers.
+- [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/): the safety and speed comparison.
+- [Performance](/guides/performance/): the benchmark methodology.

--- a/docs/src/content/docs/comparisons/vs-strictyaml.md
+++ b/docs/src/content/docs/comparisons/vs-strictyaml.md
@@ -1,0 +1,94 @@
+---
+title: YAMLRocks vs strictyaml
+description: How YAMLRocks answers strictyaml's safety concerns without crippling YAML or the throughput.
+---
+
+[strictyaml](https://pypi.org/project/strictyaml/) takes a strong position: YAML's
+implicit typing and its more exotic features are footguns, so it parses only a
+restricted subset and makes you supply a schema to get anything other than
+strings. The concern is real. The remedy is heavy: strictyaml is pure Python
+built on ruamel.yaml, it removes large parts of YAML, it is load-only, and it is
+the slowest option in the field by a wide margin. YAMLRocks answers the same
+concern by defaulting to YAML 1.2 and offering real JSON Schema validation,
+without throwing away YAML or the speed.
+
+## The concern, and how YAMLRocks addresses it
+
+strictyaml's headline argument is the "Norway problem": in YAML 1.1, `no` becomes
+boolean `False`, so a country list containing `NO` (Norway) silently corrupts.
+YAMLRocks does not have this problem, because it defaults to the YAML 1.2 core
+schema, where `no` is the string `"no"`.
+
+```python
+import yamlrocks
+
+yamlrocks.loads(b"countries: [NO, SE, DK]")
+# {'countries': ['NO', 'SE', 'DK']}   strings, not [False, 'SE', 'DK']
+```
+
+Where strictyaml removes implicit typing entirely and hands you strings, YAMLRocks
+gives you correct 1.2 types by default and lets you _enforce_ a shape with JSON
+Schema validation that reports line-numbered errors. You get type safety without
+giving up numbers, booleans, or a dumper.
+
+## Feature comparison
+
+| Feature                   |      strictyaml      |       YAMLRocks       |
+| ------------------------- | :------------------: | :-------------------: |
+| Implicit `no` -> `False`  |   Avoided (subset)   | Avoided (1.2 default) |
+| Typed values without cast |  No (strings only)   | Yes (1.2 core schema) |
+| Schema validation         | Yes (own schema DSL) |   Yes (JSON Schema)   |
+| Anchors/aliases           |  Rejected by design  |    Yes (preserved)    |
+| Flow style `{}` / `[]`    |  Rejected by design  |          Yes          |
+| Custom tags               |  Rejected by design  |          Yes          |
+| Dumping arbitrary data    |  No general dumper   |          Yes          |
+| Comment preservation      |   Yes (via ruamel)   |          Yes          |
+| Implementation            | Pure Python (ruamel) |    Rust extension     |
+| Speed (parse)             |       baseline       |     ~760x faster      |
+
+## Speed
+
+![YAMLRocks vs strictyaml on reading: YAMLRocks is roughly three orders of magnitude faster to load.](/benchmarks/vs-strictyaml.svg)
+
+strictyaml is built for a specific safety story, not for throughput, and it shows:
+it is roughly three orders of magnitude slower to load than YAMLRocks, and it has
+no general-purpose dumper to benchmark at all.
+
+| Operation | strictyaml | YAMLRocks | YAMLRocks is |
+| --------- | ---------: | --------: | -----------: |
+| load      |    ~1.14 s |   ~1.5 ms | ~760x faster |
+| dump      |  no dumper |   ~815 µs |            - |
+
+:::note[Reproduce it]
+Wall-clock times from one machine and payload set. Run `python bench/compare.py`
+to measure on your own hardware.
+:::
+
+## What strictyaml gives up
+
+To enforce its subset, strictyaml rejects flow style, anchors and aliases, and
+tags outright, and it returns every leaf as a string until a schema casts it. That
+is a deliberate, sometimes reasonable trade for a locked-down config format you
+fully control. But it means strictyaml cannot read a large fraction of real-world
+YAML, and it cannot write YAML back out as a drop-in dumper.
+
+YAMLRocks reads all of standard YAML 1.2, is safe by default (it never constructs
+arbitrary Python objects from tags), types scalars correctly, validates against a
+schema when you want enforcement, and round-trips with comments intact.
+
+## When to choose YAMLRocks
+
+Choose strictyaml only if you specifically want a maximally restricted YAML dialect
+and are willing to pay for it in speed and in features. For everything else, safe
+loading, correct 1.2 types, schema-enforced validation, reading real-world YAML,
+round-trip editing, and speed, YAMLRocks covers the same safety goals without the
+sacrifices.
+
+## See also
+
+- [Schema validation](/guides/schema-validation/): enforce a shape with
+  line-numbered errors.
+- [YAML 1.1 vs 1.2](/guides/yaml-11-vs-12/): why the Norway problem does not
+  happen by default.
+- [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/) and
+  [performance](/guides/performance/).

--- a/docs/src/content/docs/comparisons/vs-yaml-rs.md
+++ b/docs/src/content/docs/comparisons/vs-yaml-rs.md
@@ -1,0 +1,118 @@
+---
+title: YAMLRocks vs yaml-rs
+description: A detailed comparison of YAMLRocks and yaml-rs, with benchmarks and the capabilities that set them apart.
+---
+
+[yaml-rs](https://pypi.org/project/yaml-rs/) is a young Rust-backed YAML 1.2
+parser that markets itself as the fastest in the ecosystem. It is genuinely fast,
+and the closest competitor to YAMLRocks on raw throughput. But it is only a
+parser: text in, Python values out. YAMLRocks is the whole toolkit real
+configuration work needs, comment-preserving round-trip, native includes, schema
+validation, source locations, rigorously verified correctness, and it is faster
+on top.
+
+## Feature comparison
+
+| Feature                       |       yaml-rs        |         YAMLRocks          |
+| ----------------------------- | :------------------: | :------------------------: |
+| YAML 1.2                      |         Yes          |            Yes             |
+| Comment-preserving round-trip |          No          |    Yes (byte-for-byte)     |
+| Native `!include` + writeback |          No          |            Yes             |
+| JSON Schema validation        |          No          |    Yes (line-numbered)     |
+| Source line/column            |          No          |    Yes (annotated mode)    |
+| Custom tag handling           |          No          |            Yes             |
+| Verified vs the YAML suite    |      Not stated      |        Yes, in full        |
+| Anchors/aliases resolved      |         Yes          |            Yes             |
+| Merge keys (`<<`)             |          No          |            Yes             |
+| Implementation                |  Rust (saphyr fork)  | Rust (own scanner/emitter) |
+| Speed (parse / dump)          |       baseline       |    ~1.2x / ~1.4x faster    |
+| Maturity                      | 0.1.x, public domain |    Battle-tested corpus    |
+
+## A parser, or a toolkit
+
+This is the difference that matters. yaml-rs reads YAML into Python values and
+stops there. YAMLRocks does that and everything a real configuration workflow
+needs around it:
+
+- **Comment-preserving round-trip.** Load with `OPT_ROUND_TRIP`, change a value,
+  and re-emit with every comment, anchor, and formatting choice intact; an
+  unmodified document comes back byte-for-byte. yaml-rs discards comments and
+  layout, so it cannot edit a file, only read it.
+- **Native `!include`.** YAMLRocks resolves `!include` and the `!include_dir_*`
+  family, and in round-trip mode writes edits back to the specific file each node
+  came from. Split configurations (Home Assistant, Kubernetes overlays) work out
+  of the box.
+- **JSON Schema validation** with line-numbered errors, so a bad config is
+  rejected with a message that points at the line, not a stack trace.
+- **Annotated mode** attaches the source line and column to every node, which is
+  what lets a tool underline the exact place a value came from.
+- **Custom tag handling** through a `tags=` registry or a `tag_handler`.
+- **Safe by default.** Loading never constructs arbitrary Python objects.
+
+See [round-trip editing](/guides/round-trip/), [includes](/guides/includes/),
+[schema validation](/guides/schema-validation/), and
+[annotated mode](/guides/annotated/).
+
+## Speed
+
+Both are Rust extensions, so this is Rust vs Rust, not Rust vs Python. yaml-rs is
+the nearest rival on the field, and YAMLRocks is still ahead on both directions.
+
+![YAMLRocks vs yaml-rs on reading and writing: YAMLRocks is faster on both loads and dumps.](/benchmarks/vs-yaml-rs.svg)
+
+| Operation | yaml-rs | YAMLRocks | YAMLRocks is |
+| --------- | ------: | --------: | -----------: |
+| Reading   | ~1.8 ms |   ~1.5 ms | ~1.2x faster |
+| Writing   | ~1.1 ms |   ~815 µs | ~1.4x faster |
+
+The gap is smaller than against a pure-Python library, as you would expect from
+two native implementations. Speed is real, but it is not the reason to choose
+between them, the capabilities above and the correctness below are.
+
+:::note[Reproduce it]
+Wall-clock times from one machine and payload set, not a fixed law. Run
+`python bench/compare.py` to measure both on your own hardware.
+:::
+
+## Correctness, verified rather than assumed
+
+YAMLRocks's parsing is checked against the entire official YAML test suite on
+every change: a case must load, round-trip, and match its canonical result, or
+CI fails. That is the substantive correctness claim, and it is why the edges hold
+up. yaml-rs makes no such published guarantee, and it shows in cases like these:
+
+```python
+import yamlrocks
+
+# Merge keys: YAMLRocks folds the base in; yaml-rs leaves `<<` as a literal key.
+yamlrocks.loads(b"base: &b\n  timeout: 30\nsvc:\n  <<: *b\n  name: api\n")
+# {'base': {'timeout': 30}, 'svc': {'timeout': 30, 'name': 'api'}}
+
+# Leading-zero integers: `0777` is a string in YAML 1.2, not the number 777.
+yamlrocks.loads(b"mode: 0777")
+# {'mode': '0777'}
+```
+
+These are not the reason to switch on their own; they are evidence that "verified
+against the whole suite" is a real difference, not a slogan.
+
+## Where yaml-rs is a reasonable pick
+
+yaml-rs is a small, fast, public-domain (Unlicense) parser. If all you need is to
+turn a trusted YAML 1.2 file into Python data as quickly as possible, and never
+write YAML back out, it does that one job well. It is early software (0.1.x) with
+a deliberately thin surface.
+
+## When to choose YAMLRocks
+
+Choose YAMLRocks when YAML is something you edit and depend on, not just read:
+comment-preserving round-trip, native includes, schema validation, and source
+locations, on a parser that is verified correct against the full YAML test suite
+and is faster too. That is almost every real configuration use.
+
+## See also
+
+- [YAMLRocks vs PyYAML](/comparisons/vs-pyyaml/): the safety and speed comparison.
+- [YAMLRocks vs ryaml](/comparisons/vs-ryaml/) and
+  [vs py-yaml12](/comparisons/vs-py-yaml12/): the other Rust-backed parsers.
+- [Performance](/guides/performance/): the benchmark methodology.

--- a/docs/src/content/docs/comparisons/vs-yamlium.md
+++ b/docs/src/content/docs/comparisons/vs-yamlium.md
@@ -1,0 +1,94 @@
+---
+title: YAMLRocks vs yamlium
+description: A detailed comparison of YAMLRocks and yamlium, with benchmarks and the capabilities that set them apart.
+---
+
+[yamlium](https://pypi.org/project/yamlium/) is a pure-Python, dependency-free
+YAML library that preserves comments and structure through a manipulation API,
+a real feature for a zero-dependency package. Where YAMLRocks pulls ahead is
+everything around that: it is one to two orders of magnitude faster, it commits
+to YAML 1.2 and proves it against the test suite, and it adds native includes and
+schema validation that yamlium has no equivalent for.
+
+## Feature comparison
+
+| Feature                       |     yamlium     |      YAMLRocks       |
+| ----------------------------- | :-------------: | :------------------: |
+| Comment-preserving round-trip |       Yes       | Yes (byte-for-byte)  |
+| Native `!include` + writeback |       No        |         Yes          |
+| JSON Schema validation        |       No        | Yes (line-numbered)  |
+| Source line/column            |       No        | Yes (annotated mode) |
+| Verified vs the YAML suite    |   Not stated    |     Yes, in full     |
+| Declared YAML version         |  Undocumented   |  1.2 (1.1 optional)  |
+| Anchors / merge keys          | Preserved / yes |   Preserved / yes    |
+| Implementation                |   Pure Python   |    Rust extension    |
+| Speed (parse / dump)          |    baseline     |  ~40x / ~12x faster  |
+
+## Speed: Rust vs pure Python
+
+yamlium is pure Python, which makes it portable but slow. YAMLRocks does the same
+work in Rust, one to two orders of magnitude faster on both directions.
+
+![YAMLRocks vs yamlium on reading and writing: YAMLRocks is an order of magnitude faster on both loads and dumps.](/benchmarks/vs-yamlium.svg)
+
+| Operation |  yamlium | YAMLRocks | YAMLRocks is |
+| --------- | -------: | --------: | -----------: |
+| Reading   | ~59.6 ms |   ~1.5 ms |  ~40x faster |
+| Writing   | ~10.1 ms |   ~815 µs |  ~12x faster |
+
+:::note[Reproduce it]
+Wall-clock times from one machine and payload set. Run `python bench/compare.py`
+to measure on your own hardware.
+:::
+
+## Same round-trip, more of everything else
+
+yamlium's comment-and-structure-preserving editing is its selling point, and
+YAMLRocks matches it: load with `OPT_ROUND_TRIP`, edit through a node API, and
+re-emit with comments, anchors, and layout intact, byte-for-byte when unmodified.
+On that same foundation YAMLRocks adds what yamlium does not have:
+
+- **Native `!include`** with file-aware write-back across a split configuration.
+- **JSON Schema validation** with line-numbered errors.
+- **Annotated mode** with the source line and column on every node.
+- **Safe-by-default** loading and correct YAML 1.2 typing.
+
+See [round-trip editing](/guides/round-trip/), [includes](/guides/includes/),
+[schema validation](/guides/schema-validation/), and
+[annotated mode](/guides/annotated/).
+
+## Correctness, verified rather than assumed
+
+YAMLRocks commits to the YAML 1.2 core schema and checks it against the entire
+official test suite in CI. yamlium does not document which YAML version it
+targets, and its scalar resolution lands between the two in surprising ways:
+
+```python
+import yamlrocks
+
+yamlrocks.loads(b"mode: 0777")   # {'mode': '0777'}  a string, per YAML 1.2
+yamlrocks.loads(b"mask: 0o17")   # {'mask': 15}      the 1.2 octal
+# yamlium returns {'mode': 777} and {'mask': '0o17'}.
+```
+
+When you cannot tell which spec a library follows, you cannot tell what a value
+will become. YAMLRocks makes that explicit and pins it.
+
+## Where yamlium is a reasonable pick
+
+yamlium is a fair choice when you specifically need a pure-Python,
+zero-dependency package (no binary wheel to install) and can accept its speed and
+its scalar quirks. Its comment-editing API is nicely done.
+
+## When to choose YAMLRocks
+
+Choose YAMLRocks when you can install a wheel and want the same comment-preserving
+round-trip with real speed, native includes, schema validation, source
+locations, and correctness that is verified rather than undocumented.
+
+## See also
+
+- [Round-trip editing](/guides/round-trip/): the comment-preserving workflow.
+- [YAMLRocks vs ruamel.yaml](/comparisons/vs-ruamel/): the other round-trip
+  comparison.
+- [Performance](/guides/performance/): the benchmark methodology.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ charts = [
   "ryaml==0.5.1",
   "py-yaml12==0.1.0",
   "yaml-rs==0.1.4",
+  "fastyaml-rs==0.6.3",
   "oyaml==1.0",
   "strictyaml==1.7.3",
   "matplotlib==3.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,35 @@ wheels = [
 ]
 
 [[package]]
+name = "fastyaml-rs"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/3c/ef16b75a8536a63b5f085b673b09c981de23912b60ef9b5db8c0512e48d5/fastyaml_rs-0.6.3.tar.gz", hash = "sha256:c74363052a44e0266b5e42349887bb638a67c83fb3aea35bbf70799f23784fb0", size = 266451, upload-time = "2026-05-26T17:01:04.763Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7c/d6166052a32bb1ef4b20f07535a25164da35cea3051b9fd7d53bd003b045/fastyaml_rs-0.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:023f79c08b8248230262bf23f4977bb981a2abc37c83657b3cff71eb4c09b234", size = 749195, upload-time = "2026-05-26T17:00:34.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ce/5c3af5c5dd843c56eb0d5e8b1ed2b32d8f0efafeb895c6a3646e980bf694/fastyaml_rs-0.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1edecdbb8ec05c09b6968ab2673108015f922a8d9e1282e037b24bd94c548cb3", size = 698768, upload-time = "2026-05-26T17:00:35.916Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a1/c85db4c0f35bdf235642f6678bea3e2e0c6b1ed5b9101fb5e45cacce11d3/fastyaml_rs-0.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0b7e95ee93438d423bca2f95f4f3b49786cc99c18b120ad99c5cfd0c6a6f0df", size = 732830, upload-time = "2026-05-26T17:00:37.794Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/52/aaf122b105b69ce970843da4b9009ce723374aa3ab58542dd4d01559c217/fastyaml_rs-0.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b09a26ee9ba9951f24750cd8aec9ff6d535cbfd0802ba231e00d842944d668d8", size = 778238, upload-time = "2026-05-26T17:00:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f0/573e5ac3ea7a1963fb2ac814eca8a105c8a4d56b88866810ec8e4fa31afa/fastyaml_rs-0.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6c717dc4b9e4889fcac8d7c503644ac125b4db4216253571eec8104bb22beb87", size = 910491, upload-time = "2026-05-26T17:00:40.526Z" },
+    { url = "https://files.pythonhosted.org/packages/db/af/e31b27bf1360be09fc9d3f1a455ee6410e436a8a0989c87b25abfa3dadac/fastyaml_rs-0.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:eadca6e74c54dd76c54e5fee5914db213d43e134e6a96678543650ecf9961f9c", size = 989362, upload-time = "2026-05-26T17:00:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4b/d388018906a9918705671791000a88a88e6fafbe3de431acacb191cddfb8/fastyaml_rs-0.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:750e6aebdecc1ef7edc449cdf63b31a7cceb1f400860d17685877d2575d8729d", size = 709296, upload-time = "2026-05-26T17:00:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bc/cc52137f257d35999fed0a71f79de527630c6ff90b41322e762172e11394/fastyaml_rs-0.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:04e3e935006db915afb7b1155597b93a5ea5b3cf562e94ebf7a18f62b3485b81", size = 749221, upload-time = "2026-05-26T17:00:44.8Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/70/4098e899fb41de2576057f424663fa94b2657c7de1ac07e01e3f81b10fc9/fastyaml_rs-0.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd42247d88f91c368672af37799c0d7005089d662ea77b81f3a0c6d88518e33d", size = 698785, upload-time = "2026-05-26T17:00:46.086Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/37/5dd263bd189860c3522ae22adb6f624968a0cf0474fe4f585b77b5fd6786/fastyaml_rs-0.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dc62b65bbb776627535db73f40b2c9725ef6dfaaf6593269329b20ab787a1f4", size = 732778, upload-time = "2026-05-26T17:00:47.471Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1d/bed549db62d0fdab8b5e2dfd08d505017396e84a0cb981018bcaf7a9e0d3/fastyaml_rs-0.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec3a4eca8c82b0395bd711f5089980735a8bb5ceb362adcb9f99bb7f40099fef", size = 778175, upload-time = "2026-05-26T17:00:48.841Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/19/c4cda6d95800f0be6c3f755a8681bd413ed8e94fb3fcae530bb692e2c69f/fastyaml_rs-0.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:66a0b410c1835a945381987413d79eecca81bd31bca87e861ba6100c99b1f606", size = 910188, upload-time = "2026-05-26T17:00:50.379Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/5a/4cfd6b68d1e154a1a8c1e2af81a510a99696c6a287b892cb9efe686899e2/fastyaml_rs-0.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca355019e655a4509b3f44d878b760a682fe68d391e42aebc40c1078fa8bfb70", size = 989244, upload-time = "2026-05-26T17:00:51.878Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b0/ac487c955b7265c4ebc91841be9686e9b3f4a218a5588dc8a00d845a51a7/fastyaml_rs-0.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:8f2c0828c4c742a93df02e182d02ecc8ff5ce1aaa34a3dbdc193a1f76242425f", size = 709211, upload-time = "2026-05-26T17:00:53.449Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f2/ce6c248ebacc6f019411928d9ab4592abdddb5198e90116308e5c2440fec/fastyaml_rs-0.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6710892a260b42b689186926ba7fee7e6a71132a89e2ff34369c127ae1fe70d0", size = 749285, upload-time = "2026-05-26T17:00:54.871Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/95/a0ca82d62918e53bb39e2d9ef1663ae8e3d1ffe364924d8aecec9dd59347/fastyaml_rs-0.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acb862768dc0979006d2c13bde346433875b8901464117bdd5b7cd6af53571c7", size = 698778, upload-time = "2026-05-26T17:00:56.283Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b6/f8decc0b1d0b0cfbc274545e36edbea0a8a156979dedf638bb8a29f4080c/fastyaml_rs-0.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ce61fa6406b85506aa35babc54b42411badb961a5deedd2f9e3de62082d7584", size = 732407, upload-time = "2026-05-26T17:00:57.705Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6a/ebcf28b2731486a30f93d25fbbe80ed926bda9e16d2110e27543667cd426/fastyaml_rs-0.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6cd7b387758a4dc240daf42292a25996d993e7ef9d7ac5291eacb9a557f3892", size = 778087, upload-time = "2026-05-26T17:00:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/86/10/d75a2823cae6ca31cb792a8f4ac24603cadb58b5d7e2509b81d686ac8775/fastyaml_rs-0.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0e6db48b5a46ead01e16d6cf83bb6999dff2786f2747e00602a8dd8cc6b5870", size = 909999, upload-time = "2026-05-26T17:01:00.609Z" },
+    { url = "https://files.pythonhosted.org/packages/26/63/88102585ca9b8f1397b6520a22ebbc66200d12d3730c4e9431c00c12c6d0/fastyaml_rs-0.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:daad00e2472a4cc3f12c365440a97cd667ca7315aa04352c05ac0005fda3e118", size = 989190, upload-time = "2026-05-26T17:01:02.003Z" },
+    { url = "https://files.pythonhosted.org/packages/94/93/07e1072a5d793f92e32796fc54a2114d813fda5f50573a0d8e62e2e12a6e/fastyaml_rs-0.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:34c29f4bdf4a7e21ee2e3188f2c02c4b731be7169fcc3786e221c2bd6c13d33c", size = 709560, upload-time = "2026-05-26T17:01:03.399Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1130,6 +1159,7 @@ build = [
     { name = "maturin" },
 ]
 charts = [
+    { name = "fastyaml-rs" },
     { name = "matplotlib" },
     { name = "oyaml" },
     { name = "py-yaml12" },
@@ -1190,6 +1220,7 @@ bench = [
 ]
 build = [{ name = "maturin", specifier = "==1.14.1" }]
 charts = [
+    { name = "fastyaml-rs", specifier = "==0.6.3" },
     { name = "matplotlib", specifier = "==3.11.0" },
     { name = "oyaml", specifier = "==1.0" },
     { name = "py-yaml12", specifier = "==0.1.0" },


### PR DESCRIPTION
## Breaking change

None. Documentation and a benchmark-charting helper only.

## Proposed change

The docs compared YAMLRocks against PyYAML and ruamel.yaml. This adds honest, benchmarked comparison pages for every other library in the benchmark suite: **yaml-rs, ryaml, py-yaml12, yamlium, strictyaml, and oyaml**.

Each page leads with the substantive reasons to choose YAMLRocks, comment-preserving round-trip, native includes with write-back, JSON Schema validation, source-located annotated mode, safe-by-default loading, and correctness verified against the entire official YAML test suite, then backs them with a feature table, a head-to-head benchmark chart, and a text speed table (kept as text so search engines and LLMs can read the numbers).

Charts are generated by `bench/charts.py` via a new `_head_to_head` renderer: plain time bars (shorter is faster), YAMLRocks labelled with how many times faster it is and its time. PyYAML's chart shows both its C loader and pure loader. The existing PyYAML and ruamel pages gain the same chart.

The comparisons index gains a whole-field leaderboard across all ten libraries and links to every page; the sidebar lists them. Benchmark numbers are machine- and run-dependent, labelled indicative, and reproducible with `python bench/compare.py`.

Competitors are credited where they are genuinely good (py-yaml12's first-class tag handling, yamlium's pure-Python comment editing, strictyaml's safety stance). The specific gaps found while measuring (unresolved `<<` merge keys in the Rust parsers, a mis-typed `0777`) appear as evidence for the verified-correctness claim, not as the headline.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the cross-library comparison benchmarks (#200)
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.