### PR TITLE
🐛 Keep a nested final-block foot comment at its indent on edit

### DIFF
--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -287,10 +287,61 @@ fn attach_comments(nodes: &mut [YamlNode], comments: &[Comment], input: &str) {
     if cursor < comments.len() {
         if let Some(last) = nodes.last_mut() {
             for comment in &comments[cursor..] {
-                last.comments.foot.push(comment.text.clone());
+                // Route each trailing comment to the deepest block it is indented
+                // into, so a comment at the end of a nested final block is owned
+                // by that block and re-emits at its indent instead of flattening
+                // to column 0 once the document is edited. A comment at the
+                // document's own indent stays on the outermost node.
+                let target = foot_target(&mut *last, comment.span.column);
+                target.comments.foot.push(comment.text.clone());
             }
         }
     }
+}
+
+/// The node a trailing comment at `column` belongs to: the deepest block
+/// collection reachable by descending through last children whose own column is
+/// no greater than the comment's. A comment aligned with a nested block's
+/// contents lands on that block; one at the document's indent stays on `node`.
+fn foot_target(node: &mut YamlNode, column: u32) -> &mut YamlNode {
+    // Descends the last-child spine only, so recursion is bounded by the
+    // document's nesting depth (the composer already caps that at `MAX_DEPTH`);
+    // the stack guard keeps a deeply nested document off a small thread stack.
+    crate::stack::guard(|| foot_target_inner(node, column))
+}
+
+fn foot_target_inner(node: &mut YamlNode, column: u32) -> &mut YamlNode {
+    let descend = match &node.kind {
+        YamlNodeKind::Mapping(pairs) => pairs
+            .last()
+            .is_some_and(|(_, val)| is_block_collection(val) && val.span.column <= column),
+        YamlNodeKind::Sequence(items) => items
+            .last()
+            .is_some_and(|item| is_block_collection(item) && item.span.column <= column),
+        _ => false,
+    };
+    if !descend {
+        return node;
+    }
+    // Recurse through the guarded `foot_target`, not `foot_target_inner`, so the
+    // stack guard fires at every nesting level (see `stack.rs`), matching the
+    // other per-level descents in this file.
+    match &mut node.kind {
+        YamlNodeKind::Mapping(pairs) => foot_target(&mut pairs.last_mut().unwrap().1, column),
+        YamlNodeKind::Sequence(items) => foot_target(items.last_mut().unwrap(), column),
+        _ => unreachable!("descend is only set for a non-empty block mapping or sequence"),
+    }
+}
+
+/// Whether `node` is a non-empty block mapping or sequence: a collection the
+/// emitter renders across multiple lines, so it can carry a foot comment.
+fn is_block_collection(node: &YamlNode) -> bool {
+    node.style == NodeStyle::Block
+        && match &node.kind {
+            YamlNodeKind::Mapping(pairs) => !pairs.is_empty(),
+            YamlNodeKind::Sequence(items) => !items.is_empty(),
+            _ => false,
+        }
 }
 
 /// Raise the running "last source line seen" to at least `line`.

--- a/tests/roundtrip/test_node.py
+++ b/tests/roundtrip/test_node.py
@@ -223,6 +223,25 @@ def test_read_document_trailing_comment_as_root_comment_after():
     assert doc.node.comment_after == "footer"
 
 
+def test_nested_final_block_comment_reads_as_that_blocks_comment_after():
+    """A trailing comment at the end of a nested final block is owned by that block,
+    not dumped on the document root."""
+    doc = load(b"parent:\n  a: 1\n  # end of parent\n")
+    assert doc.node["parent"].comment_after == "end of parent"
+    assert doc.node.comment_after is None
+
+
+def test_multi_level_trailing_comments_route_to_their_blocks():
+    """Trailing comments at different indents each attach to the block they sit in."""
+    doc = load(
+        b"parent:\n  child:\n    x: 1\n"
+        b"    # foot of child\n  # foot of parent\n# foot of doc\n"
+    )
+    assert doc.node["parent"]["child"].comment_after == "foot of child"
+    assert doc.node["parent"].comment_after == "foot of parent"
+    assert doc.node.comment_after == "foot of doc"
+
+
 def test_comment_after_absent_is_none():
     """A node with no trailing comment reports comment_after as None."""
     assert load(b"a: 1\n").node.comment_after is None

--- a/tests/roundtrip/test_roundtrip.py
+++ b/tests/roundtrip/test_roundtrip.py
@@ -66,6 +66,19 @@ def test_foot_comment_preserved():
     assert roundtrip(src) == src
 
 
+def test_nested_final_block_foot_keeps_indent_on_edit():
+    """A comment at the end of a nested final block keeps that block's indent
+    after an edit, instead of flattening to column 0.
+
+    Unmodified documents re-emit from the source cache, which hides the bug; an
+    edit forces the AST path, where the trailing comment must stay owned by the
+    nested block it sits in (not the document root, which emits at column 0).
+    """
+    doc = yamlrocks.loads(b"parent:\n  a: 1\n  b: 2\n  # end of parent\n", option=RT)
+    doc["parent"]["b"] = 9
+    assert doc.to_yaml() == b"parent:\n  a: 1\n  b: 9\n  # end of parent\n"
+
+
 def test_sequence_comments_preserved():
     """Round-trip preserves comments attached to sequence items."""
     src = "items:\n  # about list\n  - one # first\n  - two\n"


### PR DESCRIPTION
## Breaking change

None. Fixes a round-trip fidelity bug; no API change.

## Proposed change

Fixes a foot-comment fidelity bug exposed while adding `comment_after` (#213). A comment at the end of a *nested* final block round-trips byte-for-byte when untouched, but the moment the document is edited it re-emits at column 0 instead of the block's indent:

```yaml
parent:
  a: 1
  b: 2
  # end of parent      <- edit `b`, and this jumps to column 0
```

The cause was in the composer: every trailing comment left after the walk was attached to the outermost (root) node's foot, which the emitter renders at indent 0. On the AST re-emit path (taken after an edit) the comment therefore detached from the block it belongs to.

The fix routes each trailing comment to the deepest block it is indented into, by descending the last-child spine while the child is a block collection no more indented than the comment. A comment aligned with a nested block's contents now lands on that block (and re-emits at its indent); a comment at the document's own indent still stays on the outermost node. Multi-level trailing comments each attach to their own level. The descent is bounded by the document's nesting depth and stack-guarded, consistent with the other composer walks.

Because unmodified documents re-emit their trailing comment verbatim (independent of which node owns it), this changes only the post-edit path: the full compliance suite and the entire real-world round-trip corpus stay byte-for-byte. New tests cover the edit-keeps-indent case, the nested read-back attribution, and multi-level routing.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #213 (follow-up to writable foot comments)
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
