### PR TITLE
✨ Add writable foot comments via node.comment_after

### DIFF
--- a/docs/src/content/docs/comparisons/vs-ruamel.md
+++ b/docs/src/content/docs/comparisons/vs-ruamel.md
@@ -27,7 +27,7 @@ exhaustive comment surgery, covered honestly below.
 | Source line/column             |         partial         |      Yes (annotated mode)       |
 | JSON Schema validation         |           No            |               Yes               |
 | Save only changed files        |           No            |               Yes               |
-| Per-node comment editing API   | Yes (`.ca`, exhaustive) | Yes (inline + leading comments) |
+| Per-node comment editing API   | Yes (`.ca`, exhaustive) | Yes (inline, leading, trailing) |
 | Output type                    |   `str` (to a stream)   |             `bytes`             |
 
 ## Speed: Rust vs pure Python
@@ -123,8 +123,9 @@ editing one automation and saving only `automations.yaml`.
 ## Scripting comments
 
 YAMLRocks does more than _preserve_ comments through a round-trip: every
-`YAMLRocksNode` exposes a writable `comment` (the inline `# ...` after a value) and
-`comment_before` (the standalone line(s) above a key). A tool can read, add, edit,
+`YAMLRocksNode` exposes a writable `comment` (the inline `# ...` after a value),
+`comment_before` (the standalone line(s) above a key), and `comment_after` (the
+trailing block at the foot of a mapping or sequence). A tool can read, add, edit,
 remove, or move a comment (read it from one node, set it on another) and re-emit.
 This works on mapping values, keys, and sequence items alike, and on keys you add
 to a loaded document.
