### PR TITLE
🐛 Escape C1 controls and non-characters, and fuzz the include engine

### DIFF
--- a/.github/scripts/test_wheel.sh
+++ b/.github/scripts/test_wheel.sh
@@ -17,6 +17,11 @@ pyexe="$(python -c 'import sys; print(sys.executable)')"
 uv pip install --python "${pyexe}" --group test
 uv pip install --python "${pyexe}" --group numpy \
   || echo "::notice::numpy has no wheel on this target; its tests will skip"
+# Hypothesis ships ABI-specific wheels and has none for some targets here
+# (prerelease CPython, 32-bit/ARM Windows); best-effort, and the property tests
+# skip when it is absent, exactly like numpy above.
+uv pip install --python "${pyexe}" --group proptest \
+  || echo "::notice::hypothesis has no wheel on this target; property tests will skip"
 
 # Install the just-built wheel, offline (never PyPI), no deps (yamlrocks has
 # none of its own).

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -44,8 +44,9 @@ jobs:
         with:
           components: llvm-tools-preview
       - name: 🏗 Install dependencies
-        # numpy keeps the OPT_SERIALIZE_NUMPY path inside the coverage numbers.
-        run: uv sync --locked --no-install-project --no-default-groups --group build --group test --group numpy
+        # numpy keeps the OPT_SERIALIZE_NUMPY path inside the coverage numbers;
+        # proptest adds Hypothesis so the property tests run (and count) here.
+        run: uv sync --locked --no-install-project --no-default-groups --group build --group test --group numpy --group proptest
       - name: 🏗 Install cargo-llvm-cov
         # Pin the tool version (not just its locked deps) so coverage runs are
         # reproducible across CI. Bump this deliberately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,12 +153,14 @@ structures and arbitrary bytes). For deeper, coverage-guided fuzzing of the Rust
 parser, there are [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz) targets
 under `fuzz/`:
 
-| Target         | What it drives                                                      | Contract                    |
-| -------------- | ------------------------------------------------------------------- | --------------------------- |
-| `parse`        | scanner → parser → composer (the round-trip AST)                    | never panic/hang            |
-| `decode`       | fast `loads` path → `Value` tree → fast `dumps`, under both schemas | never panic/hang            |
-| `roundtrip`    | compose → emit → re-compose (the round-trip emitter)                | never panic/hang            |
-| `differential` | `loads(dumps(loads(x)))` must equal `loads(x)`                      | never silently corrupt data |
+| Target                 | What it drives                                                      | Contract                                       |
+| ---------------------- | ------------------------------------------------------------------- | ---------------------------------------------- |
+| `parse`                | scanner → parser → composer (the round-trip AST)                    | never panic/hang                               |
+| `decode`               | fast `loads` path → `Value` tree → fast `dumps`, under both schemas | never panic/hang                               |
+| `roundtrip`            | compose → emit → re-compose (the round-trip emitter)                | never panic/hang                               |
+| `differential`         | `loads(dumps(loads(x)))` must equal `loads(x)`                      | never silently corrupt data                    |
+| `differential_options` | the same, under a matrix of non-default emit options                | never silently corrupt data                    |
+| `include`              | `!include`/`!include_dir_*`/`!secret`/`!env_var` over a temp tree   | never panic/hang; no read escapes the base dir |
 
 ```bash
 cargo install cargo-fuzz             # once; needs a nightly toolchain
@@ -167,18 +169,24 @@ just fuzz 60 differential            # fuzz any target by name
 cargo +nightly fuzz run parse        # or invoke cargo-fuzz directly, until a crash or Ctrl-C
 ```
 
-The first three targets check that no input _crashes_ the parser. `differential`
-checks something a crash-only target cannot: that `dumps` never emits YAML which
+The crash-only targets (`parse`, `decode`, `roundtrip`, `include`) check that no
+input _crashes_ or hangs the engine. `differential` and `differential_options`
+check something a crash-only target cannot: that `dumps` never emits YAML which
 `loads` reads back as _different data_ (a mis-quoted string re-resolving to a
 bool, a float losing precision). Such a bug produces wrong values, not a panic,
-so only comparing the two trees surfaces it.
+so only comparing the two trees surfaces it. `include` adds a security assertion
+on top of never crashing: a resolved `!include` or `!secret` path can never
+escape the configured base directory, so a traversal or a symlink swap is caught
+as a confinement error rather than a read outside the tree.
 
 [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) builds and runs
 every target for a short batch on each pull request (see
-`.github/workflows/clusterfuzzlite.yaml` and `.clusterfuzzlite/`). A `parse`,
-`decode`, or `roundtrip` crash is a parser bug (the parser may reject malformed
-input with an error, but must never panic or hang); a `differential` failure is a
-correctness bug (a document that does not survive a `dumps`/`loads` round-trip).
+`.github/workflows/clusterfuzzlite.yaml` and `.clusterfuzzlite/`; the build
+compiles every `fuzz/fuzz_targets/*.rs`, so a new target is picked up
+automatically). A `parse`, `decode`, `roundtrip`, or `include` crash is an engine
+bug (it may reject malformed input with an error, but must never panic or hang);
+a `differential` or `differential_options` failure is a correctness bug (a
+document that does not survive a `dumps`/`loads` round-trip).
 
 ## Code quality
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,9 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+# The include target materializes each input as a real directory tree, because
+# the include engine reads files; tempfile gives it a fresh, auto-cleaned dir.
+tempfile = "3"
 
 [dependencies.yamlrocks]
 path = ".."
