### PR TITLE
⚡ Borrow single-quoted scalars instead of copying char by char

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -120,6 +120,15 @@ STRINGS_ARRAY = b"lines:\n" + b"".join(
     for i in range(500)
 )
 
+# The same shape but single-quoted: stresses the quoted-scalar scanner, the
+# common shape of config exports and generated YAML. Paired with STRINGS_ARRAY
+# so the plain and quoted scalar paths are measured side by side.
+QUOTED_STRINGS = b"lines:\n" + b"".join(
+    b"  - 'this is a fairly long single-quoted scalar line number %d with several words in it'\n"
+    % i
+    for i in range(500)
+)
+
 PAYLOADS = {
     "small (10 lines)": SMALL,
     "medium (k8s, ~50 lines)": MEDIUM,
@@ -127,6 +136,7 @@ PAYLOADS = {
     "deep (30 levels)": DEEP,
     "small_objects (500 tiny maps)": SMALL_OBJECTS,
     "strings_array (500 long scalars)": STRINGS_ARRAY,
+    "quoted_strings (500 quoted scalars)": QUOTED_STRINGS,
 }
 
 

--- a/src/scanner/scalar.rs
+++ b/src/scanner/scalar.rs
@@ -26,7 +26,18 @@ pub fn scan_single_quoted<'input>(
     let start_span = reader.span();
     reader.advance(); // skip opening '
 
-    let mut value = String::new();
+    // Scan by tracking offsets, not by pushing each char: a single-quoted scalar
+    // with no `''` escape and no line fold is exactly the input slice between the
+    // quotes, so it borrows with zero allocation (the common case). An owned
+    // buffer is materialized lazily the first time an escape or fold forces a
+    // transformation, and thereafter each clean run is bulk-copied with
+    // `push_str` rather than character by character. This mirrors `scan_plain`.
+    let content_start = reader.offset();
+    // `Some` once a `''` escape or a fold has forced an owned buffer; the start of
+    // the current clean run (into which nothing has been copied yet) is `run_start`.
+    let mut owned: Option<String> = None;
+    let mut run_start = content_start;
+
     loop {
         if reader.is_eof() {
             return Err(ScanError::new(
@@ -34,37 +45,53 @@ pub fn scan_single_quoted<'input>(
                 start_span,
             ));
         }
-        if at_document_marker(reader) {
-            return Err(ScanError::new(
-                "a document marker cannot appear inside a quoted scalar",
-                start_span,
-            ));
-        }
         match reader.peek() {
             '\'' => {
+                let quote_off = reader.offset();
                 reader.advance();
                 if reader.peek() == '\'' {
-                    // escaped single quote ''
-                    value.push('\'');
+                    // Escaped `''`: flush the clean run, emit one quote, continue.
+                    let buf = owned.get_or_insert_with(String::new);
+                    buf.push_str(reader.slice(run_start, quote_off));
+                    buf.push('\'');
                     reader.advance();
+                    run_start = reader.offset();
                 } else {
-                    break;
+                    // Closing quote at `quote_off`.
+                    return Ok(match owned {
+                        Some(mut buf) => {
+                            buf.push_str(reader.slice(run_start, quote_off));
+                            Cow::Owned(buf)
+                        }
+                        None => Cow::Borrowed(reader.slice(content_start, quote_off)),
+                    });
                 }
             }
             '\n' | '\r' => {
-                // A leading break folds the same way, so an empty buffer is no
-                // exception. Single-quoted scalars have no escapes, so every
-                // trailing blank is foldable whitespace.
-                trim_trailing_blanks(&mut value);
-                fold_quoted_break(reader, &mut value, parent_indent)?;
+                // A fold forces an owned buffer. Copy the clean run, drop its
+                // trailing blanks (single-quoted scalars have no escapes, so every
+                // trailing blank is foldable whitespace), then fold the break.
+                let here = reader.offset();
+                let buf = owned.get_or_insert_with(String::new);
+                buf.push_str(reader.slice(run_start, here));
+                trim_trailing_blanks(buf);
+                fold_quoted_break(reader, buf, parent_indent)?;
+                // A document marker (`---`/`...`) can only begin at column 0, so it
+                // is checked once here, after the fold lands on a continuation line,
+                // rather than on every character.
+                if at_document_marker(reader) {
+                    return Err(ScanError::new(
+                        "a document marker cannot appear inside a quoted scalar",
+                        start_span,
+                    ));
+                }
+                run_start = reader.offset();
             }
-            ch => {
-                value.push(ch);
+            _ => {
                 reader.advance();
             }
         }
     }
-    Ok(Cow::Owned(value))
 }
 
 /// After advancing to the content of a quoted-scalar continuation line (leading


### PR DESCRIPTION
## Breaking change

None. Pure internal optimization; parse results and round-trip output are byte-for-byte identical.

## Proposed change

The single-quoted scalar scanner walked the content **character by character**: every byte was decoded to a `char`, pushed into a freshly allocated `String`, and the result was always returned as `Cow::Owned`, even for the overwhelmingly common case of a scalar with no `''` escape and no line fold. It also checked for a `---`/`...` document marker on every character, when a marker can only ever begin at column 0.

This rewrites it to mirror the plain-scalar scanner: it tracks byte offsets and returns `Cow::Borrowed` on the input slice between the quotes when the scalar is clean (no escape, no fold), so the common case allocates nothing. An owned buffer is materialized lazily only when a `''` escape or a line fold forces a transformation, and each clean run is then bulk-copied with `push_str` rather than a char at a time. The document-marker check moves out of the per-character loop to run once, after a fold lands on a continuation line.

Measured on a quoted-scalar-heavy load with callgrind (deterministic instruction counts): **~27% fewer instructions** (1.572B to 1.148B). Plain scalars already scanned this way; this brings single-quoted scalars up to parity. Behavior is unchanged: the full suite, the YAML compliance suite, all Rust unit tests, and 1.14M round-trip fuzz runs pass with no differences.

Also adds a `quoted_strings` payload to `bench/bench.py`, paired with the existing plain `strings_array`, so the quoted-scalar path is benchmarked alongside the plain one and this cannot silently regress. (A double-quoted equivalent will follow as a separate change.)

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