@@ -136,19 +137,17 @@ doc = yamlrocks.loads(b"name: app\nport: 8080\n", option=yamlrocks.OPT_ROUND_TRI
 
 doc.node["port"].comment = "the listen port"          # inline, no '#'
 doc.node["name"].comment_before = "service identity"  # standalone line above
+doc.node.comment_after = "end of config"              # trailing block (foot)
 doc.to_yaml()
-# b'# service identity\nname: app\nport: 8080 # the listen port\n'
+# b'# service identity\nname: app\nport: 8080 # the listen port\n# end of config\n'
 ```
 
 ## Where ruamel.yaml is still richer
 
-Two cases remain ruamel's. **Foot comments**, a trailing comment block at the end
-of a mapping or sequence, are preserved through a YAMLRocks round-trip but are not
-yet writable through the node API (only inline and leading comments are). And
-**building a fully commented document from nothing** needs ruamel: YAMLRocks edits
+**Building a fully commented document from nothing** needs ruamel: YAMLRocks edits
 comments on a loaded document rather than assembling one with no parsed source.
-ruamel's `.ca` API also reaches a few unusual placements that `comment` /
-`comment_before` do not.
+ruamel's `.ca` API also reaches a few unusual placements that `comment`,
+`comment_before`, and `comment_after` do not.
 
 On emitter configuration the two are closer than they once were: YAMLRocks's
 `dumps` takes an explicit `width`, indentation options (`OPT_INDENT_2` / `_4`,
@@ -159,11 +158,11 @@ intricate document transformations.
 
 ## When to stick with ruamel.yaml
 
-Reach for ruamel.yaml when you need foot comments or build a fully commented
-document from scratch, lean on its class-based representer/constructor extension
-points for deeply custom types, or perform intricate document surgery where its
-maturity matters more than throughput. For high-throughput loading and dumping,
-native includes, schema validation, scripting inline and leading comments, or
+Reach for ruamel.yaml when you need to build a fully commented document from
+scratch, lean on its class-based representer/constructor extension points for
+deeply custom types, or perform intricate document surgery where its maturity
+matters more than throughput. For high-throughput loading and dumping, native
+includes, schema validation, scripting inline, leading, and trailing comments, or
 byte-for-byte round-trip with file-aware saving, YAMLRocks is the faster,
 batteries-included choice.
 

--- a/docs/src/content/docs/guides/round-trip.md
+++ b/docs/src/content/docs/guides/round-trip.md
@@ -295,25 +295,26 @@ doc.node["server"]["tags"].style   # 'flow'
 
 Every `YAMLRocksNode` exposes the same attributes, whatever it points at:
 
-| Attribute         | Meaning                                                              |
-| ----------------- | -------------------------------------------------------------------- |
-| `value`           | the resolved Python value (scalar, `dict`, or `list`)                |
-| `comment`         | the inline comment trailing the value, or `None`                     |
-| `comment_before`  | the standalone comment line(s) above the node, or `None`             |
-| `line` / `column` | 1-based source position                                              |
-| `file`            | the source file the node came from, or `None` without includes       |
-| `style`           | `plain`, `single`, `double`, `literal`, `folded`, `block`, or `flow` |
-| `anchor`          | the node's anchor name (`&name`), or `None`                          |
-| `tag`             | the node's explicit tag (`!!str`, `!custom`), or `None`              |
+| Attribute         | Meaning                                                               |
+| ----------------- | --------------------------------------------------------------------- |
+| `value`           | the resolved Python value (scalar, `dict`, or `list`)                 |
+| `comment`         | the inline comment trailing the value, or `None`                      |
+| `comment_before`  | the standalone comment line(s) above the node, or `None`              |
+| `comment_after`   | the trailing comment block after the node (a block's foot), or `None` |
+| `line` / `column` | 1-based source position                                               |
+| `file`            | the source file the node came from, or `None` without includes        |
+| `style`           | `plain`, `single`, `double`, `literal`, `folded`, `block`, or `flow`  |
+| `anchor`          | the node's anchor name (`&name`), or `None`                           |
+| `tag`             | the node's explicit tag (`!!str`, `!custom`), or `None`               |
 
 Comment text is always bare (no leading `#`, no surrounding whitespace), so you
-read and write the words, not the punctuation. A multi-line `comment_before` is
-returned as one string with `\n` between the lines.
+read and write the words, not the punctuation. A multi-line `comment_before` or
+`comment_after` is returned as one string with `\n` between the lines.
 
 ### Writing metadata
 
-`value`, `comment`, and `comment_before` are writable, and the change re-emits in
-the right place:
+`value`, `comment`, `comment_before`, and `comment_after` are writable, and the
+change re-emits in the right place:
 
 ```python
 import yamlrocks
@@ -327,12 +328,22 @@ port = doc.node["server"]["port"]
 port.value = 8443
 port.comment = "now uses TLS"
 doc.node["server"].comment_before = "HTTP front end (TLS)"
+doc.node["server"].comment_after = "end of server block"
 
 print(doc.to_yaml().decode())
 # # HTTP front end (TLS)
 # server:
 #   port: 8443 # now uses TLS
+#   # end of server block
 ```
+
+`comment_after` is the counterpart to `comment_before`: it writes a trailing
+comment block after a node. On a block mapping or sequence it lands at the
+collection's own indent, after its last entry; on the document root it becomes a
+comment at the end of the file. Set it to `None` to remove the block. It applies
+only to block collections and the root: a scalar or a flow collection has nowhere
+to place a foot, so setting one there raises `ValueError` instead of silently
+dropping it.
 
 Setting `value` keeps the node's comments, anchor, and tag, so editing a value
 never silently drops the comment beside it. Set `comment` or `comment_before` to

--- a/pysrc/yamlrocks/__init__.pyi
+++ b/pysrc/yamlrocks/__init__.pyi
@@ -144,6 +144,7 @@ class YAMLRocksNode:
     value: Any
     comment: str | None
     comment_before: str | None
+    comment_after: str | None
     anchor: str | None
     @property
     def line(self) -> int: ...

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -881,6 +881,44 @@ impl YAMLRocksNode {
         Ok(())
     }
 
+    /// The trailing comment line(s) after this node, joined by newlines, or
+    /// `None`. For a block collection this is the comment block at the end of the
+    /// mapping or sequence, indented with its contents; for the document root it
+    /// is the comment block at the end of the file.
+    #[getter]
+    fn comment_after(&self, py: Python<'_>) -> PyResult<Option<String>> {
+        let doc = self.root.borrow(py);
+        let node = resolve_path(&doc.nodes, &self.path).ok_or_else(stale_node)?;
+        Ok(join_comment_lines(&node.comments.foot))
+    }
+
+    /// Set or clear the trailing comment after this node. A multi-line string
+    /// becomes one comment line per line; `None` removes it. On a block mapping or
+    /// sequence the block is emitted at the collection's own indent, after its
+    /// last entry; on the document root it is a comment at the end of the file.
+    ///
+    /// A foot comment only has a well-defined rendered position after a block
+    /// collection or at the document root. Setting one on a scalar or a flow
+    /// collection (anywhere but the root) has nowhere to emit, so it is rejected
+    /// with `ValueError` rather than stored and silently dropped on re-emit.
+    /// Clearing (`None`) is always allowed.
+    #[setter]
+    fn set_comment_after(&self, py: Python<'_>, text: Option<String>) -> PyResult<()> {
+        let mut doc = self.root.borrow_mut(py);
+        let node = resolve_path_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
+        // The root (an empty path) renders a foot for any node kind; elsewhere
+        // only a non-empty block mapping or sequence does.
+        if text.is_some() && !self.path.is_empty() && !renders_foot(node) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "comment_after is only supported on a block mapping, a block \
+                 sequence, or the document root",
+            ));
+        }
+        node.comments.foot = split_comment_lines(text);
+        node.mark_modified();
+        Ok(())
+    }
+
     /// The presentation style: a scalar's quoting (`plain`, `single`, `double`,
     /// `literal`, `folded`), a collection's layout (`block`, `flow`), `alias`,
     /// or `null`.
