### PR TITLE
✨ Drop the null_style= dump kwarg in favor of the null-style flags

### DIFF
--- a/docs/src/content/docs/guides/dumping.md
+++ b/docs/src/content/docs/guides/dumping.md
@@ -167,9 +167,9 @@ yamlrocks.dumps({"b": 1, "a": 2}, option=yamlrocks.OPT_SORT_KEYS | yamlrocks.OPT
 `None` is left **blank** by default (`key:` with nothing after the colon), which
 is what hand-written configs and PyYAML-based tools overwhelmingly produce. Some
 formats prefer the explicit `null` keyword (data and spec formats such as
-OpenAPI), and some prefer the `~` indicator. Pass `null_style` to choose per call,
-or set `OPT_NULL_AS_KEYWORD` / `OPT_NULL_AS_TILDE` to make that style the default
-(the two flags are mutually exclusive):
+OpenAPI), and some prefer the `~` indicator. Set `OPT_NULL_AS_KEYWORD` or
+`OPT_NULL_AS_TILDE` to make that style the default (the two flags are mutually
+exclusive):
 
 ```python
 import yamlrocks
@@ -177,21 +177,17 @@ import yamlrocks
 yamlrocks.dumps({"a": None, "b": None})
 # b'a:\nb:\n'
 
-yamlrocks.dumps({"a": None, "b": None}, null_style="null")
+yamlrocks.dumps({"a": None, "b": None}, option=yamlrocks.OPT_NULL_AS_KEYWORD)
 # b'a: null\nb: null\n'
 
-yamlrocks.dumps({"a": None}, null_style="~")
+yamlrocks.dumps({"a": None}, option=yamlrocks.OPT_NULL_AS_TILDE)
 # b'a: ~\n'
-
-yamlrocks.dumps({"a": None}, option=yamlrocks.OPT_NULL_AS_KEYWORD)
-# b'a: null\n'
 ```
 
 The three styles all parse back to `None`, so the choice is cosmetic. The blank
 form is only used where it is unambiguous, a block mapping value or a block
 sequence entry; at the top level, inside a flow collection, or as a mapping key it
-falls back to `null` so the output stays valid YAML 1.2. The `null_style` argument
-overrides the flag for a single call.
+falls back to `null` so the output stays valid YAML 1.2.
 
 ### Line width: `width`
 

--- a/docs/src/content/docs/guides/yaml-style.md
+++ b/docs/src/content/docs/guides/yaml-style.md
@@ -112,7 +112,7 @@ yamlrocks.dumps({"nickname": None})
 
 Some formats prefer the explicit keyword, in particular data and specification
 formats such as OpenAPI, where `null` is idiomatic. Opt into it with
