### PR TITLE
⚡ Bulk-copy block scalar content lines instead of char by char

### DIFF
--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -347,6 +347,29 @@ impl<'input> Reader<'input> {
         self.pos = i;
     }
 
+    /// Bulk-consume the rest of the current line (to the next `\n`/`\r`, or EOF)
+    /// and return it. The block-scalar scanner copies whole content lines into
+    /// its owned buffer, so a per-character loop there is pure overhead; the line
+    /// end is found with a SIMD [`memchr::memchr2`]. `column` advances by the byte
+    /// length for a pure-ASCII line (the common case) and by a code-point count
+    /// (non-continuation bytes) otherwise; see
+    /// [`take_single_quoted_run`](Self::take_single_quoted_run).
+    #[inline]
+    pub fn take_until_line_break(&mut self) -> &'input str {
+        let bytes = self.input.as_bytes();
+        let start = self.pos;
+        let stop =
+            memchr::memchr2(b'\n', b'\r', &bytes[start..]).map_or(bytes.len(), |i| start + i);
+        let run = &self.input[start..stop];
+        self.column += if run.is_ascii() {
+            run.len() as u32
+        } else {
+            run.bytes().filter(|&b| (b & 0xc0) != 0x80).count() as u32
+        };
+        self.pos = stop;
+        run
+    }
+
     /// Check if the next character is a line break or EOF.
     #[inline]
     pub fn check_next_is_break_or_eof(&self) -> bool {

--- a/src/scanner/scalar.rs
+++ b/src/scanner/scalar.rs
@@ -569,10 +569,8 @@ pub fn scan_block<'input>(
             value.push('\n');
         }
         let leading_non_space = !matches!(reader.peek(), ' ' | '\t');
-        while !reader.is_eof() && reader.peek() != '\n' && reader.peek() != '\r' {
-            value.push(reader.peek());
-            reader.advance();
-        }
+        // Copy the whole content line in one pass instead of char by char.
+        value.push_str(reader.take_until_line_break());
         let had_break = !reader.is_eof();
         if had_break {
             reader.advance_line();


### PR DESCRIPTION
## Breaking change

None. Pure internal optimization; parse results and round-trip output are byte-for-byte identical.

## Proposed change

Profiling the real-world config corpus (`bench/corpus_bench.py` + callgrind) showed the block-scalar scanner (`|` and `>`) at ~8.6% of loads, and reading each content line one character at a time: `value.push(reader.peek()); reader.advance()` in a loop. Real configs are full of block scalars (embedded scripts, certificates, SQL, multi-line descriptions, Helm values), so this is a hot path that our earlier synthetic benchmarks never exercised.

This replaces the per-character line loop with a single bulk copy: a new `Reader::take_until_line_break` finds the line end with a SIMD `memchr2` and returns the slice, which the block scanner appends with `push_str`. Column tracking stays exact, by byte length for a pure-ASCII line (the common case, SIMD `is_ascii`) and by a code-point count (non-continuation bytes) otherwise, mirroring the single-quoted scanner. A block scalar is inherently multi-line and owned, so the line-folding and chomping logic is unchanged; only the inner content copy is bulked.

Measured with callgrind over the real-world corpus (2000 files, 3 passes): **~8.4% fewer instructions** across the whole corpus load (15.61B to 14.29B). Behavior is unchanged: the full suite, the YAML compliance suite, all Rust unit tests, and round-trip fuzzing pass with no differences, and byte-for-byte round-trip of block scalars is preserved.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
