### PR TITLE
✨ Rename the dump-side tags= registry to serializers=

### DIFF
--- a/docs/src/content/docs/guides/tags.md
+++ b/docs/src/content/docs/guides/tags.md
@@ -183,9 +183,11 @@ yamlrocks.dumps({"opts": yamlrocks.YAMLRocksTag("!extend", {"a": 1, "b": 2})})
 ### Emitting your own types as tags
 
 When you hold your own objects (not `YAMLRocksTag` instances) and want them to
-emit as a tag, pass a `tags` registry to `dumps`. It maps a **Python type** to a
-callable that returns a `YAMLRocksTag` (or a `(tag, value)` tuple). This is the
-exact inverse of the load-side `tags={"!tag": func}` registry:
+emit as a tag, pass a `serializers` registry to `dumps`. It maps a **Python
+type** to a callable that returns a `YAMLRocksTag` (or a `(tag, value)` tuple).
+It is the write-side mirror of the load-side `tags={"!tag": func}` registry, but
+keyed the other way round: on load you dispatch on the YAML tag, on dump you
+dispatch on the Python type.
 
 ```python
 import yamlrocks
@@ -196,7 +198,7 @@ class Input:
 
 yamlrocks.dumps(
     {"brightness": Input("kitchen")},
-    tags={Input: lambda o: yamlrocks.YAMLRocksTag("!input", o.name)},
+    serializers={Input: lambda o: yamlrocks.YAMLRocksTag("!input", o.name)},
 )
 # b'brightness: !input kitchen\n'
 ```