@@ -1185,6 +1223,21 @@ fn split_comment_lines(text: Option<String>) -> Vec<String> {
     match text {
         None => Vec::new(),
         Some(s) => s.split('\n').map(|line| line.to_owned()).collect(),
+    }
+}
+
+/// Whether the emitter renders a node's foot comment in place: only after a
+/// non-empty block mapping or sequence (an empty or flow collection emits inline
+/// with no foot position). The document root is handled separately by its caller,
+/// since its foot renders for any node kind.
+fn renders_foot(node: &YamlNode) -> bool {
+    if node.style != NodeStyle::Block {
+        return false;
+    }
+    match &node.kind {
+        YamlNodeKind::Mapping(pairs) => !pairs.is_empty(),
+        YamlNodeKind::Sequence(items) => !items.is_empty(),
+        _ => false,
     }
 }
 

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -242,6 +242,9 @@ impl RoundTripEmitter {
                 self.buf.push(b'\n');
                 self.emit_head(&val.comments, child);
                 self.emit_block_mapping(m, child);
+                // A trailing comment block at the end of the mapping, indented
+                // with its keys.
+                self.emit_foot(&val.comments, child);
             }
             YamlNodeKind::Sequence(s) if val.style == NodeStyle::Block && !s.is_empty() => {
                 self.emit_anchor_tag_compact(val);
@@ -260,6 +263,9 @@ impl RoundTripEmitter {
                 };
                 self.emit_head(&val.comments, seq_indent);
                 self.emit_block_sequence(s, seq_indent);
+                // A trailing comment block at the end of the sequence, aligned
+                // with its dashes.
+                self.emit_foot(&val.comments, seq_indent);
             }
             // A `key:` with no value: emitted empty for a loaded null (preserving
             // it) and for a synthetic null whose style is `empty`. A synthetic
