### PR TITLE
📝 Correct ruamel migration doc: foot comments are writable

### DIFF
--- a/docs/src/content/docs/getting-started/migrating-from-ruamel.md
+++ b/docs/src/content/docs/getting-started/migrating-from-ruamel.md
@@ -165,22 +165,23 @@ doc.to_yaml()
 
 ## What ruamel still does that YAMLRocks does not
 
-Be honest with yourself about these before migrating:
+Be honest with yourself about this before migrating:
 
-- **Foot comments.** YAMLRocks scripts inline and leading comments per node
-  (`comment` / `comment_before`), and these work on mapping values, keys, and
-  sequence items, but a trailing/foot comment block at the end of a collection is
-  preserved through a round-trip rather than writable through the node API.
 - **Building a commented document from nothing.** YAMLRocks edits comments on a
   loaded document (including keys you add to it), but there is no constructor for
   a fresh round-trip document with no parsed source, the way ruamel can assemble a
   fully commented `CommentedMap` in memory.
 
+YAMLRocks does write comments in every position, including the foot: inline
+(`comment`), leading (`comment_before`), and trailing (`comment_after`) comments
+are all editable, on mapping values, keys, and sequence items. A foot comment
+attaches to a block collection or the document root.
+
 :::caution[When to stick with ruamel]
-If your workflow depends on foot comments or on assembling a fully commented
-document from nothing, ruamel's `.ca` API still does things YAMLRocks does not. For
-loading, editing existing configuration in place (comments included, on values,
-keys, and sequence items), and high-volume parsing or emitting, YAMLRocks is the
+If your workflow depends on assembling a fully commented document from nothing,
+ruamel's `.ca` API still does that and YAMLRocks does not. For loading, editing
+existing configuration in place (comments included, on values, keys, and sequence
+items, in every position), and high-volume parsing or emitting, YAMLRocks is the
 faster and stricter choice.
 :::
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The ruamel migration guide still listed foot comments under "What ruamel still does that YAMLRocks does not," claiming a trailing/foot comment block is only preserved through a round-trip rather than writable through the node API. That has been false since `comment_after` shipped (#213, #215): foot comments are now editable through the node API, on block collections and the document root.

This corrects the stale section: it drops the foot-comment bullet, states plainly that inline (`comment`), leading (`comment_before`), and trailing (`comment_after`) comments are all writable, and trims foot comments out of the "when to stick with ruamel" caution so only the genuine remaining gap (building a fully commented document from nothing) stays.

The `vs-ruamel.md` and `round-trip.md` pages already described `comment_after` correctly, so no change was needed there.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #213, #215
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