@@ -217,7 +219,7 @@ class Input:
 
 out = yamlrocks.dumps(
     {"brightness": Input("kitchen")},
-    tags={Input: lambda o: yamlrocks.YAMLRocksTag("!input", o.name)},
+    serializers={Input: lambda o: yamlrocks.YAMLRocksTag("!input", o.name)},
 )
 yamlrocks.loads(out, tags={"!input": lambda v: Input(str(v))})
 # {'brightness': Input('kitchen')}

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -231,7 +231,7 @@ def dumps(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> bytes: ...
 ```
@@ -246,8 +246,8 @@ not `str`; decode with `.decode()` if you need text.
 - `null_style`: how `None` is rendered, one of `"empty"` (default), `"null"`, or
   `"~"`. Overrides `OPT_NULL_AS_KEYWORD` / `OPT_NULL_AS_TILDE` for this call. See
   [Null style](/reference/options/#null-style).
-- `tags`: a `{type: func}` registry for emitting custom `!tag value` output;
-  `func` receives a value of that exact type and returns a
+- `serializers`: a `{type: func}` registry for emitting custom `!tag value`
+  output; `func` receives a value of that exact type and returns a
   [`YAMLRocksTag`](#yamlrockstag) (or `(tag, value)` tuple). The write-side mirror
   of the load-side `tags`. See [emitting custom tags](/guides/tags/#emitting-custom-tags).
 - `width`: a best-effort maximum line length. `None` (the default) leaves lines
@@ -279,7 +279,7 @@ def dump(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None: ...
 ```

--- a/pysrc/yamlrocks/__init__.py
+++ b/pysrc/yamlrocks/__init__.py
@@ -531,7 +531,7 @@ def dump(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None:
     """Serialize ``obj`` as YAML to a filesystem path or file-like object.
@@ -556,7 +556,7 @@ def dump(
         default=default,
         option=option,
         null_style=null_style,
-        tags=tags,
+        serializers=serializers,
         width=width,
     )
     if hasattr(target, "write"):
@@ -701,7 +701,7 @@ async def async_dump(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None:
     """Serialize and write YAML off the event loop thread; see :func:`dump`.
@@ -717,6 +717,6 @@ async def async_dump(
         default=default,
         option=option,
         null_style=null_style,
-        tags=tags,
+        serializers=serializers,
         width=width,
     )

--- a/pysrc/yamlrocks/__init__.pyi
+++ b/pysrc/yamlrocks/__init__.pyi
@@ -393,7 +393,7 @@ def dump(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None: ...
 def loads_all(
@@ -411,7 +411,7 @@ def dumps(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> bytes: ...
 def to_json(
@@ -475,7 +475,7 @@ async def async_dump(
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
     null_style: str | None = None,
-    tags: dict[type, Callable[[Any], Any]] | None = None,
+    serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None: ...
 def dump_includes(

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -583,20 +583,20 @@ pub fn yaml_version(py: Python<'_>, data: &Bound<'_, PyAny>) -> PyResult<Py<PyAn
 }
 
 #[pyfunction]
-#[pyo3(signature = (obj, /, *, default=None, option=None, null_style=None, tags=None, width=None))]
+#[pyo3(signature = (obj, /, *, default=None, option=None, null_style=None, serializers=None, width=None))]
 pub fn dumps(
     py: Python<'_>,
     obj: &Bound<'_, PyAny>,
     default: Option<Py<PyAny>>,
     option: Option<u64>,
     null_style: Option<&str>,
-    tags: Option<Py<PyDict>>,
+    serializers: Option<Py<PyDict>>,
     width: Option<usize>,
 ) -> PyResult<Py<PyAny>> {
     let opts = option.unwrap_or(0);
 
     // A round-trip document re-emits from its own preserved layout, so the
-    // emit-shaping arguments (option, null_style, width, tags, default) do not
+    // emit-shaping arguments (option, null_style, width, serializers, default) do not
     // apply here and are intentionally ignored; round-trip styles win.
     if let Ok(doc) = obj.cast::<YAMLRocksDocument>() {
         return doc.borrow().to_yaml(py);
@@ -629,7 +629,7 @@ pub fn dumps(
         utc_z: opts & OPT_UTC_Z != 0,
         passthrough_datetime: opts & OPT_PASSTHROUGH_DATETIME != 0,
         passthrough_dataclass: opts & OPT_PASSTHROUGH_DATACLASS != 0,
-        tags: tags.as_ref(),
+        tags: serializers.as_ref(),
         depth: 0,
     };
     let value = python_to_value(py, obj, ctx)?;

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -138,8 +138,8 @@ def test_dumps_passthrough_tag_round_trips():
     assert yamlrocks.dumps(data) == b"x: !input foo\n"
 
 
-def test_dumps_tags_registry_by_type():
-    """tags={type: func} emits a `!tag value` for a registered type."""
+def test_dumps_serializers_registry_by_type():
+    """serializers={type: func} emits a `!tag value` for a registered type."""
 
     class Marker:
         def __init__(self, name):
@@ -147,13 +147,13 @@ def test_dumps_tags_registry_by_type():
 
     out = yamlrocks.dumps(
         {"hello": Marker("world")},
-        tags={Marker: lambda o: yamlrocks.YAMLRocksTag("!marker", o.name)},
+        serializers={Marker: lambda o: yamlrocks.YAMLRocksTag("!marker", o.name)},
     )
     assert out == b"hello: !marker world\n"
 
 
-def test_dumps_tags_registry_tuple_return():
-    """A tags callback may return a (tag, value) tuple instead of a Tag."""
+def test_dumps_serializers_registry_tuple_return():
+    """A serializers callback may return a (tag, value) tuple instead of a Tag."""
 
     class Marker:
         def __init__(self, name):
@@ -161,12 +161,12 @@ def test_dumps_tags_registry_tuple_return():
 
     out = yamlrocks.dumps(
         {"x": Marker("z")},
-        tags={Marker: lambda o: ("!marker", o.name)},
+        serializers={Marker: lambda o: ("!marker", o.name)},
     )
     assert out == b"x: !marker z\n"
 
 
-def test_dumps_tags_registry_before_dataclass():
+def test_dumps_serializers_registry_before_dataclass():
     """A registered dataclass type emits a tag rather than auto-mapping."""
     from dataclasses import dataclass
 
@@ -176,7 +176,7 @@ def test_dumps_tags_registry_before_dataclass():
 
     out = yamlrocks.dumps(
         {"hello": Input("test_name")},
-        tags={Input: lambda o: yamlrocks.YAMLRocksTag("!input", o.name)},
+        serializers={Input: lambda o: yamlrocks.YAMLRocksTag("!input", o.name)},
     )
     assert out == b"hello: !input test_name\n"
     # Round-trip closes with the load-side tags registry.
@@ -184,7 +184,7 @@ def test_dumps_tags_registry_before_dataclass():
     assert back == {"hello": Input("test_name")}
 
 
-def test_dumps_tags_registry_is_exact_type():
+def test_dumps_serializers_registry_is_exact_type():
     """Matching is by exact type; a subclass is not caught by a base entry."""
 
     class Base:
@@ -200,7 +200,7 @@ def test_dumps_tags_registry_is_exact_type():
     with pytest.raises(yamlrocks.YAMLRocksUnserializableError):
         yamlrocks.dumps(
             {"x": Derived()},
-            tags={Base: lambda o: yamlrocks.YAMLRocksTag("!b", "x")},
+            serializers={Base: lambda o: yamlrocks.YAMLRocksTag("!b", "x")},
         )
 
 
@@ -219,14 +219,14 @@ def test_dumps_default_may_return_tag():
 
 
 def test_dumps_tags_callback_bad_return_raises():
-    """A tags callback that returns a non-tag, non-tuple value errors clearly."""
+    """A serializers callback that returns a non-tag, non-tuple value errors clearly."""
     import pytest
 
     class Marker:
         pass
 
     with pytest.raises(yamlrocks.YAMLRocksError):
-        yamlrocks.dumps({"x": Marker()}, tags={Marker: lambda o: 123})
+        yamlrocks.dumps({"x": Marker()}, serializers={Marker: lambda o: 123})
 
 
 def test_dumps_tag_with_whitespace_is_rejected():
@@ -258,7 +258,9 @@ def test_dumps_tuple_tag_with_whitespace_is_rejected():
         pass
 
     with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="invalid tag"):
-        yamlrocks.dumps({"x": Marker()}, tags={Marker: lambda o: ("!bad tag", "v")})
+        yamlrocks.dumps(
+            {"x": Marker()}, serializers={Marker: lambda o: ("!bad tag", "v")}
+        )
 
 
 def test_dumps_verbatim_tag_with_commas_is_allowed():

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -204,6 +204,21 @@ def test_dumps_serializers_registry_is_exact_type():
         )
 
 
+def test_dump_side_tags_keyword_is_gone():
+    """The dump-side registry is `serializers=`, not `tags=`; the old name was
+    renamed with no deprecation alias, so it must raise (guards against a future
+    accidental re-introduction)."""
+    import pytest
+
+    class Marker:
+        pass
+
+    reg = {Marker: lambda o: yamlrocks.YAMLRocksTag("!m", "x")}
+    for fn in (yamlrocks.dumps, yamlrocks.dump, yamlrocks.async_dump):
+        with pytest.raises(TypeError):
+            fn({"x": Marker()}, tags=reg)
+
+
 def test_dumps_default_may_return_tag():
     """A `default` callback returning a YAMLRocksTag is emitted as a tag."""
 
@@ -218,7 +233,7 @@ def test_dumps_default_may_return_tag():
     assert out == b"x: !marker foo\n"
 
 
-def test_dumps_tags_callback_bad_return_raises():
+def test_dumps_serializers_callback_bad_return_raises():
     """A serializers callback that returns a non-tag, non-tuple value errors clearly."""
     import pytest
 


### PR DESCRIPTION
## Breaking change

Yes. The dump-side registry keyword argument is renamed from `tags` to `serializers` on `dumps`, `dump`, and `async_dump`. Code that passed a type-keyed registry to dump now needs the new name:

```python
# before
yamlrocks.dumps(obj, tags={MyType: lambda o: yamlrocks.YAMLRocksTag("!t", o.x)})
# after
yamlrocks.dumps(obj, serializers={MyType: lambda o: yamlrocks.YAMLRocksTag("!t", o.x)})
```

There is no deprecation alias: the old `tags=` on dump now raises `TypeError`. This is intentional, done before 1.0 so the name never has to be carried forward. The load-side `tags=` (keyed by YAML tag string) is unchanged.

## Proposed change

On load, `tags` is keyed by the YAML tag string (`{"!vec": func}`): "when you see this tag, transform the value." On dump, the same-named argument was keyed by Python type (`{MyType: func}`): "when you see this type, emit it like this." One name covered two different registries keyed by two different things, which read as a symmetry that was not real.

Renaming the dump side to `serializers` reflects what it actually does (turn a Python object into something emittable) and reveals the true parallel: each side has a registry plus a catch-all.

```
load:  tags=         (by YAML tag)      + tag_handler=  (catch-all)
dump:  serializers=  (by Python type)   + default=      (catch-all)
```

This is part of the pre-1.0 API-surface review: freezing a clearer surface now rather than a confusing one later. The internal `EncodeCtx.tags` field is left as-is (private, not user-visible).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [x] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
