### PR TITLE
📝 Note the timestamp resolution differences in the comparisons

### DIFF
--- a/docs/src/content/docs/comparisons/vs-pyyaml.md
+++ b/docs/src/content/docs/comparisons/vs-pyyaml.md
@@ -81,7 +81,22 @@ yamlrocks.upgrade(b"enabled: yes\nmode: on\n")
 # b'%YAML 1.2\n---\nenabled: true\nmode: true\n'
 ```
 
-See [YAML 1.1 vs 1.2](/guides/yaml-11-vs-12/) for the full list of differences.
+The same 1.1 heritage means PyYAML also resolves implicit timestamps and
+sexagesimals, so a plain `2024-01-15` becomes a `datetime.date` and a bare
+`13:30:45` becomes the integer `48645` (base-60), a config value silently turned
+into a large number. YAMLRocks stays clean by default and makes timestamp typing
+an explicit opt-in that never touches other 1.1 forms:
+
+```python
+import datetime
+import yamlrocks
+
+yamlrocks.loads(b"at: 13:30:45")                                 # {'at': '13:30:45'}
+yamlrocks.loads(b"on: 2024-01-15", option=yamlrocks.OPT_TIMESTAMPS)  # {'on': datetime.date(2024, 1, 15)}
+```
+
+See [YAML 1.1 vs 1.2](/guides/yaml-11-vs-12/) for the full list of differences,
+and [timestamps](/reference/options/#timestamps) for the opt-in.
 
 ## Comments and round-trip editing
 

--- a/docs/src/content/docs/comparisons/vs-yaml-rs.md
+++ b/docs/src/content/docs/comparisons/vs-yaml-rs.md
@@ -13,20 +13,21 @@ on top.
 
 ## Feature comparison
 
-| Feature                       |       yaml-rs        |         YAMLRocks          |
-| ----------------------------- | :------------------: | :------------------------: |
-| YAML 1.2                      |         Yes          |            Yes             |
-| Comment-preserving round-trip |          No          |    Yes (byte-for-byte)     |
-| Native `!include` + writeback |          No          |            Yes             |
-| JSON Schema validation        |          No          |    Yes (line-numbered)     |
-| Source line/column            |          No          |    Yes (annotated mode)    |
-| Custom tag handling           |          No          |            Yes             |
-| Verified vs the YAML suite    |      Not stated      |        Yes, in full        |
-| Anchors/aliases resolved      |         Yes          |            Yes             |
-| Merge keys (`<<`)             |          No          |            Yes             |
-| Implementation                |  Rust (saphyr fork)  | Rust (own scanner/emitter) |
-| Speed (parse / dump)          |       baseline       |    ~1.2x / ~1.4x faster    |
-| Maturity                      | 0.1.x, public domain |    Battle-tested corpus    |
+| Feature                       |           yaml-rs           |         YAMLRocks          |
+| ----------------------------- | :-------------------------: | :------------------------: |
+| YAML 1.2                      |             Yes             |            Yes             |
+| Comment-preserving round-trip |             No              |    Yes (byte-for-byte)     |
+| Native `!include` + writeback |             No              |            Yes             |
+| JSON Schema validation        |             No              |    Yes (line-numbered)     |
+| Source line/column            |             No              |    Yes (annotated mode)    |
+| Custom tag handling           |             No              |            Yes             |
+| Verified vs the YAML suite    |         Not stated          |        Yes, in full        |
+| Anchors/aliases resolved      |             Yes             |            Yes             |
+| Merge keys (`<<`)             |             No              |            Yes             |
+| Timestamp resolution          | On by default, incl. quoted | Opt-in, plain scalars only |
+| Implementation                |     Rust (saphyr fork)      | Rust (own scanner/emitter) |
+| Speed (parse / dump)          |          baseline           |    ~1.2x / ~1.4x faster    |
+| Maturity                      |    0.1.x, public domain     |    Battle-tested corpus    |
 
 ## A parser, or a toolkit
 
@@ -91,6 +92,22 @@ yamlrocks.loads(b"base: &b\n  timeout: 30\nsvc:\n  <<: *b\n  name: api\n")
 # Leading-zero integers: `0777` is a string in YAML 1.2, not the number 777.
 yamlrocks.loads(b"mode: 0777")
 # {'mode': '0777'}
+```
+
+Timestamps are a sharper example. yaml-rs resolves a date/datetime scalar to a
+Python object by default, and it does so even for a **quoted** scalar. In YAML a
+quoted scalar is explicitly a string, so quoting is exactly how you say "keep
+this as text", and yaml-rs ignores that. YAMLRocks makes timestamp resolution
+opt-in ([`OPT_TIMESTAMPS`](/reference/options/#timestamps)) and only ever applies
+it to plain scalars, matching PyYAML and the spec:
+
+```python
+import yamlrocks
+
+# A quoted scalar is a string, even with timestamp resolution enabled.
+yamlrocks.loads(b'when: "2024-01-15"', option=yamlrocks.OPT_TIMESTAMPS)
+# {'when': '2024-01-15'}
+# yaml-rs returns {'when': datetime.date(2024, 1, 15)}, quoting ignored.
 ```
 
 These are not the reason to switch on their own; they are evidence that "verified


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

Documents the timestamp-resolution differences on the comparison pages, following the `OPT_TIMESTAMPS` feature (#216).

- **vs yaml-rs**: adds a feature-table row and a runnable example for the concrete correctness win. yaml-rs resolves timestamps by default and even for *quoted* scalars; a quoted scalar is explicitly a string in YAML, so quoting is how you say "keep this as text", and yaml-rs ignores that. YAMLRocks makes resolution opt-in and only applies it to plain scalars, matching PyYAML and the spec.
- **vs PyYAML**: notes in the Norway-problem section that PyYAML's YAML 1.1 heritage also turns a plain `13:30:45` into the integer `48645` (base-60) and dates into `datetime` implicitly, contrasted with YAMLRocks staying clean by default and offering timestamp typing as an explicit `OPT_TIMESTAMPS` opt-in.

Both examples are runnable and pass `docs/verify_examples.py`, and both link to the new timestamps anchor in the options reference.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #216 (the `OPT_TIMESTAMPS` feature)
- Link to a separate documentation pull request:

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