-`OPT_NULL_AS_KEYWORD` (or `null_style="null"` for a single call):
+`OPT_NULL_AS_KEYWORD`:
 
 ```python
 import yamlrocks

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -230,7 +230,6 @@ def dumps(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> bytes: ...
@@ -242,9 +241,9 @@ not `str`; decode with `.decode()` if you need text.
 - `default`: a callable invoked for a value YAMLRocks cannot serialize on its own.
   It receives the value and returns something serializable, or raises to signal
   that the value is unsupported.
-- `option`: a bitwise-OR of [`OPT_*` flags](/reference/options/).
-- `null_style`: how `None` is rendered, one of `"empty"` (default), `"null"`, or
-  `"~"`. Overrides `OPT_NULL_AS_KEYWORD` / `OPT_NULL_AS_TILDE` for this call. See
+- `option`: a bitwise-OR of [`OPT_*` flags](/reference/options/). How `None` is
+  rendered is one of these: the default empty node (`key:`), `OPT_NULL_AS_KEYWORD`
+  (`key: null`), or `OPT_NULL_AS_TILDE` (`key: ~`). See
   [Null style](/reference/options/#null-style).
 - `serializers`: a `{type: func}` registry for emitting custom `!tag value`
   output; `func` receives a value of that exact type and returns a
@@ -278,7 +277,6 @@ def dump(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None: ...

--- a/docs/src/content/docs/reference/options.md
+++ b/docs/src/content/docs/reference/options.md
@@ -185,11 +185,10 @@ yamlrocks.dumps({"a": 1}, option=yamlrocks.OPT_EXPLICIT_START | yamlrocks.OPT_EX
 
 When `dumps` serializes `None`, it leaves the value **blank** by default
 (`key:`), matching the dominant real-world configuration style.
-`OPT_NULL_AS_KEYWORD` switches the default to the explicit `null` keyword and
+`OPT_NULL_AS_KEYWORD` switches to the explicit `null` keyword and
 `OPT_NULL_AS_TILDE` to `~`; the two flags are mutually exclusive (setting both
-raises `ValueError`). The per-call `null_style` argument of `dumps`/`dump`
-overrides the flag for one call. The accepted styles are `"null"`, `"empty"`, and
-`"~"`. All three parse back to `None`, so the choice is purely cosmetic.
+raises `ValueError`). All three forms parse back to `None`, so the choice is
+purely cosmetic.
 
 The blank form is used only where it reads back unambiguously as null: a block
 mapping value (`key:`) or a block sequence entry (`-`). At the top level, inside a
@@ -202,15 +201,11 @@ import yamlrocks
 yamlrocks.dumps({"a": None})
 # b'a:\n'
 
-yamlrocks.dumps({"a": None}, null_style="null")
+yamlrocks.dumps({"a": None}, option=yamlrocks.OPT_NULL_AS_KEYWORD)
 # b'a: null\n'
 
-yamlrocks.dumps({"a": None}, null_style="~")
+yamlrocks.dumps({"a": None}, option=yamlrocks.OPT_NULL_AS_TILDE)
 # b'a: ~\n'
-
-# The argument overrides the flag for one call.
-yamlrocks.dumps({"a": None}, option=yamlrocks.OPT_NULL_AS_KEYWORD, null_style="empty")
-# b'a:\n'
 ```
 
 :::note[Round-trip editing]