@@ -361,6 +367,8 @@ impl RoundTripEmitter {
                 self.buf.push(b' ');
                 self.emit_anchor_tag(item);
                 self.emit_block_mapping_after_dash(m, child);
+                // A trailing comment block at the end of this item's mapping.
+                self.emit_foot(&item.comments, child);
             }
             YamlNodeKind::Sequence(s) if item.style == NodeStyle::Block && !s.is_empty() => {
                 // A compact nested sequence (`- - 1`) keeps its first item on
@@ -372,6 +380,8 @@ impl RoundTripEmitter {
                     self.buf.push(b'\n');
                     self.emit_block_sequence(s, child);
                 }
+                // A trailing comment block at the end of this item's sequence.
+                self.emit_foot(&item.comments, child);
             }
             _ => {
                 // Restore the padding between the `-` and an inline item

--- a/tests/roundtrip/test_node.py
+++ b/tests/roundtrip/test_node.py
@@ -189,6 +189,82 @@ def test_comment_before_on_first_key_replaces_leading_comment():
     assert doc.to_yaml().decode() == "# new leading\nkey: value\nother: 2\n"
 
 
+# -- Foot comments (comment_after) -------------------------------------------
+
+
+def test_set_comment_after_on_nested_mapping_indents_with_contents():
+    """comment_after on a block mapping trails its last entry, at the key indent."""
+    doc = load(b"parent:\n  a: 1\n  b: 2\nnext: 3\n")
+    doc.node["parent"].comment_after = "end of parent"
+    assert doc.to_yaml().decode() == (
+        "parent:\n  a: 1\n  b: 2\n  # end of parent\nnext: 3\n"
+    )
+
+
+def test_set_comment_after_on_sequence_aligns_with_dashes():
+    """comment_after on a block sequence trails its last item, multi-line aware."""
+    doc = load(b"items:\n  - x\n  - y\n")
+    doc.node["items"].comment_after = "line one\nline two"
+    assert doc.to_yaml().decode() == (
+        "items:\n  - x\n  - y\n  # line one\n  # line two\n"
+    )
+
+
+def test_set_comment_after_on_root_is_a_file_footer():
+    """comment_after on the document root emits a trailing comment at column 0."""
+    doc = load(b"a: 1\nb: 2\n")
+    doc.node.comment_after = "end of file"
+    assert doc.to_yaml().decode() == "a: 1\nb: 2\n# end of file\n"
+
+
+def test_read_document_trailing_comment_as_root_comment_after():
+    """A comment block at the end of the file reads back as the root's comment_after."""
+    doc = load(b"a: 1\n# footer\n")
+    assert doc.node.comment_after == "footer"
+
+
+def test_comment_after_absent_is_none():
+    """A node with no trailing comment reports comment_after as None."""
+    assert load(b"a: 1\n").node.comment_after is None
+
+
+def test_clear_comment_after():
+    """Setting comment_after to None removes the trailing comment block."""
+    doc = load(b"a: 1\n# footer\n")
+    doc.node.comment_after = None
+    assert doc.to_yaml().decode() == "a: 1\n"
+
+
+def test_comment_after_on_mapping_that_is_a_sequence_item():
+    """comment_after renders on a block mapping nested as a sequence item."""
+    doc = load(b"items:\n  - a: 1\n    b: 2\n")
+    doc.node["items"][0].comment_after = "end of item"
+    assert doc.to_yaml().decode() == ("items:\n  - a: 1\n    b: 2\n    # end of item\n")
+
+
+def test_comment_after_on_sequence_that_is_a_sequence_item():
+    """comment_after renders on a block sequence nested as a sequence item."""
+    doc = load(b"outer:\n  - - 1\n    - 2\n")
+    doc.node["outer"][0].comment_after = "end of inner"
+    assert doc.to_yaml().decode() == ("outer:\n  - - 1\n    - 2\n    # end of inner\n")
+
+
+def test_comment_after_on_scalar_is_rejected():
+    """A foot comment has no rendered position on a scalar, so setting it raises."""
+    doc = load(b"a: 1\nb: 2\n")
+    with pytest.raises(ValueError, match="comment_after"):
+        doc.node["a"].comment_after = "nowhere to go"
+    # Clearing is always allowed, even on a scalar.
+    doc.node["a"].comment_after = None
+
+
+def test_comment_after_on_flow_collection_is_rejected():
+    """A flow collection emits inline with no foot position, so setting it raises."""
+    doc = load(b"tags: [web, edge]\n")
+    with pytest.raises(ValueError, match="comment_after"):
+        doc.node["tags"].comment_after = "no foot in flow"
+
+
 # -- Value editing -----------------------------------------------------------
 
 


### PR DESCRIPTION
## Breaking change

None. Adds a new writable property; no existing behavior changes.

## Proposed change

Adds `comment_after` to `YAMLRocksNode`, the writable counterpart to `comment_before`. It scripts the trailing comment block at the foot of a mapping or sequence (and, on the document root, the comment block at the end of the file). This closes the last comment-editing gap versus ruamel.yaml: inline, leading, and now trailing comments are all writable.

- The round-trip emitter now renders a node's foot comment at the correct nested indent (block mappings, sequences, sequence-item collections, and the root). Because parsed documents carry no nested foot comment today, this is a pure no-op on existing output: the full compliance suite and the entire real-world round-trip corpus still pass byte-for-byte.
- `comment_after` reads and writes `node.comments.foot`, mirroring how `comment_before` handles `head`: bare text (no `#`), one comment line per input line, `None` to clear.
- The document-final comment block (`a: 1` then `# footer`) reads back via `doc.node.comment_after`.

Docs updated: the round-trip guide (attribute table, writable list, worked example) and the ruamel comparison, whose "foot comments are not yet writable" caveat is removed.

What this deliberately does **not** change: the parser's comment-attachment heuristic. A nested end-of-block comment sitting above a dedented sibling still attaches to that sibling's `comment_before` (where it already round-trips and is reachable). Reattributing it to the collection's `comment_after` would perturb a delicate, corpus-calibrated heuristic for marginal gain, so it is left out.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