@@ -48,6 +51,13 @@ bench = false
 [[bin]]
 name = "differential_options"
 path = "fuzz_targets/differential_options.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "include"
+path = "fuzz_targets/include.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/include.rs
+++ b/fuzz/fuzz_targets/include.rs
@@ -1,0 +1,61 @@
+#![no_main]
+
+use std::fs;
+
+use libfuzzer_sys::fuzz_target;
+use tempfile::TempDir;
+
+// Fuzz the include engine (`!include`, `!include_dir_*`, `!secret`, `!env_var`)
+// over a real directory tree, the one part of the library the other targets
+// cannot reach because it reads files. The engine is filesystem-coupled, so each
+// input is turned into a small tree in a fresh temp directory before being
+// resolved. See `_yamlrocks::fuzz::include` for the contract (never panic/hang,
+// and no read may escape the base directory).
+//
+// The input is split on NUL bytes into segments mapped onto fixed file names the
+// resolver can reference. The first segment is the root document; the rest
+// populate the tree. Fixed names let the fuzzer learn to write directives like
+// `!include a.yaml`, a cycle `a.yaml -> b.yaml -> a.yaml`, a diamond fan-out that
+// probes the expansion budget, `!secret NAME`, or `!include_dir_list sub` and
+// have them actually reach a file.
+fuzz_target!(|data: &[u8]| {
+    // The root document is parsed as text; a non-UTF-8 input is not interesting
+    // here (the whole tree would be unreadable). Individual files may still end
+    // up non-UTF-8 and exercise the read-error path.
+    let Ok(text) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // segment 0 is the root document; the rest map onto these names in order.
+    let names = [
+        "a.yaml",
+        "b.yaml",
+        "c.yaml",
+        "secrets.yaml",
+        "sub/x.yaml",
+        "sub/y.yaml",
+    ];
+    let mut segments = text.split('\u{0}');
+    let root = segments.next().unwrap_or("");
+
+    let Ok(dir) = TempDir::new() else {
+        return;
+    };
+    let base = dir.path();
+    if fs::create_dir(base.join("sub")).is_err() {
+        return;
+    }
+
+    for (name, contents) in names.iter().zip(segments) {
+        if fs::write(base.join(name), contents).is_err() {
+            return;
+        }
+    }
+
+    // Pass the canonical base so the confinement assertion in `fuzz::include` is
+    // exact (a temp dir can sit behind a symlinked prefix such as macOS `/tmp`).
+    let Ok(canonical_base) = fs::canonicalize(base) else {
+        return;
+    };
+    _yamlrocks::fuzz::include(&canonical_base, root);
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ build = ["maturin==1.14.1"]
 # Test runtime needed to run the suite anywhere, including free-threaded CPython.
 # numpy is a separate group because it has no free-threaded wheels yet.
 test = [
+  "hypothesis==6.156.1",
   "pytest==9.1.1",
   "pytest-asyncio==1.4.0",
   "pyyaml==6.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ build = ["maturin==1.14.1"]
 # Test runtime needed to run the suite anywhere, including free-threaded CPython.
 # numpy is a separate group because it has no free-threaded wheels yet.
 test = [
-  "hypothesis==6.156.1",
   "pytest==9.1.1",
   "pytest-asyncio==1.4.0",
   "pyyaml==6.0.3",
@@ -86,6 +85,12 @@ test = [
 # group so the free-threaded job can omit it (no nogil wheels yet); the numpy
 # tests skip cleanly when it is absent.
 numpy = ["numpy==2.5.0"]
+# Property-based fuzz tests (tests/robustness/test_hostile_objects.py). Kept as
+# its own group, like numpy, because Hypothesis ships ABI-specific wheels and has
+# none for some targets the wheel smoke test covers (prerelease CPython, 32-bit
+# and ARM Windows); it installs best-effort there and the tests skip when it is
+# absent. The full suite (coverage.yaml) runs on a target that has a wheel.
+proptest = ["hypothesis==6.156.1"]
 # Type checkers and linters (no build needed; they check the source and stub).
 typing = ["mypy==2.1.0", "ty==0.0.56"]
 lint = ["ruff==0.15.20", "codespell==2.4.2", "zizmor==1.26.1"]
@@ -113,6 +118,7 @@ dev = [
   { include-group = "build" },
   { include-group = "test" },
   { include-group = "numpy" },
+  { include-group = "proptest" },
   { include-group = "typing" },
   { include-group = "lint" },
   "rust-just==1.55.1",

--- a/src/emit_util.rs
+++ b/src/emit_util.rs
@@ -61,6 +61,24 @@ pub(crate) fn single_quoted_body(value: &str) -> String {
     value.replace('\'', "''")
 }
 
+/// Whether `c` falls outside YAML 1.2's `c-printable` set and so cannot appear
+/// raw in a scalar: it forces a plain scalar to be quoted and must be escaped
+/// inside a double-quoted one. This is the emitter's mirror of the scanner's
+/// `check_printable` rejection set (see `scanner::reader`), so `dumps` never
+/// emits a control character that `loads` would refuse: the C0 controls except
+/// tab, line feed, and carriage return; DEL; the C1 controls except NEL
+/// (`U+0085`, which is printable); and the non-characters `U+FFFE`/`U+FFFF`.
+pub(crate) fn is_non_printable(c: char) -> bool {
+    match c as u32 {
+        0x09 | 0x0a | 0x0d => false, // tab, LF, CR are allowed
+        0x00..=0x1f | 0x7f => true,  // other C0 controls and DEL
+        0x85 => false,               // NEL is printable in YAML 1.2
+        0x80..=0x9f => true,         // the other C1 controls
+        0xfffe | 0xffff => true,     // the two non-characters
+        _ => false,
+    }
+}
+
 /// The body of a double-quoted scalar (no surrounding quotes), with the escapes
 /// YAML requires inside double quotes applied.
 pub(crate) fn double_quoted_body(value: &str) -> String {
@@ -73,11 +91,17 @@ pub(crate) fn double_quoted_body(value: &str) -> String {
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
             '\0' => out.push_str("\\0"),
-            // Any other control character (C0 or DEL) must be escaped: a raw
-            // control byte makes YAML a spec-compliant reader rejects. `\xNN` is
-            // the YAML double-quote escape for a code point below U+0100.
-            c if (c as u32) < 0x20 || c as u32 == 0x7f => {
-                out.push_str(&format!("\\x{:02x}", c as u32));
+            // Any other non-printable character must be escaped: emitting it raw
+            // makes YAML a spec-compliant reader rejects. `\xNN` is the escape for
+            // a code point below U+0100 (the C0/C1 controls and DEL); `\uNNNN`
+            // covers the wider non-characters `U+FFFE`/`U+FFFF`.
+            c if is_non_printable(c) => {
+                let n = c as u32;
+                if n <= 0xff {
+                    out.push_str(&format!("\\x{n:02x}"));
+                } else {
+                    out.push_str(&format!("\\u{n:04x}"));
+                }
             }
             _ => out.push(ch),
         }
@@ -166,12 +190,32 @@ mod tests {
             ("a\rb", b"\"a\\rb\""),
             ("a\tb", b"\"a\\tb\""),
             ("a\0b", b"\"a\\0b\""),
+            // DEL and a C0 control escape as `\xNN`.
+            ("a\x7fb", b"\"a\\x7fb\""),
+            ("a\x01b", b"\"a\\x01b\""),
+            // The C1 controls escape as `\xNN` too (a raw one is not printable and
+            // would make YAML `loads` rejects), except NEL (`U+0085`).
+            ("a\u{80}b", b"\"a\\x80b\""),
+            ("a\u{9f}b", b"\"a\\x9fb\""),
+            // The non-characters need the wider `\uNNNN` form.
+            ("a\u{fffe}b", b"\"a\\ufffeb\""),
+            ("a\u{ffff}b", b"\"a\\uffffb\""),
         ];
         for (input, expected) in cases {
             let mut buf = Vec::new();
             push_double_quoted(&mut buf, input);
             assert_eq!(&buf, expected, "input {input:?}");
         }
+    }
+
+    #[test]
+    fn printable_high_controls_pass_through_double_quoted() {
+        // NEL (`U+0085`) and NBSP (`U+00A0`) are printable in YAML 1.2, so they
+        // stay raw rather than being escaped; this pins that they are not swept up
+        // with the neighboring C1 controls.
+        let mut buf = Vec::new();
+        push_double_quoted(&mut buf, "a\u{85}\u{a0}b");
+        assert_eq!(buf, "\"a\u{85}\u{a0}b\"".as_bytes());
     }
 
     #[test]

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -301,9 +301,13 @@ impl<'a> Emitter<'a> {
         if !value.contains('\n') {
             return false;
         }
+        // A block scalar carries its content raw, so it cannot hold a carriage
+        // return (block line breaks are normalized) nor any non-printable
+        // character (a C0/C1 control, DEL, or a non-character); such a string
+        // falls back to a double-quoted scalar that can escape them.
         if value
-            .bytes()
-            .any(|b| (b < 0x20 && b != b'\n' && b != b'\t') || b == 0x7f)
+            .chars()
+            .any(|c| c == '\r' || crate::emit_util::is_non_printable(c))
         {
             return false;
         }
@@ -500,7 +504,11 @@ impl<'a> Emitter<'a> {
             && !value.contains('\'')
             && !value.contains('\n')
             && !value.contains('\r')
-            && !value.bytes().any(|b| b < 0x20 || b == 0x7f);
+            && !value.bytes().any(|b| b < 0x20 || b == 0x7f)
+            // A single-quoted scalar cannot escape anything, so a C1 control or a
+            // non-character (which the byte check above misses) forces double
+            // quotes, where it can be escaped.
+            && !value.chars().any(crate::emit_util::is_non_printable);
         if self.options.width > 0 && !self.emitting_key {
             // Fold the (already-escaped) body between the quotes. A space in the
             // body folds the same way as in a plain scalar; the surrounding
@@ -861,17 +869,28 @@ pub(crate) fn needs_quoting(value: &str, schema: Schema) -> bool {
         return true;
     }
 
-    // Sequences that introduce structure or comments inside the scalar, plus any
-    // control character (C0 or DEL): a raw control byte in a plain scalar makes
-    // YAML a spec-compliant reader rejects, so force quoting (and, in the quoted
-    // path, escaping).
+    // Sequences that introduce structure or comments inside the scalar force
+    // quoting: a `:` before a space (or at end) is a mapping indicator, and a `#`
+    // after a space starts a comment.
     for i in 0..bytes.len() {
         match bytes[i] {
             b':' if i + 1 == bytes.len() || bytes[i + 1] == b' ' => return true,
             b'#' if i > 0 && bytes[i - 1] == b' ' => return true,
-            0x00..=0x1f | 0x7f => return true,
             _ => {}
         }
+    }
+
+    // A control character unsafe in a plain scalar forces quoting (and, in the
+    // quoted path, escaping): every C0 control (`\t`/`\n`/`\r` included, since a
+    // raw break or tab corrupts a plain scalar), plus everything
+    // [`is_non_printable`] rejects, DEL, the C1 controls, and the non-characters.
+    // Checked over `chars` because the C1 controls and non-characters are
+    // multi-byte in UTF-8.
+    if value
+        .chars()
+        .any(|c| (c as u32) < 0x20 || crate::emit_util::is_non_printable(c))
+    {
+        return true;
     }
 
     // Quote iff the value would resolve back to a *number* under the YAML 1.2 or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,48 @@ pub mod fuzz {
         }
     }
 
+    /// Resolve `!include`, `!include_dir_*`, `!secret`, and `!env_var` over a
+    /// caller-provided directory tree, driving the include engine the `parse`,
+    /// `decode`, and `roundtrip` targets never reach: tag-argument parsing, path
+    /// confinement, cycle detection, the diamond-lattice expansion budget, the
+    /// recursive directory walk, and `secrets.yaml` lookup. All three tag families
+    /// are enabled at once so their interaction is exercised too.
+    ///
+    /// The fuzz target (`fuzz/fuzz_targets/include.rs`) materializes the tree in a
+    /// temp directory and passes its canonical path here; this must be the
+    /// canonical (symlink-resolved) base so the confinement assertion below is
+    /// exact. The contract is the usual never-panic/never-hang/never-UB one *plus*
+    /// a hard security invariant: no file the resolver reads may escape the base
+    /// directory. A traversal (`!include ../../etc/passwd`) or a symlink swap must
+    /// surface as a confinement error, never as a path outside the tree.
+    pub fn include(canonical_base: &std::path::Path, root: &str) {
+        use crate::include::{IncludeResolver, ResolveTags};
+
+        let tags = ResolveTags {
+            includes: true,
+            secrets: true,
+            env_var: true,
+        };
+        let mut resolver = IncludeResolver::new(canonical_base, tags).with_dir_recursive(true);
+
+        // Resolution may fail (a missing file, a cycle, a traversal attempt, a
+        // blown expansion budget); those are clean errors, not crashes. The
+        // property is that it returns rather than panics or hangs.
+        let _ = resolver.load_str(root, None);
+
+        // Security invariant: every file the resolver registered (read, or the
+        // in-memory root placeholder) must live under the canonical base. A path
+        // outside it means confinement was bypassed, the one include bug that is
+        // silent rather than a crash.
+        let (files, _sources) = resolver.into_parts();
+        for path in &files {
+            assert!(
+                path.starts_with(canonical_base),
+                "include escaped the base directory\n  base: {canonical_base:?}\n  path: {path:?}"
+            );
+        }
+    }
+
     /// Emit `document` with `options`, re-decode the output, and assert the data
     /// survived unchanged. Shared by both differential targets so a divergence is
     /// reported identically (the panic message names the options that triggered

--- a/tests/robustness/test_hostile_objects.py
+++ b/tests/robustness/test_hostile_objects.py
@@ -1,0 +1,225 @@
+"""Property-based robustness tests for hostile Python objects at the dump boundary.
+
+`dumps`, `to_json`, and the round-trip emitter walk arbitrary Python objects
+across the PyO3 boundary. A malicious or buggy object, a lying container, a
+dunder that mutates or raises, a reference cycle, or a recursive ``default``
+hook, must never crash the interpreter or hang. The contract for every case is
+the same: the call returns ``bytes``, or it raises a catchable ``Exception``.
+
+The Rust fuzz targets (``fuzz/``) cannot reach this layer: a libFuzzer binary has
+no Python interpreter, so it never exercises the object-to-node conversion or the
+user callbacks. Hypothesis drives that surface here, generating nested structures
+that mix well-behaved values with adversarial objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+import yamlrocks
+
+# Hostile objects can be slow to reject and vary wildly in size, so the timing
+# and size health checks would flake without telling us anything. The property
+# is about crashing, not speed.
+HOSTILE = settings(
+    deadline=None,
+    max_examples=300,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+
+
+class Opaque:
+    """A plain object no serializer knows how to represent."""
+
+
+class RaisingHash:
+    """``__hash__`` raises; unserializable as a value, explosive as a key."""
+
+    def __hash__(self) -> int:
+        raise ValueError("hostile __hash__")
+
+
+class RaisingKeys(dict):
+    """A mapping whose ``keys()`` raises mid-walk."""
+
+    def keys(self):  # type: ignore[override]
+        raise RuntimeError("hostile keys()")
+
+
+class LyingKeys(dict):
+    """A mapping whose ``keys()`` advertises keys that are not present."""
+
+    def keys(self):  # type: ignore[override]
+        return ["ghost", *dict.keys(self)]
+
+
+class LyingLen(list):
+    """A sequence whose ``__len__`` disagrees with its real length."""
+
+    def __len__(self) -> int:
+        return 9999
+
+
+class RaisingLen(list):
+    """A sequence whose ``__len__`` raises."""
+
+    def __len__(self) -> int:
+        raise RuntimeError("hostile __len__")
+
+
+class RaisingIter:
+    """An object that claims to be iterable but explodes on iteration."""
+
+    def __iter__(self):
+        raise RuntimeError("hostile __iter__")
+
+
+# Each builder returns a *fresh* instance per example so no mutable state leaks
+# between Hypothesis runs.
+hostile_objects = st.one_of(
+    st.builds(Opaque),
+    st.builds(RaisingHash),
+    st.builds(lambda: RaisingKeys({"real": 1})),
+    st.builds(lambda: LyingKeys({"real": 1})),
+    st.builds(lambda: LyingLen([1, 2])),
+    st.builds(lambda: RaisingLen([1, 2])),
+    st.builds(RaisingIter),
+    st.builds(lambda: (n for n in range(3))),  # a bare generator
+)
+
+scalars = (
+    st.none()
+    | st.booleans()
+    | st.integers()
+    | st.floats(allow_nan=True, allow_infinity=True)
+    | st.text(max_size=8)
+)
+
+# Nested structures whose leaves may be well-behaved scalars or hostile objects.
+# Mapping keys stay as text (a hostile key is covered separately) so the
+# generator itself does not raise while building the example.
+structures = st.recursive(
+    scalars | hostile_objects,
+    lambda children: (
+        st.lists(children, max_size=4)
+        | st.dictionaries(st.text(max_size=5), children, max_size=4)
+    ),
+    max_leaves=25,
+)
+
+
+def _assert_bytes_or_raises(fn, value: Any) -> None:
+    """The dump contract: return ``bytes``/``bytearray`` or raise ``Exception``."""
+    try:
+        result = fn(value)
+    except Exception:
+        return
+    assert isinstance(result, (bytes, bytearray))
+
+
+@HOSTILE
+@given(value=structures)
+def test_dumps_never_crashes_on_hostile_objects(value):
+    """dumps returns bytes or raises on any structure of hostile objects."""
+    _assert_bytes_or_raises(yamlrocks.dumps, value)
+
+
+@HOSTILE
+@given(value=structures)
+def test_to_json_never_crashes_on_hostile_objects(value):
+    """to_json returns bytes or raises on any structure of hostile objects."""
+    _assert_bytes_or_raises(yamlrocks.to_json, value)
+
+
+@HOSTILE
+@given(value=structures)
+def test_round_trip_emit_never_crashes_on_hostile_objects(value):
+    """A round-trip document built from hostile objects emits or raises cleanly."""
+    try:
+        doc = yamlrocks.dumps(value)
+    except Exception:
+        return
+    # Whatever dumped must reload and re-emit without crashing.
+    reloaded = yamlrocks.loads(doc, option=yamlrocks.OPT_ROUND_TRIP)
+    assert isinstance(reloaded.to_yaml(), (bytes, bytearray))
+
+
+@settings(deadline=None, max_examples=60)
+@given(depth=st.integers(min_value=0, max_value=6))
+def test_reference_cycle_is_rejected_not_hung(depth):
+    """A self-referential structure raises rather than looping forever."""
+    root: dict[str, Any] = {}
+    cursor = root
+    for i in range(depth):
+        child: dict[str, Any] = {}
+        cursor[f"k{i}"] = child
+        cursor = child
+    cursor["loop"] = root  # close the cycle
+
+    with pytest.raises(Exception):
+        yamlrocks.dumps(root)
+    with pytest.raises(Exception):
+        yamlrocks.to_json(root)
+
+
+def _default_returns_self(obj):
+    return obj
+
+
+def _default_returns_unserializable(obj):
+    return Opaque()
+
+
+def _default_raises(obj):
+    raise ValueError("hostile default")
+
+
+def _default_returns_cycle(obj):
+    cycle: dict[str, Any] = {}
+    cycle["self"] = cycle
+    return cycle
+
+
+@pytest.mark.parametrize(
+    "hook",
+    [
+        _default_returns_self,
+        _default_returns_unserializable,
+        _default_raises,
+        _default_returns_cycle,
+    ],
+)
+def test_hostile_default_hook_raises_not_crashes(hook):
+    """A default= hook that misbehaves surfaces an exception, never a crash."""
+    with pytest.raises(Exception):
+        yamlrocks.dumps(Opaque(), default=hook)
+
+
+def test_default_hook_mutating_parent_during_walk_does_not_crash():
+    """A default= callback that mutates the mapping being serialized is safe.
+
+    Rehashing a dict while Rust iterates its items is the classic use-after-free
+    shape (see the FFI hardening for `__bool__`/`__index__`); the callback here
+    clears and repopulates the very dict under the walk.
+    """
+    parent: dict[str, Any] = {"a": Opaque(), "b": Opaque()}
+
+    def hook(obj):
+        parent["injected"] = "x"
+        parent.clear()
+        return "safe"
+
+    try:
+        yamlrocks.dumps(parent, default=hook)
+    except Exception:
+        pass
+
+
+def test_hostile_object_as_mapping_key_raises():
+    """A key whose __hash__ raises propagates that error, not a crash."""
+    with pytest.raises(Exception):
+        yamlrocks.dumps({RaisingHash(): 1})

--- a/tests/robustness/test_hostile_objects.py
+++ b/tests/robustness/test_hostile_objects.py
@@ -17,6 +17,13 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+
+# Hypothesis ships ABI-specific wheels and is unavailable on some targets the
+# wheel smoke test runs on (prerelease CPython, 32-bit/ARM Windows), so it is a
+# best-effort dependency (the `proptest` group). Skip the whole module cleanly
+# where it is absent rather than fail to import.
+pytest.importorskip("hypothesis")
+
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 

--- a/uv.lock
+++ b/uv.lock
@@ -1219,7 +1219,6 @@ charts = [
     { name = "yamlium" },
 ]
 codspeed = [
-    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
@@ -1249,8 +1248,10 @@ lint = [
 numpy = [
     { name = "numpy" },
 ]
-test = [
+proptest = [
     { name = "hypothesis" },
+]
+test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -1283,7 +1284,6 @@ charts = [
     { name = "yamlium", specifier = "==0.2.5" },
 ]
 codspeed = [
-    { name = "hypothesis", specifier = "==6.156.1" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-codspeed", specifier = "==5.0.3" },
@@ -1311,8 +1311,8 @@ lint = [
     { name = "zizmor", specifier = "==1.26.1" },
 ]
 numpy = [{ name = "numpy", specifier = "==2.5.0" }]
+proptest = [{ name = "hypothesis", specifier = "==6.156.1" }]
 test = [
-    { name = "hypothesis", specifier = "==6.156.1" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pyyaml", specifier = "==6.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,45 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.156.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/3d/1a0e54652f1b3cad354949ba83f6ab211048ff3a6cfb24edcddc748a8be1/hypothesis-6.156.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0409dea0c0b48705cad8413468282af9c5e7d3a017b6c2b94ef80e7ba4b64862", size = 749005, upload-time = "2026-07-03T14:30:26.045Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/c8b6084023faabef7612ea0169fd4df565fdc5fd73f47484e5edf03640fb/hypothesis-6.156.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:72b9305414c20802540ec0cd798478c9e06c8a248ce32d7df04722b64d7150ad", size = 741899, upload-time = "2026-07-03T14:30:34.442Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/51644c53ae055a3a3411906cc8e41e5dd53af487ca76465342256e4f18c1/hypothesis-6.156.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40584eed6a57c402d8ab32ea5c1779bae6f7390ff33d073c876e09dc8af31941", size = 1069788, upload-time = "2026-07-03T14:31:24.552Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/43/d2ec198fa56f72f8690563247e5e71a81cf5f1c9c42e977008b76338803f/hypothesis-6.156.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76f2aaa6725185f16a8fa7b58e0ba5d5119cafa33eae5e5dec996d6a28cd9dc6", size = 1119541, upload-time = "2026-07-03T14:30:15.15Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/ba8a1bf72988e7b8b743b4f4f30705fe1c2128780a7d93b203cdeb6bae79/hypothesis-6.156.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bac95ae29f7850a923f43bc7e21bbc7ee8b8094bbf07691be4f153e537b5d3db", size = 1243864, upload-time = "2026-07-03T14:30:47.869Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a3/f30ebb96f099f19e71361aefb233542f3763a0fb7c0ba3c84513c353b065/hypothesis-6.156.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8159b5e93a7724920cf55dd4ec743a84fc9c3c457a6736a92283aa4068f54daa", size = 1286401, upload-time = "2026-07-03T14:30:07.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a9/19b36a5deb78217f4f6214c7be36a14cf2da8b29392199bcd18a0628b9b8/hypothesis-6.156.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8e7deed3bc76c8c12c30e092e228a6978180f2bcab9483f5fb22240cd8eaa7d", size = 637634, upload-time = "2026-07-03T14:30:40.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f7/6f0e4186a6575abddb19047e69cb0042252be27d0be0ddc3528bf3a81edd/hypothesis-6.156.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:da65e6be5461cac9d9d7f98f43d24afb5441932502e4d1b240738aaef84e95d9", size = 749428, upload-time = "2026-07-03T14:31:04.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0c/d45d778b14f22270ac1218faf4ec7de2e9e30d3e40fd91ad86d6b6b5259e/hypothesis-6.156.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:612277e6344defe39012812d5ae620d6323e11fa62c424d64633dfa09caaa387", size = 742070, upload-time = "2026-07-03T14:30:09.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8a/9c6863eae555c674e3ab2b7ac738f50350d176f88e7a5ac4fe85340b126f/hypothesis-6.156.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a593ad462c61f252d661ccc3a1093406cf9ca5a26a6b30cefd8911075d508c8", size = 1069945, upload-time = "2026-07-03T14:30:27.45Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/98/44d9ee83542e5cb50c07387091bd2dcfb2d0f9d7eaadd78357ae0962e76d/hypothesis-6.156.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a48cdb91afa09958926a364d241d00b08ece1d105bcd48e0b433428c7b4c29b", size = 1119946, upload-time = "2026-07-03T14:30:58.939Z" },
+    { url = "https://files.pythonhosted.org/packages/09/00/03957d11e4602e60982b535bf107a1995e712e797e32ca5cc9fe53daa11c/hypothesis-6.156.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72d4115ed2c4da2cc30189026eacd27c81e0891ec4ba9fff6719e0f47874d65c", size = 1244030, upload-time = "2026-07-03T14:30:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e3/149c3b9de0f9125becdf266af9eba6934885818867c93a457af60d4a3725/hypothesis-6.156.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1e1fecee9c79956ac5e7c38cb1d1374bf22fd4066ff6a9664d45d13a09251b1", size = 1286679, upload-time = "2026-07-03T14:30:57.516Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/1c/f1a35abd3e5ef45badc3d8a128bb133725f6a93c9aa4eadc27db9d6c54c3/hypothesis-6.156.1-cp313-cp313-win_amd64.whl", hash = "sha256:32f512f6028ab2d4c56208b2edebefe384ab78a5880b098b039c65e9d08b62f7", size = 637909, upload-time = "2026-07-03T14:30:04.12Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/60/f81bc004dafc83f4fd3aee41c65ec6140481a4666495229c0102c636e74b/hypothesis-6.156.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3340f22fd71e615f9bca4499bddd7cc4e0987b08a8b4fc38f688aaac416c2aaf", size = 749464, upload-time = "2026-07-03T14:31:17.171Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/f884c2e908f5a888b22a6606368130fdf822565430e9eefcde5e765640dd/hypothesis-6.156.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:19612761d128cd15d41e414389da6b65c1883db1f358025a4c1b2df96ba2dfb0", size = 742283, upload-time = "2026-07-03T14:31:06.23Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2e/8843ca9d7103692c06b912aaa06cc664d3cb3c764a44fb2feeb702b3b704/hypothesis-6.156.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c86c00cefcf58793aebb24238247398ad5d9ce281615329293d926d794e6fe5f", size = 1070136, upload-time = "2026-07-03T14:30:19.907Z" },
+    { url = "https://files.pythonhosted.org/packages/62/62/7a1b308b3977e3d3c1920828c5fc5a440caf8036b0d9df2e9ab7722682f8/hypothesis-6.156.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:047a0a6613ff06f191d9b1c7623a9b781baddc0fdebad531157d1417fa876627", size = 1120112, upload-time = "2026-07-03T14:31:13.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/7c691582cd5b0de6314fd712ce5e69960985a89e4f619b0c4b36c8845ce2/hypothesis-6.156.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9ace8e1e885b20ae129c68ff14e86edd55771a30559561b261a15bd8c17edd36", size = 1244289, upload-time = "2026-07-03T14:31:19.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ac/d15a7a9820ca05ef7a4e8d9dc95e9a0a70cd91fb8d021913888c69801c60/hypothesis-6.156.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:eb093affaa2257f9fd2d6542b5e242f5b9512bc1009a4f563ade91e30c298e0c", size = 1287201, upload-time = "2026-07-03T14:30:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ca/dcd80b4606d97b5dba2775526aa89a7735086559c5a80eaf5bf60610bc10/hypothesis-6.156.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:209b76dab690e2182599a83c079475115d69dd2c16aed38a57bb9db376ba4195", size = 586417, upload-time = "2026-07-03T14:30:42.657Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b3/555c291b24b9b1f2e6a712d485ad8c52bbe3e31e79a8a509adc5213e42aa/hypothesis-6.156.1-cp314-cp314-win_amd64.whl", hash = "sha256:1ea0711ac7792e3ade5dfe8a6a762eec64ddb79cd00fe63ff34f17fde0ce8109", size = 637729, upload-time = "2026-07-03T14:31:20.948Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/25f26e0ed769c127b049b4fb8c9378e74d07a37a44c5938e4f6518710ef6/hypothesis-6.156.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:9b664a859ed5567bd2c0d804da4d96035e14caa15d91062cc50fcd758dc44111", size = 747497, upload-time = "2026-07-03T14:30:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/62/11/25f20b1cdbd8fc73fd8c0603aa4e817da7384400347f6d63ef569c56111e/hypothesis-6.156.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23acc5f333ce6bd2d888e7c6a33779b5c6cff42dac654f3209e9fa552103c3ba", size = 740841, upload-time = "2026-07-03T14:30:37.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/aa/9967dd9380d72d44a7973f7893383145f04277896554ebb2872ae9658de6/hypothesis-6.156.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15762876a64c66bd6ed18eb95fd8018df93b6961eb0b6c25e63409af9cb672c0", size = 1069108, upload-time = "2026-07-03T14:30:06.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6e/27999d70710a1d0d9440c1db59db385c63ed2dccca6ade5fe53258e9566f/hypothesis-6.156.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bab29b39b13603583c9874c38907071f333e7af0c48686af8c8f97f7a6a2398", size = 1119177, upload-time = "2026-07-03T14:31:09.67Z" },
+    { url = "https://files.pythonhosted.org/packages/39/45/fbaaae29a5650da6322737eeb085c78a4eb9066f815862c24c63a25dd5eb/hypothesis-6.156.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3c8831d5748394cab5ab81b3d469bcc543e7b8e1fc8422ed26a80e16b1e51c1b", size = 1243078, upload-time = "2026-07-03T14:30:10.678Z" },
+    { url = "https://files.pythonhosted.org/packages/53/9d/2db20037da6b206701ec22d6bb67d4393e4807281885663979fe7a5ff869/hypothesis-6.156.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:18ef80bdd7422e7823d8da99240c8804708bd44eeeed370fc8a71db56670e1dc", size = 1285519, upload-time = "2026-07-03T14:30:36.172Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/de/4fbc6afc03cb7098f51bea5be6300c7e13fc679c3c2d12cd40629a27278d/hypothesis-6.156.1-cp314-cp314t-win_amd64.whl", hash = "sha256:122963f511d31fb96254a5b3f0b8e3b9c3b9d2b05e10d9e67eca43e573d52d0f", size = 637822, upload-time = "2026-07-03T14:30:31.248Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -947,6 +986,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "strictyaml"
 version = "1.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1171,6 +1219,7 @@ charts = [
     { name = "yamlium" },
 ]
 codspeed = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
@@ -1179,6 +1228,7 @@ codspeed = [
 ]
 dev = [
     { name = "codespell" },
+    { name = "hypothesis" },
     { name = "maturin" },
     { name = "mypy" },
     { name = "numpy" },
@@ -1200,6 +1250,7 @@ numpy = [
     { name = "numpy" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -1232,6 +1283,7 @@ charts = [
     { name = "yamlium", specifier = "==0.2.5" },
 ]
 codspeed = [
+    { name = "hypothesis", specifier = "==6.156.1" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-codspeed", specifier = "==5.0.3" },
@@ -1240,6 +1292,7 @@ codspeed = [
 ]
 dev = [
     { name = "codespell", specifier = "==2.4.2" },
+    { name = "hypothesis", specifier = "==6.156.1" },
     { name = "maturin", specifier = "==1.14.1" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "numpy", specifier = "==2.5.0" },
@@ -1259,6 +1312,7 @@ lint = [
 ]
 numpy = [{ name = "numpy", specifier = "==2.5.0" }]
 test = [
+    { name = "hypothesis", specifier = "==6.156.1" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pyyaml", specifier = "==6.0.3" },


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Closes a fuzz-coverage gap, and fixes a real emitter bug the new coverage found.

Two engine surfaces had no coverage-guided fuzzing. This adds both:

- A new `include` cargo-fuzz target driving the include engine (`!include`, `!include_dir_*`, `!secret`, `!env_var`) over a real temp directory tree, the one part of the library the other targets cannot reach because it reads files. On top of never crashing or hanging, it asserts a security invariant: no resolved path may escape the configured base directory, so a traversal or a symlink swap is caught as a confinement error rather than a read outside the tree. It picks up `!env_var` on its own and ran 750k iterations clean. ClusterFuzzLite compiles every `fuzz/fuzz_targets/*.rs`, so it is exercised on every pull request automatically.
- A Hypothesis property test (`tests/robustness/test_hostile_objects.py`) for the `dumps`/`to_json`/round-trip boundary, which cargo-fuzz cannot reach (a libFuzzer binary has no interpreter). It throws lying containers, dunders that mutate or raise, reference cycles, and misbehaving `default=` hooks at the serializers. The contract for every case: return `bytes`, or raise a catchable exception, never crash the interpreter.

While writing the Hypothesis test it found a genuine correctness bug: `dumps` emitted the C1 control block (`U+0080`–`U+009F`, except NEL `U+0085`) and the non-characters `U+FFFE`/`U+FFFF` raw, producing YAML that `loads` rejects. The emit-quoting predicates were byte-level and could not see those multi-byte code points. A new shared `is_non_printable` mirrors the scanner's `check_printable` rejection set, and all four emit gates (`needs_quoting`, `double_quoted_body`, `single_ok`, `use_literal_block`) now use it, so `dumps` never emits a control character `loads` refuses. Locked with Rust unit tests.

The bug fix and the test infrastructure are split into two commits.

`hypothesis` is pinned in the `test` dependency group; it is pure Python and installs on free-threaded CPython too.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