--- a/pysrc/yamlrocks/__init__.py
+++ b/pysrc/yamlrocks/__init__.py
@@ -530,7 +530,6 @@ def dump(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None:
@@ -555,7 +554,6 @@ def dump(
         obj,
         default=default,
         option=option,
-        null_style=null_style,
         serializers=serializers,
         width=width,
     )
@@ -700,7 +698,6 @@ async def async_dump(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None:
@@ -716,7 +713,6 @@ async def async_dump(
         target,
         default=default,
         option=option,
-        null_style=null_style,
         serializers=serializers,
         width=width,
     )

--- a/pysrc/yamlrocks/__init__.pyi
+++ b/pysrc/yamlrocks/__init__.pyi
@@ -392,7 +392,6 @@ def dump(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None: ...
@@ -410,7 +409,6 @@ def dumps(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> bytes: ...
@@ -474,7 +472,6 @@ async def async_dump(
     *,
     default: Callable[[Any], Any] | None = None,
     option: int | None = None,
-    null_style: str | None = None,
     serializers: dict[type, Callable[[Any], Any]] | None = None,
     width: int | None = None,
 ) -> None: ...

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -220,13 +220,11 @@ pub const OPT_SINGLE_QUOTES: u64 = 1 << 24;
 /// node (`key:`). yamlrocks leaves nulls blank by default, matching the dominant
 /// real-world configuration style; this flag opts into the explicit spelling,
 /// which suits data/spec formats (OpenAPI, for instance) where `null` is idiomatic.
-/// Affects `dumps()` and the round-trip emitter's edited-in nulls; the per-call
-/// `null_style=` argument overrides it.
+/// Affects `dumps()` and the round-trip emitter's edited-in nulls.
 pub const OPT_NULL_AS_KEYWORD: u64 = 1 << 25;
 /// Emit null values as the `~` indicator instead of the default empty node. `~`
 /// is unambiguous in every position, so it is used verbatim everywhere. Affects
-/// `dumps()` and the round-trip emitter's edited-in nulls; the per-call
-/// `null_style=` argument overrides it. Mutually exclusive with
+/// `dumps()` and the round-trip emitter's edited-in nulls. Mutually exclusive with
 /// `OPT_NULL_AS_KEYWORD` (setting both is a `ValueError`).
 pub const OPT_NULL_AS_TILDE: u64 = 1 << 26;
 
@@ -583,20 +581,19 @@ pub fn yaml_version(py: Python<'_>, data: &Bound<'_, PyAny>) -> PyResult<Py<PyAn
 }
 
 #[pyfunction]
-#[pyo3(signature = (obj, /, *, default=None, option=None, null_style=None, serializers=None, width=None))]
+#[pyo3(signature = (obj, /, *, default=None, option=None, serializers=None, width=None))]
 pub fn dumps(
     py: Python<'_>,
     obj: &Bound<'_, PyAny>,
     default: Option<Py<PyAny>>,
     option: Option<u64>,
-    null_style: Option<&str>,
     serializers: Option<Py<PyDict>>,
     width: Option<usize>,
 ) -> PyResult<Py<PyAny>> {
     let opts = option.unwrap_or(0);
 
     // A round-trip document re-emits from its own preserved layout, so the
-    // emit-shaping arguments (option, null_style, width, serializers, default) do not
+    // emit-shaping arguments (option, width, serializers, default) do not
     // apply here and are intentionally ignored; round-trip styles win.
     if let Ok(doc) = obj.cast::<YAMLRocksDocument>() {
         return doc.borrow().to_yaml(py);
@@ -614,11 +611,8 @@ pub fn dumps(
     };
 
     let mut emit_options = build_emit_options(opts);
-    // The per-call `null_style=` argument overrides the option flags.
-    emit_options.null_style = match null_style {
-        Some(style) => parse_null_style(style)?,
-        None => null_style_from_opts(opts)?,
-    };
+    // The null style comes from the option flags (OPT_NULL_AS_KEYWORD / _TILDE).
+    emit_options.null_style = null_style_from_opts(opts)?;
     // Best-effort line wrapping; 0 (the default) leaves lines unwrapped.
     emit_options.width = width.unwrap_or(0);
     let ctx = EncodeCtx {
@@ -1278,18 +1272,5 @@ pub fn null_style_from_opts(opts: u64) -> PyResult<NullStyle> {
         (true, false) => Ok(NullStyle::Null),
         (false, true) => Ok(NullStyle::Tilde),
         (false, false) => Ok(NullStyle::Empty),
-    }
-}
-
-/// Map the `null_style=` argument to a [`NullStyle`]. Accepts `"null"`, `"empty"`,
-/// and `"~"`/`"tilde"`; anything else is a `ValueError`.
-fn parse_null_style(value: &str) -> PyResult<NullStyle> {
-    match value {
-        "null" => Ok(NullStyle::Null),
-        "empty" => Ok(NullStyle::Empty),
-        "~" | "tilde" => Ok(NullStyle::Tilde),
-        other => Err(PyValueError::new_err(format!(
-            "null_style must be 'null', 'empty', or '~', not {other:?}"
-        ))),
     }
 }

--- a/tests/core/test_dumps.py
+++ b/tests/core/test_dumps.py
@@ -257,30 +257,10 @@ def test_dumps_null_style_default_is_empty():
     assert yamlrocks.dumps({"a": None, "list": [1, None]}) == b"a:\nlist:\n  - 1\n  -\n"
 
 
-def test_dumps_null_style_empty_in_block_positions():
-    """``null_style='empty'`` (the default) emits a bare ``key:``/``-``."""
-    out = yamlrocks.dumps({"a": None, "list": [1, None]}, null_style="empty")
-    assert out == b"a:\nlist:\n  - 1\n  -\n"
-
-
-def test_dumps_null_style_tilde():
-    """``null_style='~'`` emits the tilde indicator everywhere."""
-    out = yamlrocks.dumps({"a": None, "list": [None]}, null_style="~")
-    assert out == b"a: ~\nlist:\n  - ~\n"
-
-
 def test_dumps_opt_null_as_keyword_flag():
     """``OPT_NULL_AS_KEYWORD`` selects the explicit ``null`` keyword."""
     out = yamlrocks.dumps({"a": None}, option=yamlrocks.OPT_NULL_AS_KEYWORD)
     assert out == b"a: null\n"
-
-
-def test_dumps_null_style_kwarg_overrides_flag():
-    """The per-call ``null_style=`` argument wins over the option flag."""
-    out = yamlrocks.dumps(
-        {"a": None}, option=yamlrocks.OPT_NULL_AS_KEYWORD, null_style="empty"
-    )
-    assert out == b"a:\n"
 
 
 @pytest.mark.parametrize(
@@ -291,30 +271,26 @@ def test_dumps_null_style_kwarg_overrides_flag():
     ],
 )
 def test_dumps_null_style_empty_falls_back_where_ambiguous(obj, expected):
-    """Empty null is only used where it reads back unambiguously; elsewhere
-    (top-level scalar, flow, a key) it falls back to the ``null`` keyword."""
-    assert yamlrocks.dumps(obj, null_style="empty") == expected
+    """The default empty null is only used where it reads back unambiguously;
+    elsewhere (top-level scalar, flow, a key) it falls back to the ``null``
+    keyword."""
+    assert yamlrocks.dumps(obj) == expected
 
 
 def test_dumps_null_style_empty_flow_falls_back():
     """In a flow collection an empty entry is invalid, so ``null`` is used."""
-    out = yamlrocks.dumps(
-        {"a": [None, 1]}, option=yamlrocks.OPT_FLOW_STYLE, null_style="empty"
-    )
+    out = yamlrocks.dumps({"a": [None, 1]}, option=yamlrocks.OPT_FLOW_STYLE)
     assert out == b"{a: [null, 1]}\n"
 
 
-@pytest.mark.parametrize("style", ["null", "empty", "~"])
-def test_dumps_null_style_always_round_trips_to_none(style):
+@pytest.mark.parametrize(
+    "option",
+    [None, yamlrocks.OPT_NULL_AS_KEYWORD, yamlrocks.OPT_NULL_AS_TILDE],
+)
+def test_dumps_null_style_always_round_trips_to_none(option):
     """Every null style parses back to None, so the choice is purely cosmetic."""
     data = {"a": None, "b": [None, {"c": None}]}
-    assert yamlrocks.loads(yamlrocks.dumps(data, null_style=style)) == data
-
-
-def test_dumps_invalid_null_style_raises():
-    """An unknown null_style is a ValueError naming the valid choices."""
-    with pytest.raises(ValueError, match="null_style"):
-        yamlrocks.dumps({"a": None}, null_style="nil")
+    assert yamlrocks.loads(yamlrocks.dumps(data, option=option)) == data
 
 
 def test_dumps_opt_null_as_tilde_flag():


### PR DESCRIPTION
## Breaking change

Yes. The `null_style=` keyword argument is removed from `dumps`, `dump`, and `async_dump`. Null rendering is now controlled solely by the option flags:

```python
# before
yamlrocks.dumps(obj, null_style="null")   # or "empty" / "~"
# after
yamlrocks.dumps(obj, option=yamlrocks.OPT_NULL_AS_KEYWORD)   # or default (empty) / OPT_NULL_AS_TILDE
```

The old `null_style=` now raises `TypeError`, with no deprecation alias. The three states are unchanged: default blank (`key:`), `OPT_NULL_AS_KEYWORD` (`key: null`), `OPT_NULL_AS_TILDE` (`key: ~`). The two flags remain mutually exclusive (setting both is a `ValueError`).

## Proposed change

There were two ways to choose the null style: the `null_style=` string kwarg and the `OPT_NULL_AS_KEYWORD` / `OPT_NULL_AS_TILDE` flags. Worse, when both were given the kwarg silently won with no error, so `dumps(obj, null_style="empty", option=OPT_NULL_AS_TILDE)` quietly produced empty nulls. Two mechanisms for one setting, with a silent precedence footgun.

This drops the kwarg and keeps the flags, which compose into the single `option` mask like every other emit setting and match the orjson-style surface the library is modeled on. Part of the pre-1.0 API-surface review: one setting, one way to express it.

The internal `NullStyle` enum and all flag-driven emitter machinery are untouched; only the public kwarg and its now-unused string parser (`parse_null_style`) are removed.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [x] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
