### PR TITLE
📝 Add a YAML/JSON recipe and llms.txt for AI tooling

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import starlightLlmsTxt from "starlight-llms-txt";
 
 import rehypeYamlrocks from "./src/plugins/rehype-yamlrocks.mjs";
 
@@ -14,6 +15,37 @@ export default defineConfig({
     starlight({
       title: "YAMLRocks",
       description: "Rock-solid YAML for Python, written in Rust.",
+      plugins: [
+        starlightLlmsTxt({
+          projectName: "YAMLRocks",
+          description:
+            "YAMLRocks is a fast, correct YAML library for Python, implemented in Rust with PyO3. It is safe by default (tags never construct arbitrary objects), defaults to the YAML 1.2 core schema, reads and writes bytes without an extra encode step, and adds a comment-preserving round-trip mode, native `!include` resolution, JSON Schema validation, and source-tracked annotated mode.",
+          details: [
+            "Important notes for working with YAMLRocks:",
+            "",
+            "- Install with `pip install yamlrocks`; the import name is `yamlrocks`. Prebuilt wheels ship for CPython (including free-threaded builds); no C toolchain is needed.",
+            "- The core API is `loads`/`load` (parse), `dumps`/`dump` (serialize), `to_json` (JSON output), and the `loads_all`/`load_all` multi-document variants. `async_loads`/`async_load`/`async_load_all` run the parse off the event loop.",
+            "- `loads` takes and `dumps` returns `bytes` (a `str` is also accepted on input). There is no `yamlrocks.load` that executes code; the safe behavior is the only behavior.",
+            "- Behavior is controlled by `option=` flags combined with `|`, such as `OPT_ROUND_TRIP`, `OPT_INCLUDES`, `OPT_SECRETS`, `OPT_ENV_VAR`, `OPT_ANNOTATED`, `OPT_YAML_1_1`, `OPT_SORT_KEYS`, and the `OPT_INDENT_2`/`OPT_INDENT_4` pair.",
+            "- Round-trip mode returns a `YAMLRocksDocument`: edit it like a `dict`/`list`, then `to_yaml()` re-emits with comments and layout intact, byte-for-byte for an unmodified document.",
+            "- For a near drop-in migration from PyYAML, `import yamlrocks.compat as yaml` exposes `safe_load`/`safe_dump` and friends returning `str` like PyYAML.",
+          ].join("\n"),
+          customSets: [
+            {
+              label: "Guides and recipes",
+              paths: ["guides/**", "recipes/**"],
+              description:
+                "Task-oriented documentation: loading, dumping, JSON, round-trip editing, includes, annotated mode, schema validation, custom tags, and worked recipes.",
+            },
+            {
+              label: "API reference",
+              paths: ["reference/**", "getting-started/**"],
+              description:
+                "The full function and option reference, exceptions, the security model, and migration guides.",
+            },
+          ],
+        }),
+      ],
       head: [
         {
           tag: "meta",
@@ -128,6 +160,7 @@ export default defineConfig({
           items: [
             { label: "Home Assistant", slug: "recipes/home-assistant" },
             { label: "Config editor", slug: "recipes/config-editor" },
+            { label: "YAML and JSON", slug: "recipes/yaml-to-json" },
           ],
         },
         {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,7 +11,8 @@
         "@astrojs/starlight": "0.41.3",
         "@fontsource-variable/inter": "5.2.8",
         "astro": "7.0.5",
-        "sharp": "0.35.3"
+        "sharp": "0.35.3",
+        "starlight-llms-txt": "0.11.0"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
@@ -2220,6 +2221,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2273,6 +2280,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
       "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
       "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2563,6 +2579,18 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -3257,6 +3285,18 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -3626,6 +3666,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -3869,6 +3935,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -5322,6 +5397,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5846,6 +5946,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -5885,6 +5999,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6296,6 +6427,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/starlight-llms-txt": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.11.0.tgz",
+      "integrity": "sha512-83TU5zPgJhL9fXIWAOWjQjyQ6EKocshEjJyA4zOJjOqu/oxQsrTpYGYxjHLyfZe4LRD52N9eCuykSkaIYwUyDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^7.0.0",
+        "@types/hast": "^3.0.4",
+        "@types/micromatch": "^4.0.10",
+        "github-slugger": "^2.0.0",
+        "hast-util-select": "^6.0.4",
+        "micromatch": "^4.0.8",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.41.0",
+        "astro": "^7.0.0"
+      }
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -6399,10 +6554,32 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6541,6 +6718,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,8 @@
     "@astrojs/starlight": "0.41.3",
     "@fontsource-variable/inter": "5.2.8",
     "astro": "7.0.5",
-    "sharp": "0.35.3"
+    "sharp": "0.35.3",
+    "starlight-llms-txt": "0.11.0"
   },
   "overrides": {
     "esbuild": "0.28.1"

--- a/docs/src/content/docs/recipes/yaml-to-json.md
+++ b/docs/src/content/docs/recipes/yaml-to-json.md
@@ -1,0 +1,176 @@
+---
+title: Converting between YAML and JSON
+description: Convert YAML to JSON and JSON to YAML in Python, including multi-document streams, big integers, and stable diffs, with YAMLRocks.
+---
+
+YAML is a superset of JSON, so converting between the two is a common chore: feed
+a YAML config to a tool that only speaks JSON, or pretty-print a JSON blob as
+readable YAML. YAMLRocks does both with one call in each direction, safely and
+fast, and it keeps the things a naive `json` round-trip drops: key order, big
+integers, and multi-document streams. This recipe is the practical loop; the
+[JSON guide](/guides/json/) is the reference behind it.
+
+## YAML to JSON
+
+Read the YAML with `loads`, write JSON with `to_json`. Both speak `bytes`, so
+there is no extra encode step before you write to a file or socket:
+
+```python
+import yamlrocks
+
+config = b"name: app\nports:\n  - 80\n  - 443\nenabled: true\n"
+
+yamlrocks.to_json(yamlrocks.loads(config))
+# b'{"name":"app","ports":[80,443],"enabled":true}'
+```
+
+The output is compact by default, like a fast JSON writer. Note `enabled: true`
+became JSON `true`, not the string `"true"`: YAMLRocks defaults to YAML 1.2, so
+the booleans line up with JSON's without the [Norway
+problem](/guides/yaml-11-vs-12/).
+
+## JSON to YAML
+
+The reverse is `loads` (JSON is valid YAML, so no separate parser) then `dumps`:
+
+```python
+import yamlrocks
+
+yamlrocks.dumps(yamlrocks.loads(b'{"name":"app","ports":[80,443]}'))
+# b'name: app\nports:\n  - 80\n  - 443\n'
+```
+
+There is no `from_json`. Every valid JSON document is valid YAML 1.2, so `loads`
+already reads it.
+
+## Stable, diff-friendly JSON
+
+For JSON you commit or compare in review, compact output is noisy. Add indentation
+and sort the keys, so the same data always serializes to the same bytes and diffs
+stay small:
+
+```python
+import yamlrocks
+
+opt = yamlrocks.OPT_INDENT_2 | yamlrocks.OPT_SORT_KEYS
+print(yamlrocks.to_json(yamlrocks.loads(b"name: app\nport: 8080\n"), option=opt).decode())
+# {
+#   "name": "app",
+#   "port": 8080
+# }
+```
+
+Use `OPT_INDENT_4` for four-space indentation. Without an indent option the output
+stays compact. Leave out `OPT_SORT_KEYS` to keep the document's own key order,
+which YAMLRocks preserves end to end.
+
+## Multi-document YAML to a JSON array
+
+A YAML stream can hold several documents separated by `---`. JSON has no such
+separator, so the natural projection is a single JSON array. Read the stream with
+`loads_all` and hand the list straight to `to_json`:
+
+```python
+import yamlrocks
+
+stream = b"---\nname: a\n---\nname: b\n"
+
+docs = yamlrocks.loads_all(stream)
+docs
+# [{'name': 'a'}, {'name': 'b'}]
+
+yamlrocks.to_json(docs)
+# b'[{"name":"a"},{"name":"b"}]'
+```
+
+## Big integers survive the trip
+
+Python's standard `json` module handles arbitrary-precision integers, but many
+converters route through a type that clamps to 64 bits. YAMLRocks carries big
+integers through both YAML and JSON exactly:
+
+```python
+import yamlrocks
+
+big = 2**70
+yamlrocks.to_json({"n": big})
+# b'{"n":1180591620717411303424}'
+
+yamlrocks.loads(yamlrocks.to_json({"n": big}))["n"] == big
+# True
+```
+
+## Values JSON cannot hold
+
+A few YAML values have no JSON equivalent, so `to_json` projects them consistently
+rather than guessing. `NaN` and the infinities are not valid JSON numbers, so they
+become `null`:
+
+```python
+import yamlrocks
+
+yamlrocks.to_json({"x": float("nan"), "y": float("inf")})
+# b'{"x":null,"y":null}'
+```
+
+Tags are dropped to their underlying value, non-string scalar keys are stringified
+(`1` becomes `"1"`), and a collection used as a key raises, because JSON genuinely
+cannot represent it. The full table lives in the
+[JSON guide](/guides/json/#the-yaml-to-json-projection).
+
+## A tiny yaml2json command
+
+Put the pieces together and you have a converter that reads YAML on stdin and
+writes JSON on stdout, ready to drop into a shell pipeline. It touches the process
+streams, so it carries a skip marker for the docs verifier:
+
+<!-- verify: skip -->
+
+```python
+#!/usr/bin/env python3
+"""Read YAML on stdin, write pretty, sorted JSON on stdout."""
+import sys
+import yamlrocks
+
+opt = yamlrocks.OPT_INDENT_2 | yamlrocks.OPT_SORT_KEYS
+data = yamlrocks.loads(sys.stdin.buffer.read())
+sys.stdout.buffer.write(yamlrocks.to_json(data, option=opt))
+```
+
+Run it with `cat config.yaml | python yaml2json.py`. Swap `to_json` for `dumps`
+and drop the sort to make a `json2yaml` in the same shape.
+
+## Keeping the YAML when you convert
+
+Plain `loads` gives you data, not the document, so comments and layout are gone.
+That is exactly what you want when the destination is JSON. If instead you convert
+to JSON to inspect part of a config but keep editing the YAML, load once in
+[round-trip mode](/guides/round-trip/): `to_json` accepts a `YAMLRocksDocument` or a
+nested view, so you can export a sub-tree while the original stays intact for
+editing.
+
+```python
+import yamlrocks
+
+doc = yamlrocks.loads(
+    b"service:\n  name: web\n  ports: [80, 443]\nmeta:\n  owner: ops\n",
+    option=yamlrocks.OPT_ROUND_TRIP,
+)
+
+yamlrocks.to_json(doc["service"])   # just one sub-tree, as JSON
+# b'{"name":"web","ports":[80,443]}'
+
+doc.to_yaml()                       # the YAML is untouched, comments and all
+# b'service:\n  name: web\n  ports: [80, 443]\nmeta:\n  owner: ops\n'
+```
+
+## See also
+
+- [JSON import and export](/guides/json/): the full `to_json` reference and the
+  YAML-to-JSON projection rules.
+- [Loading YAML](/guides/loading/) and [Dumping YAML](/guides/dumping/): the
+  options that shape both directions.
+- [YAML 1.1 vs 1.2](/guides/yaml-11-vs-12/): why booleans and `null` line up with
+  JSON by default.
+- [Building a config editor](/recipes/config-editor/): when you convert to inspect
+  but keep editing the YAML.


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Two documentation additions for developers and for the coding assistants they use.

A new recipe, "Converting between YAML and JSON", covers the practical loop most people actually search for: YAML to JSON and back, stable diff-friendly output with `OPT_INDENT_2 | OPT_SORT_KEYS`, multi-document streams projected to a JSON array, big integers surviving the trip, the values JSON cannot hold, a tiny `yaml2json` stdin/stdout command, and how to keep the YAML intact when you only convert to inspect a sub-tree. Every example is runnable and checked by `docs/verify_examples.py`. It is phrased around high-intent queries ("convert yaml to json python") so search engines and LLMs pick it up cleanly.

An `llms.txt` for the docs site, via the `starlight-llms-txt` plugin. It generates `/llms.txt` (an index with a description and API-oriented notes), `/llms-full.txt` (the complete docs), `/llms-small.txt` (an abridged version), and two topic bundles a coding AI can grab as a focused slice: guides-and-recipes and api-reference. Auto-generated from the same source as the site on every build, so it never drifts behind the docs.

The `docs/package.json` and `docs/package-lock.json` changes pin the plugin and regenerate the lockfile with the CI Node version (24.18.0 / npm 11).

I originally drafted a second recipe on editing GitHub Actions workflows, but dropped it: scripting edits to workflow YAML and bumping mutable action tags is not a practice worth showcasing.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
