### PR TITLE
✨ Add async_loads_all to complete the async load family

### DIFF
--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -348,12 +348,13 @@ object holds the GIL for the object traversal and only frees it for the final
 byte emit, so a thread offload buys little. Use `asyncio.to_thread(dumps, obj)`
 directly in the rare case it matters.
 
-| Coroutine                      | Wraps                   | Notes                                 |
-| ------------------------------ | ----------------------- | ------------------------------------- |
-| `async_loads(data, ...)`       | [`loads`](#loads)       | Same keyword arguments.               |
-| `async_load(source, ...)`      | [`load`](#load)         | Offloads the file read and the parse. |
-| `async_load_all(source, ...)`  | [`load_all`](#load_all) | Multi-document file.                  |
-| `async_dump(obj, target, ...)` | [`dump`](#dump)         | Offloads the serialize and the write. |
+| Coroutine                      | Wraps                     | Notes                                 |
+| ------------------------------ | ------------------------- | ------------------------------------- |
+| `async_loads(data, ...)`       | [`loads`](#loads)         | Same keyword arguments.               |
+| `async_load(source, ...)`      | [`load`](#load)           | Offloads the file read and the parse. |
+| `async_load_all(source, ...)`  | [`load_all`](#load_all)   | Multi-document file.                  |
+| `async_loads_all(data, ...)`   | [`loads_all`](#loads_all) | Multi-document in-memory stream.      |
+| `async_dump(obj, target, ...)` | [`dump`](#dump)           | Offloads the serialize and the write. |
 
 ```python
 import yamlrocks

--- a/pysrc/yamlrocks/__init__.py
+++ b/pysrc/yamlrocks/__init__.py
@@ -387,6 +387,7 @@ __all__ = [
     "async_load",
     "async_load_all",
     "async_loads",
+    "async_loads_all",
     "dump",
     "dump_includes",
     "dump_includes_map",
@@ -666,6 +667,26 @@ async def async_load_all(
     return await asyncio.to_thread(
         load_all,
         source,
+        option=option,
+        tag_handler=tag_handler,
+        tags=tags,
+    )
+
+
+async def async_loads_all(
+    data: bytes | bytearray | memoryview | str,
+    /,
+    *,
+    option: int | None = None,
+    tag_handler: Callable[[str, Any], Any] | None = None,
+    tags: dict[str, Callable[[Any], Any]] | None = None,
+) -> list[Any]:
+    """Parse a multi-document stream off the event loop thread; see :func:`loads_all`."""
+    import asyncio  # lazy; see async_loads (issue #52)
+
+    return await asyncio.to_thread(
+        loads_all,
+        data,
         option=option,
         tag_handler=tag_handler,
         tags=tags,

--- a/pysrc/yamlrocks/__init__.pyi
+++ b/pysrc/yamlrocks/__init__.pyi
@@ -459,6 +459,14 @@ async def async_load_all(
     tag_handler: Callable[[str, Any], Any] | None = None,
     tags: dict[str, Callable[[Any], Any]] | None = None,
 ) -> list[Any]: ...
+async def async_loads_all(
+    data: bytes | bytearray | memoryview | str,
+    /,
+    *,
+    option: int | None = None,
+    tag_handler: Callable[[str, Any], Any] | None = None,
+    tags: dict[str, Callable[[Any], Any]] | None = None,
+) -> list[Any]: ...
 async def async_dump(
     obj: Any,
     target: str | os.PathLike[str] | _Writable | None = None,

--- a/tests/features/test_async.py
+++ b/tests/features/test_async.py
@@ -70,6 +70,12 @@ async def test_async_load_all_reads_multidoc(tmp_path):
     assert await yamlrocks.async_load_all(str(p)) == [{"a": 1}, {"b": 2}]
 
 
+async def test_async_loads_all_parses_multidoc_stream():
+    """async_loads_all returns every document from an in-memory stream."""
+    src = b"---\na: 1\n---\nb: 2\n"
+    assert await yamlrocks.async_loads_all(src) == yamlrocks.loads_all(src)
+
+
 async def test_async_dump_writes_file(tmp_path):
     """async_dump serializes and writes to a path."""
     p = tmp_path / "out.yaml"


### PR DESCRIPTION
## Breaking change

None. This is purely additive: a new coroutine alongside the existing async family.

## Proposed change

The async wrappers cover the load family so an asyncio application can run the blocking scan/parse off its event loop, but one entry point was missing: there was `async_load_all` (multi-document from a file) yet no `async_loads_all` (multi-document from an in-memory `bytes`/`str` stream), even though the sync side has both `load_all` and `loads_all`.

This closes that gap. `async_loads_all` is a thin `asyncio.to_thread(loads_all, ...)` wrapper, identical in shape to `async_load_all`, with the same keyword arguments as `loads_all` (`option`, `tag_handler`, `tags`).

The deliberate absence of `async_dumps`/`async_to_json` is unchanged and still asserted by `test_no_async_serializers`: serializing holds the GIL for the object traversal, so a thread offload buys little there. Async stays reserved for the load family and the file APIs.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
