### PR TITLE
📝 Refresh benchmark charts and numbers for the current build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ many times faster YAMLRocks is:
 
 | Operation                                    | vs PyYAML (C loader) |   vs ruamel.yaml |
 | -------------------------------------------- | -------------------: | ---------------: |
-| Parse (`loads`)                              |        ~5-10x faster |  ~85-135x faster |
-| Serialize (`dumps`)                          |       ~15-19x faster | ~155-210x faster |
-| Split config (`!include`, hundreds of files) |          ~18x faster |              n/a |
+| Parse (`loads`)                              |        ~6-10x faster | ~105-141x faster |
+| Serialize (`dumps`)                          |       ~17-19x faster | ~160-208x faster |
+| Split config (`!include`, hundreds of files) |          ~17x faster |              n/a |
 
 Across the wider field of Python YAML libraries, on both reading and writing:
 

--- a/docs/public/benchmarks/dump.svg
+++ b/docs/public/benchmarks/dump.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.640445</dc:date>
+    <dc:date>2026-07-06T11:56:45.344240</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -40,14 +40,14 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 143.178514 385.893969
-L 143.178514 31.077969
-" clip-path="url(#p8f64772141)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 128.901695 385.893969
+L 128.901695 31.077969
+" clip-path="url(#p8f4a941ceb)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(134.378514 398.793969)">
+      <g style="fill: #9aa3ad" transform="translate(120.101695 398.793969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -58,14 +58,14 @@ L 143.178514 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 297.756375 385.893969
-L 297.756375 31.077969
-" clip-path="url(#p8f64772141)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 285.785183 385.893969
+L 285.785183 31.077969
+" clip-path="url(#p8f4a941ceb)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(288.956375 398.693969)">
+      <g style="fill: #9aa3ad" transform="translate(276.985183 398.693969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -76,14 +76,14 @@ L 297.756375 31.077969
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 452.334235 385.893969
-L 452.334235 31.077969
-" clip-path="url(#p8f64772141)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 442.668671 385.893969
+L 442.668671 31.077969
+" clip-path="url(#p8f4a941ceb)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(443.534235 398.693969)">
+      <g style="fill: #9aa3ad" transform="translate(433.868671 398.693969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -95,166 +95,166 @@ L 452.334235 31.077969
     <g id="xtick_4">
      <g id="line2d_7">
       <defs>
-       <path id="m3039d6b0cc" d="M 0 0
+       <path id="mddd58a5a0a" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m3039d6b0cc" x="119.234101" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="113.698114" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="128.198372" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="121.7231" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="136.105419" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="176.128331" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="189.711087" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="203.754142" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="216.930897" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="223.354966" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="236.24366" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="238.558547" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="251.223802" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="250.980777" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="263.46347" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="261.483623" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="273.811961" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="270.581602" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="282.776232" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="278.606588" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="290.68328" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="333.011819" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="344.288947" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="360.63763" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="371.508757" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="380.238454" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="390.82152" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="395.442035" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="405.801662" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="407.864265" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="418.04133" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="418.367111" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="428.389821" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="427.46509" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="437.354092" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="435.490076" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="445.26114" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="489.895307" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="498.866808" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="517.521118" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="526.086618" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="537.121942" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="545.39938" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="552.325523" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m3039d6b0cc" x="560.379523" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#mddd58a5a0a" x="564.747753" y="385.893969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -330,114 +330,114 @@ L 568.913125 385.893969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -154898.415333 47.205969
-L 129.423363 47.205969
-L 129.423363 71.099302
-L -154898.415333 71.099302
+    <path d="M -157225.236813 47.205969
+L 129.367902 47.205969
+L 129.367902 71.099302
+L -157225.236813 71.099302
 z
-" clip-path="url(#p8f64772141)" style="fill: #24fefd"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #24fefd"/>
    </g>
    <g id="patch_5">
-    <path d="M -154898.415333 80.391154
-L 147.709683 80.391154
-L 147.709683 104.284487
-L -154898.415333 104.284487
+    <path d="M -157225.236813 80.391154
+L 145.018012 80.391154
+L 145.018012 104.284487
+L -157225.236813 104.284487
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
-    <path d="M -154898.415333 113.576339
-L 157.174739 113.576339
-L 157.174739 137.469672
-L -154898.415333 137.469672
+    <path d="M -157225.236813 113.576339
+L 149.574841 113.576339
+L 149.574841 137.469672
+L -157225.236813 137.469672
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_7">
-    <path d="M -154898.415333 146.761524
-L 174.333355 146.761524
-L 174.333355 170.654858
-L -154898.415333 170.654858
+    <path d="M -157225.236813 146.761524
+L 166.711051 146.761524
+L 166.711051 170.654858
+L -157225.236813 170.654858
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -154898.415333 179.946709
-L 213.766222 179.946709
-L 213.766222 203.840043
-L -154898.415333 203.840043
+    <path d="M -157225.236813 179.946709
+L 211.916125 179.946709
+L 211.916125 203.840043
+L -157225.236813 203.840043
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
-    <path d="M -154898.415333 213.131895
-L 298.238255 213.131895
-L 298.238255 237.025228
-L -154898.415333 237.025228
+    <path d="M -157225.236813 213.131895
+L 291.129871 213.131895
+L 291.129871 237.025228
+L -157225.236813 237.025228
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_10">
-    <path d="M -154898.415333 246.31708
-L 324.667378 246.31708
-L 324.667378 270.210413
-L -154898.415333 270.210413
+    <path d="M -157225.236813 246.31708
+L 318.047825 246.31708
+L 318.047825 270.210413
+L -157225.236813 270.210413
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_11">
-    <path d="M -154898.415333 279.502265
-L 442.993033 279.502265
-L 442.993033 303.395598
-L -154898.415333 303.395598
+    <path d="M -157225.236813 279.502265
+L 446.559743 279.502265
+L 446.559743 303.395598
+L -157225.236813 303.395598
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_12">
-    <path d="M -154898.415333 312.68745
-L 443.3202 312.68745
-L 443.3202 336.580784
-L -154898.415333 336.580784
+    <path d="M -157225.236813 312.68745
+L 446.989174 312.68745
+L 446.989174 336.580784
+L -157225.236813 336.580784
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="patch_13">
-    <path d="M -154898.415333 345.872635
-L 490.828122 345.872635
-L 490.828122 369.765969
-L -154898.415333 369.765969
+    <path d="M -157225.236813 345.872635
+L 489.663434 345.872635
+L 489.663434 369.765969
+L -157225.236813 369.765969
 z
-" clip-path="url(#p8f64772141)" style="fill: #5b626d"/>
+" clip-path="url(#p8f4a941ceb)" style="fill: #5b626d"/>
    </g>
    <g id="text_15">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="138.805905" y="61.100878" transform="rotate(-0 138.805905 61.100878)">815 µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="138.890391" y="61.100878" transform="rotate(-0 138.890391 61.100878)">1.0 ms</text>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="157.092225" y="94.286063" transform="rotate(-0 157.092225 94.286063)">1.1 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="154.540501" y="94.286063" transform="rotate(-0 154.540501 94.286063)">1.3 ms</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="166.557281" y="127.471248" transform="rotate(-0 166.557281 127.471248)">1.2 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="159.09733" y="127.471248" transform="rotate(-0 159.09733 127.471248)">1.4 ms</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="183.715897" y="160.656433" transform="rotate(-0 183.715897 160.656433)">1.6 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="176.23354" y="160.656433" transform="rotate(-0 176.23354 160.656433)">1.7 ms</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="223.148764" y="193.841618" transform="rotate(-0 223.148764 193.841618)">2.9 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="221.438614" y="193.841618" transform="rotate(-0 221.438614 193.841618)">3.4 ms</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="307.620798" y="227.026804" transform="rotate(-0 307.620798 227.026804)">10.1 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="300.65236" y="227.026804" transform="rotate(-0 300.65236 227.026804)">10.8 ms</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="334.049921" y="260.211989" transform="rotate(-0 334.049921 260.211989)">14.9 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="327.570314" y="260.211989" transform="rotate(-0 327.570314 260.211989)">16.1 ms</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="452.375576" y="293.397174" transform="rotate(-0 452.375576 293.397174)">87.0 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="456.082232" y="293.397174" transform="rotate(-0 456.082232 293.397174)">105.9 ms</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="452.702742" y="326.582359" transform="rotate(-0 452.702742 326.582359)">87.4 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="456.511663" y="326.582359" transform="rotate(-0 456.511663 326.582359)">106.5 ms</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="500.210665" y="359.767544" transform="rotate(-0 500.210665 359.767544)">177.4 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="499.185923" y="359.767544" transform="rotate(-0 499.185923 359.767544)">199.3 ms</text>
    </g>
    <g id="text_25">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="111.353125" y="17.077969" transform="rotate(-0 111.353125 17.077969)">Serializing (dumps), across libraries</text>
@@ -445,7 +445,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p8f64772141">
+  <clipPath id="p8f4a941ceb">
    <rect x="111.353125" y="31.077969" width="457.56" height="354.816"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/load.svg
+++ b/docs/public/benchmarks/load.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.483674</dc:date>
+    <dc:date>2026-07-06T11:56:45.202601</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -40,14 +40,14 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 236.281644 413.613969
-L 236.281644 31.077969
-" clip-path="url(#p240ed87935)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 228.021415 413.613969
+L 228.021415 31.077969
+" clip-path="url(#pa89ee1fcc8)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(227.481644 426.413969)">
+      <g style="fill: #9aa3ad" transform="translate(219.221415 426.413969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -58,14 +58,14 @@ L 236.281644 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 366.069986 413.613969
-L 366.069986 31.077969
-" clip-path="url(#p240ed87935)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 356.916491 413.613969
+L 356.916491 31.077969
+" clip-path="url(#pa89ee1fcc8)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(357.269986 426.413969)">
+      <g style="fill: #9aa3ad" transform="translate(348.116491 426.413969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -76,14 +76,14 @@ L 366.069986 31.077969
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 495.858328 413.613969
-L 495.858328 31.077969
-" clip-path="url(#p240ed87935)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 485.811566 413.613969
+L 485.811566 31.077969
+" clip-path="url(#pa89ee1fcc8)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- $\mathdefault{10^{6}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(487.058328 426.513969)">
+      <g style="fill: #9aa3ad" transform="translate(477.011566 426.513969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -95,187 +95,194 @@ L 495.858328 31.077969
     <g id="xtick_4">
      <g id="line2d_7">
       <defs>
-       <path id="m2e623312eb" d="M 0 0
+       <path id="m1b3b4becc7" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2e623312eb" x="145.563486" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="137.927624" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2e623312eb" x="168.418078" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="160.62492" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m2e623312eb" x="184.63367" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="176.728908" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2e623312eb" x="197.21146" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="189.220131" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m2e623312eb" x="207.488262" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="199.426204" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2e623312eb" x="216.177175" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="208.055316" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m2e623312eb" x="223.703854" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="215.530192" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2e623312eb" x="230.342855" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="222.1235" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2e623312eb" x="275.351828" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="266.822699" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2e623312eb" x="298.20642" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="289.519996" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m2e623312eb" x="314.422012" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="305.623983" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2e623312eb" x="326.999802" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="318.115207" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m2e623312eb" x="337.276604" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="328.32128" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2e623312eb" x="345.965517" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="336.950391" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m2e623312eb" x="353.492196" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="344.425268" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2e623312eb" x="360.131197" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="351.018576" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2e623312eb" x="405.14017" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="395.717775" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2e623312eb" x="427.994762" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="418.415071" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m2e623312eb" x="444.210354" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="434.519059" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2e623312eb" x="456.788144" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="447.010282" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m2e623312eb" x="467.064946" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="457.216355" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2e623312eb" x="475.753859" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="465.845467" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m2e623312eb" x="483.280538" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="473.320343" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_27">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2e623312eb" x="489.919539" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="479.913651" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_28">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m2e623312eb" x="534.928512" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="524.61285" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_29">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2e623312eb" x="557.783104" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m1b3b4becc7" x="547.310147" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m1b3b4becc7" x="563.414134" y="413.613969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -285,67 +292,67 @@ L 0 2
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_33"/>
+     <g id="line2d_34"/>
      <g id="text_5">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="63.943695" transform="rotate(-0 107.853125 63.943695)">YAMLRocks</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_34"/>
+     <g id="line2d_35"/>
      <g id="text_6">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="96.383993" transform="rotate(-0 107.853125 96.383993)">yaml_rs 0.1.4</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_35"/>
+     <g id="line2d_36"/>
      <g id="text_7">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="128.824292" transform="rotate(-0 107.853125 128.824292)">fast-yaml 0.6.3</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_36"/>
+     <g id="line2d_37"/>
      <g id="text_8">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="161.26459" transform="rotate(-0 107.853125 161.26459)">py-yaml12 0.1.0</text>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_37"/>
+     <g id="line2d_38"/>
      <g id="text_9">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="193.704889" transform="rotate(-0 107.853125 193.704889)">ryaml 0.5.1</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_38"/>
+     <g id="line2d_39"/>
      <g id="text_10">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="226.144797" transform="rotate(-0 107.853125 226.144797)">PyYAML (C) 6.0.3</text>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_39"/>
+     <g id="line2d_40"/>
      <g id="text_11">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="258.585486" transform="rotate(-0 107.853125 258.585486)">yamlium 0.2.5</text>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_40"/>
+     <g id="line2d_41"/>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="291.025394" transform="rotate(-0 107.853125 291.025394)">PyYAML (pure) 6.0.3</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="291.025785" transform="rotate(-0 107.853125 291.025785)">oyaml 1.0</text>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_41"/>
+     <g id="line2d_42"/>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="323.466083" transform="rotate(-0 107.853125 323.466083)">oyaml 1.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="323.465692" transform="rotate(-0 107.853125 323.465692)">PyYAML (pure) 6.0.3</text>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_42"/>
+     <g id="line2d_43"/>
      <g id="text_14">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="355.906382" transform="rotate(-0 107.853125 355.906382)">ruamel.yaml 0.19.1</text>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_43"/>
+     <g id="line2d_44"/>
      <g id="text_15">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="107.853125" y="388.34668" transform="rotate(-0 107.853125 388.34668)">strictyaml 1.7.3</text>
      </g>
@@ -357,125 +364,125 @@ L 568.913125 413.613969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -130071.213787 48.465969
-L 130.019669 48.465969
-L 130.019669 71.822984
-L -130071.213787 71.822984
+    <path d="M -129182.63437 48.465969
+L 130.041156 48.465969
+L 130.041156 71.822984
+L -129182.63437 71.822984
 z
-" clip-path="url(#p240ed87935)" style="fill: #24fefd"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #24fefd"/>
    </g>
    <g id="patch_5">
-    <path d="M -130071.213787 80.906267
-L 141.038646 80.906267
-L 141.038646 104.263282
-L -130071.213787 104.263282
+    <path d="M -129182.63437 80.906267
+L 139.722321 80.906267
+L 139.722321 104.263282
+L -129182.63437 104.263282
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
-    <path d="M -130071.213787 113.346566
-L 159.179882 113.346566
-L 159.179882 136.703581
-L -130071.213787 136.703581
+    <path d="M -129182.63437 113.346566
+L 158.268702 113.346566
+L 158.268702 136.703581
+L -129182.63437 136.703581
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_7">
-    <path d="M -130071.213787 145.786864
-L 177.803687 145.786864
-L 177.803687 169.143879
-L -130071.213787 169.143879
+    <path d="M -129182.63437 145.786864
+L 176.851506 145.786864
+L 176.851506 169.143879
+L -129182.63437 169.143879
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -130071.213787 178.227163
-L 186.259473 178.227163
-L 186.259473 201.584178
-L -130071.213787 201.584178
+    <path d="M -129182.63437 178.227163
+L 185.712621 178.227163
+L 185.712621 201.584178
+L -129182.63437 201.584178
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
-    <path d="M -130071.213787 210.667461
-L 263.34488 210.667461
-L 263.34488 234.024476
-L -130071.213787 234.024476
+    <path d="M -129182.63437 210.667461
+L 258.02607 210.667461
+L 258.02607 234.024476
+L -129182.63437 234.024476
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_10">
-    <path d="M -130071.213787 243.10776
-L 336.911822 243.10776
-L 336.911822 266.464775
-L -130071.213787 266.464775
+    <path d="M -129182.63437 243.10776
+L 337.518285 243.10776
+L 337.518285 266.464775
+L -129182.63437 266.464775
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_11">
-    <path d="M -130071.213787 275.548058
-L 389.021582 275.548058
-L 389.021582 298.905073
-L -130071.213787 298.905073
+    <path d="M -129182.63437 275.548058
+L 388.670264 275.548058
+L 388.670264 298.905073
+L -129182.63437 298.905073
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_12">
-    <path d="M -130071.213787 307.988357
-L 389.456668 307.988357
-L 389.456668 331.345372
-L -130071.213787 331.345372
+    <path d="M -129182.63437 307.988357
+L 388.980842 307.988357
+L 388.980842 331.345372
+L -129182.63437 331.345372
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_13">
-    <path d="M -130071.213787 340.428655
-L 413.948083 340.428655
-L 413.948083 363.78567
-L -130071.213787 363.78567
+    <path d="M -129182.63437 340.428655
+L 410.449972 340.428655
+L 410.449972 363.78567
+L -129182.63437 363.78567
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="patch_14">
-    <path d="M -130071.213787 372.868954
-L 503.350547 372.868954
-L 503.350547 396.225969
-L -130071.213787 396.225969
+    <path d="M -129182.63437 372.868954
+L 503.80178 372.868954
+L 503.80178 396.225969
+L -129182.63437 396.225969
 z
-" clip-path="url(#p240ed87935)" style="fill: #5b626d"/>
+" clip-path="url(#pa89ee1fcc8)" style="fill: #5b626d"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.897541" y="62.092718" transform="rotate(-0 137.897541 62.092718)">1.5 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.864809" y="62.092718" transform="rotate(-0 137.864809 62.092718)">1.7 ms</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="148.916518" y="94.533017" transform="rotate(-0 148.916518 94.533017)">1.8 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="147.545974" y="94.533017" transform="rotate(-0 147.545974 94.533017)">2.1 ms</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="167.057754" y="126.973315" transform="rotate(-0 167.057754 126.973315)">2.5 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="166.092354" y="126.973315" transform="rotate(-0 166.092354 126.973315)">2.9 ms</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="185.681559" y="159.413614" transform="rotate(-0 185.681559 159.413614)">3.5 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="184.675159" y="159.413614" transform="rotate(-0 184.675159 159.413614)">4.0 ms</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="194.137345" y="191.853912" transform="rotate(-0 194.137345 191.853912)">4.1 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="193.536274" y="191.853912" transform="rotate(-0 193.536274 191.853912)">4.7 ms</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="271.222752" y="224.294211" transform="rotate(-0 271.222752 224.294211)">16.2 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="265.849723" y="224.294211" transform="rotate(-0 265.849723 224.294211)">17.1 ms</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="344.789694" y="256.734509" transform="rotate(-0 344.789694 256.734509)">59.6 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="345.341937" y="256.734509" transform="rotate(-0 345.341937 256.734509)">70.7 ms</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="396.899454" y="289.174808" transform="rotate(-0 396.899454 289.174808)">150.3 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="396.493917" y="289.174808" transform="rotate(-0 396.493917 289.174808)">176.3 ms</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="397.33454" y="321.615106" transform="rotate(-0 397.33454 321.615106)">151.4 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="396.804494" y="321.615106" transform="rotate(-0 396.804494 321.615106)">177.3 ms</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="421.825955" y="354.055405" transform="rotate(-0 421.825955 354.055405)">233.8 ms</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="418.273625" y="354.055405" transform="rotate(-0 418.273625 354.055405)">260.2 ms</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="511.228419" y="386.495703" transform="rotate(-0 511.228419 386.495703)">1.14 s</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="511.625433" y="386.495703" transform="rotate(-0 511.625433 386.495703)">1.38 s</text>
    </g>
    <g id="text_27">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="111.353125" y="17.077969" transform="rotate(-0 111.353125 17.077969)">Parsing (loads), across libraries</text>
@@ -483,7 +490,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p240ed87935">
+  <clipPath id="pa89ee1fcc8">
    <rect x="111.353125" y="31.077969" width="457.56" height="382.536"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-fast-yaml.svg
+++ b/docs/public/benchmarks/vs-fast-yaml.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.839134</dc:date>
+    <dc:date>2026-07-06T11:56:45.537672</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 234.933452 38.889969
-L 234.933452 70.14506
+L 236.822907 38.889969
+L 236.822907 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#p1535d50d2c)" style="fill: #24fefd"/>
+" clip-path="url(#p6812f3c5ac)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="237.823305" y="56.725854" transform="rotate(-0 237.823305 56.725854)">1.7x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="239.712759" y="56.725854" transform="rotate(-0 239.712759 56.725854)">1.7x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#p1535d50d2c)" style="fill: #5b626d"/>
+" clip-path="url(#p6812f3c5ac)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">2.5 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">2.9 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 168.4271 127.531748
-L 168.4271 158.786839
+L 175.677625 127.531748
+L 175.677625 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#p1535d50d2c)" style="fill: #24fefd"/>
+" clip-path="url(#p6812f3c5ac)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="171.316953" y="145.367633" transform="rotate(-0 171.316953 145.367633)">2.0x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="178.567478" y="145.367633" transform="rotate(-0 178.567478 145.367633)">1.7x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 241.796195 163.874877
-L 241.796195 195.129969
+L 237.211222 163.874877
+L 237.211222 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#p1535d50d2c)" style="fill: #5b626d"/>
+" clip-path="url(#p6812f3c5ac)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="244.686048" y="181.580548" transform="rotate(-0 244.686048 181.580548)">1.6 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="240.101074" y="181.580548" transform="rotate(-0 240.101074 181.580548)">1.7 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs fast-yaml</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p1535d50d2c">
+  <clipPath id="p6812f3c5ac">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-oyaml.svg
+++ b/docs/public/benchmarks/vs-oyaml.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.997947</dc:date>
+    <dc:date>2026-07-06T11:56:45.704647</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 93.792311 38.889969
-L 93.792311 70.14506
+L 93.750512 38.889969
+L 93.750512 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#pb0cdcce935)" style="fill: #24fefd"/>
+" clip-path="url(#pc13481b58c)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="96.682164" y="56.725854" transform="rotate(-0 96.682164 56.725854)">100x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="96.640365" y="56.725854" transform="rotate(-0 96.640365 56.725854)">102x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#pb0cdcce935)" style="fill: #5b626d"/>
+" clip-path="url(#pc13481b58c)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">151.4 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">176.3 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 92.673866 127.531748
-L 92.673866 158.786839
+L 92.753156 127.531748
+L 92.753156 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#pb0cdcce935)" style="fill: #24fefd"/>
+" clip-path="url(#pc13481b58c)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.563719" y="145.367633" transform="rotate(-0 95.563719 145.367633)">107x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.643009" y="145.367633" transform="rotate(-0 95.643009 145.367633)">106x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 230.434095 163.874877
-L 230.434095 195.129969
+L 236.883943 163.874877
+L 236.883943 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#pb0cdcce935)" style="fill: #5b626d"/>
+" clip-path="url(#pc13481b58c)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="233.323948" y="181.580548" transform="rotate(-0 233.323948 181.580548)">87.4 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="239.773796" y="181.580548" transform="rotate(-0 239.773796 181.580548)">106.5 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs oyaml</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb0cdcce935">
+  <clipPath id="pc13481b58c">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-py-yaml12.svg
+++ b/docs/public/benchmarks/vs-py-yaml12.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.905290</dc:date>
+    <dc:date>2026-07-06T11:56:45.604901</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 194.541525 38.889969
-L 194.541525 70.14506
+L 195.736698 38.889969
+L 195.736698 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#pfe0bf97a6a)" style="fill: #24fefd"/>
+" clip-path="url(#p89eafe20a3)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="197.431378" y="56.725854" transform="rotate(-0 197.431378 56.725854)">2.3x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="198.62655" y="56.725854" transform="rotate(-0 198.62655 56.725854)">2.3x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#pfe0bf97a6a)" style="fill: #5b626d"/>
+" clip-path="url(#p89eafe20a3)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">3.5 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">4.0 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 146.747956 127.531748
-L 146.747956 158.786839
+L 151.864142 127.531748
+L 151.864142 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#pfe0bf97a6a)" style="fill: #24fefd"/>
+" clip-path="url(#p89eafe20a3)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="149.637809" y="145.367633" transform="rotate(-0 149.637809 145.367633)">1.5x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="154.753994" y="145.367633" transform="rotate(-0 154.753994 145.367633)">1.3x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 175.093125 163.874877
-L 175.093125 195.129969
+L 172.74679 163.874877
+L 172.74679 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#pfe0bf97a6a)" style="fill: #5b626d"/>
+" clip-path="url(#p89eafe20a3)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="177.982978" y="181.580548" transform="rotate(-0 177.982978 181.580548)">1.2 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="175.636643" y="181.580548" transform="rotate(-0 175.636643 181.580548)">1.4 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs py-yaml12</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pfe0bf97a6a">
+  <clipPath id="p89eafe20a3">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-pyyaml.svg
+++ b/docs/public/benchmarks/vs-pyyaml.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.730493</dc:date>
+    <dc:date>2026-07-06T11:56:45.430022</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,25 +59,25 @@ L 548.938125 255.609969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 41.283969
-L 93.811018 41.283969
-L 93.811018 68.213817
+L 93.737386 41.283969
+L 93.737386 68.213817
 L 91.378125 68.213817
 z
-" clip-path="url(#pf583515795)" style="fill: #24fefd"/>
+" clip-path="url(#p897639877e)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="96.70087" y="56.956901" transform="rotate(-0 96.70087 56.956901)">1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="96.627239" y="56.956901" transform="rotate(-0 96.627239 56.956901)">1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 72.597746
-L 117.282554 72.597746
-L 117.282554 99.527594
+L 114.590245 72.597746
+L 114.590245 99.527594
 L 91.378125 99.527594
 z
-" clip-path="url(#pf583515795)" style="fill: #5b626d"/>
+" clip-path="url(#p897639877e)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="120.172407" y="88.141107" transform="rotate(-0 120.172407 88.141107)">16.2 ms · 11x slower</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="117.480098" y="88.141107" transform="rotate(-0 117.480098 88.141107)">17.1 ms · 9.8x slower</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 103.911522
@@ -85,43 +85,43 @@ L 332.199178 103.911522
 L 332.199178 130.841371
 L 91.378125 130.841371
 z
-" clip-path="url(#pf583515795)" style="fill: #41464f"/>
+" clip-path="url(#p897639877e)" style="fill: #41464f"/>
    </g>
    <g id="text_5">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="119.454884" transform="rotate(-0 335.08903 119.454884)">150.3 ms · 99x slower</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="119.454884" transform="rotate(-0 335.08903 119.454884)">177.3 ms · 102x slower</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 155.846567
-L 92.683907 155.846567
-L 92.683907 182.776415
+L 92.745548 155.846567
+L 92.745548 182.776415
 L 91.378125 182.776415
 z
-" clip-path="url(#pf583515795)" style="fill: #24fefd"/>
+" clip-path="url(#p897639877e)" style="fill: #24fefd"/>
    </g>
    <g id="text_6">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.573759" y="171.519499" transform="rotate(-0 95.573759 171.519499)">815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.635401" y="171.519499" transform="rotate(-0 95.635401 171.519499)">1.0 ms</text>
    </g>
    <g id="patch_8">
     <path d="M 91.378125 187.160344
-L 115.308489 187.160344
-L 115.308489 214.090192
+L 113.184245 187.160344
+L 113.184245 214.090192
 L 91.378125 214.090192
 z
-" clip-path="url(#pf583515795)" style="fill: #5b626d"/>
+" clip-path="url(#p897639877e)" style="fill: #5b626d"/>
    </g>
    <g id="text_7">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="118.198342" y="202.703705" transform="rotate(-0 118.198342 202.703705)">14.9 ms · 18x slower</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="116.074098" y="202.703705" transform="rotate(-0 116.074098 202.703705)">16.1 ms · 16x slower</text>
    </g>
    <g id="patch_9">
     <path d="M 91.378125 218.474121
-L 230.830332 218.474121
-L 230.830332 245.403969
+L 235.16974 218.474121
+L 235.16974 245.403969
 L 91.378125 245.403969
 z
-" clip-path="url(#pf583515795)" style="fill: #41464f"/>
+" clip-path="url(#p897639877e)" style="fill: #41464f"/>
    </g>
    <g id="text_8">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="233.720184" y="234.017482" transform="rotate(-0 233.720184 234.017482)">87.0 ms · 107x slower</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="238.059592" y="234.017482" transform="rotate(-0 238.059592 234.017482)">105.9 ms · 105x slower</text>
    </g>
    <g id="text_9">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs PyYAML</text>
@@ -164,7 +164,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pf583515795">
+  <clipPath id="p897639877e">
    <rect x="91.378125" y="31.077969" width="457.56" height="224.532"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-ruamel.svg
+++ b/docs/public/benchmarks/vs-ruamel.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.769830</dc:date>
+    <dc:date>2026-07-06T11:56:45.469316</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 92.941517 38.889969
-L 92.941517 70.14506
+L 92.985855 38.889969
+L 92.985855 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#pd7d10d9576)" style="fill: #24fefd"/>
+" clip-path="url(#pcd0a4d2de2)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.83137" y="56.725854" transform="rotate(-0 95.83137 56.725854)">154x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.875708" y="56.725854" transform="rotate(-0 95.875708 56.725854)">150x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#pd7d10d9576)" style="fill: #5b626d"/>
+" clip-path="url(#pcd0a4d2de2)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">233.8 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">260.2 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 92.217228 127.531748
-L 92.217228 158.786839
+L 92.309962 127.531748
+L 92.309962 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#pd7d10d9576)" style="fill: #24fefd"/>
+" clip-path="url(#pcd0a4d2de2)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.107081" y="145.367633" transform="rotate(-0 95.107081 145.367633)">218x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="95.199815" y="145.367633" transform="rotate(-0 95.199815 145.367633)">198x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 274.115196 163.874877
-L 274.115196 195.129969
+L 275.84586 163.874877
+L 275.84586 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#pd7d10d9576)" style="fill: #5b626d"/>
+" clip-path="url(#pcd0a4d2de2)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="277.005049" y="181.580548" transform="rotate(-0 277.005049 181.580548)">177.4 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="278.735713" y="181.580548" transform="rotate(-0 278.735713 181.580548)">199.3 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs ruamel.yaml</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd7d10d9576">
+  <clipPath id="pcd0a4d2de2">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-ryaml.svg
+++ b/docs/public/benchmarks/vs-ryaml.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.872240</dc:date>
+    <dc:date>2026-07-06T11:56:45.571694</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 180.170376 38.889969
-L 180.170376 70.14506
+L 180.45837 38.889969
+L 180.45837 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#pdd2bba842d)" style="fill: #24fefd"/>
+" clip-path="url(#p13115e513c)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="183.060229" y="56.725854" transform="rotate(-0 183.060229 56.725854)">2.7x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="183.348223" y="56.725854" transform="rotate(-0 183.348223 56.725854)">2.7x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#pdd2bba842d)" style="fill: #5b626d"/>
+" clip-path="url(#p13115e513c)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">4.1 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">4.7 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 139.034677 127.531748
-L 139.034677 158.786839
+L 143.008854 127.531748
+L 143.008854 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#pdd2bba842d)" style="fill: #24fefd"/>
+" clip-path="url(#p13115e513c)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="141.92453" y="145.367633" transform="rotate(-0 141.92453 145.367633)">3.5x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="145.898707" y="145.367633" transform="rotate(-0 145.898707 145.367633)">3.4x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 258.778382 163.874877
-L 258.778382 195.129969
+L 264.791905 163.874877
+L 264.791905 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#pdd2bba842d)" style="fill: #5b626d"/>
+" clip-path="url(#p13115e513c)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="261.668235" y="181.580548" transform="rotate(-0 261.668235 181.580548)">2.9 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="267.681758" y="181.580548" transform="rotate(-0 267.681758 181.580548)">3.4 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs ryaml</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pdd2bba842d">
+  <clipPath id="p13115e513c">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-strictyaml.svg
+++ b/docs/public/benchmarks/vs-strictyaml.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.968379</dc:date>
+    <dc:date>2026-07-06T11:56:45.670861</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -53,14 +53,14 @@ L 546.417812 150.273969
    </g>
    <g id="patch_4">
     <path d="M 88.857813 36.495969
-L 89.177875 36.495969
-L 89.177875 86.597904
+L 89.161178 36.495969
+L 89.161178 86.597904
 L 88.857813 86.597904
 z
-" clip-path="url(#p4c529ee2f1)" style="fill: #24fefd"/>
+" clip-path="url(#pcd44e1defc)" style="fill: #24fefd"/>
    </g>
    <g id="text_2">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="92.067728" y="63.755276" transform="rotate(-0 92.067728 63.755276)">752x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="92.051031" y="63.755276" transform="rotate(-0 92.051031 63.755276)">794x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 88.857813 94.754033
@@ -68,10 +68,10 @@ L 329.678865 94.754033
 L 329.678865 144.855969
 L 88.857813 144.855969
 z
-" clip-path="url(#p4c529ee2f1)" style="fill: #5b626d"/>
+" clip-path="url(#pcd44e1defc)" style="fill: #5b626d"/>
    </g>
    <g id="text_3">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="332.568718" y="121.883126" transform="rotate(-0 332.568718 121.883126)">1.14 s</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="332.568718" y="121.883126" transform="rotate(-0 332.568718 121.883126)">1.38 s</text>
    </g>
    <g id="text_4">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="88.857813" y="17.077969" transform="rotate(-0 88.857813 17.077969)">YAMLRocks vs strictyaml</text>
@@ -103,7 +103,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p4c529ee2f1">
+  <clipPath id="pcd44e1defc">
    <rect x="88.857813" y="31.077969" width="457.56" height="119.196"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-yaml-rs.svg
+++ b/docs/public/benchmarks/vs-yaml-rs.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.804532</dc:date>
+    <dc:date>2026-07-06T11:56:45.504241</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 289.437252 38.889969
-L 289.437252 70.14506
+L 293.952994 38.889969
+L 293.952994 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#p2461946bfe)" style="fill: #24fefd"/>
+" clip-path="url(#pd0b157ccd4)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="292.327105" y="56.725854" transform="rotate(-0 292.327105 56.725854)">1.2x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="296.842846" y="56.725854" transform="rotate(-0 296.842846 56.725854)">1.2x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#p2461946bfe)" style="fill: #5b626d"/>
+" clip-path="url(#pd0b157ccd4)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">1.8 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">2.1 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 197.680364 127.531748
-L 197.680364 158.786839
+L 208.790107 127.531748
+L 208.790107 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#p2461946bfe)" style="fill: #24fefd"/>
+" clip-path="url(#pd0b157ccd4)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="200.570217" y="145.367633" transform="rotate(-0 200.570217 145.367633)">1.3x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="211.67996" y="145.367633" transform="rotate(-0 211.67996 145.367633)">1.3x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 230.963801 163.874877
-L 230.963801 195.129969
+L 239.108121 163.874877
+L 239.108121 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#p2461946bfe)" style="fill: #5b626d"/>
+" clip-path="url(#pd0b157ccd4)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="233.853654" y="181.580548" transform="rotate(-0 233.853654 181.580548)">1.1 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="241.997973" y="181.580548" transform="rotate(-0 241.997973 181.580548)">1.3 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs yaml-rs</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2461946bfe">
+  <clipPath id="pd0b157ccd4">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-yamlium.svg
+++ b/docs/public/benchmarks/vs-yamlium.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-04T10:47:56.939731</dc:date>
+    <dc:date>2026-07-06T11:56:45.642640</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -59,14 +59,14 @@ L 548.938125 202.941969
    </g>
    <g id="patch_4">
     <path d="M 91.378125 38.889969
-L 97.510391 38.889969
-L 97.510391 70.14506
+L 97.294223 38.889969
+L 97.294223 70.14506
 L 91.378125 70.14506
 z
-" clip-path="url(#p5363715f76)" style="fill: #24fefd"/>
+" clip-path="url(#p5b26974c03)" style="fill: #24fefd"/>
    </g>
    <g id="text_3">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="100.400244" y="56.725854" transform="rotate(-0 100.400244 56.725854)">39x faster · 1.5 ms</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="100.184076" y="56.725854" transform="rotate(-0 100.184076 56.725854)">41x faster · 1.7 ms</text>
    </g>
    <g id="patch_5">
     <path d="M 91.378125 75.233098
@@ -74,32 +74,32 @@ L 332.199178 75.233098
 L 332.199178 106.48819
 L 91.378125 106.48819
 z
-" clip-path="url(#p5363715f76)" style="fill: #5b626d"/>
+" clip-path="url(#p5b26974c03)" style="fill: #5b626d"/>
    </g>
    <g id="text_4">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">59.6 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="335.08903" y="92.938769" transform="rotate(-0 335.08903 92.938769)">70.7 ms</text>
    </g>
    <g id="patch_6">
     <path d="M 91.378125 127.531748
-L 94.669433 127.531748
-L 94.669433 158.786839
+L 94.807083 127.531748
+L 94.807083 158.786839
 L 91.378125 158.786839
 z
-" clip-path="url(#p5363715f76)" style="fill: #24fefd"/>
+" clip-path="url(#p5b26974c03)" style="fill: #24fefd"/>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="97.559286" y="145.367633" transform="rotate(-0 97.559286 145.367633)">12x faster · 815 µs</text>
+    <text style="font-weight: 700; font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #24fefd" x="97.696936" y="145.367633" transform="rotate(-0 97.696936 145.367633)">11x faster · 1.0 ms</text>
    </g>
    <g id="patch_7">
     <path d="M 91.378125 163.874877
-L 132.066579 163.874877
-L 132.066579 195.129969
+L 128.212935 163.874877
+L 128.212935 195.129969
 L 91.378125 195.129969
 z
-" clip-path="url(#p5363715f76)" style="fill: #5b626d"/>
+" clip-path="url(#p5b26974c03)" style="fill: #5b626d"/>
    </g>
    <g id="text_6">
-    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="134.956432" y="181.580548" transform="rotate(-0 134.956432 181.580548)">10.1 ms</text>
+    <text style="font-size: 8px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="131.102788" y="181.580548" transform="rotate(-0 131.102788 181.580548)">10.8 ms</text>
    </g>
    <g id="text_7">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="91.378125" y="17.077969" transform="rotate(-0 91.378125 17.077969)">YAMLRocks vs yamlium</text>
@@ -131,7 +131,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5363715f76">
+  <clipPath id="p5b26974c03">
    <rect x="91.378125" y="31.077969" width="457.56" height="171.864"/>
   </clipPath>
  </defs>

--- a/docs/src/content/docs/comparisons/index.md
+++ b/docs/src/content/docs/comparisons/index.md
@@ -15,8 +15,8 @@ includes, schema validation, and source tracking on top.
 | ------------------------------------- | :--------------: | :----------: | :--------------------: |
 | YAML 1.2                              |        No        |     Yes      |        **Yes**         |
 | Implementation                        |    C + Python    | Pure Python  |        **Rust**        |
-| Parse speed                           |     C loader     |     slow     | **5-10x vs PyYAML C**  |
-| Dump speed                            |     C dumper     |     slow     | **15-19x vs PyYAML C** |
+| Parse speed                           |     C loader     |     slow     | **6-10x vs PyYAML C**  |
+| Dump speed                            |     C dumper     |     slow     | **17-19x vs PyYAML C** |
 | Comments preserved                    |        No        |     Yes      |        **Yes**         |
 | Byte-for-byte round-trip (unmodified) |        No        |    Close     |        **Yes**         |
 | Native `!include` (+ write-back)      |        No        |      No      |        **Yes**         |
@@ -31,10 +31,10 @@ includes, schema validation, and source tracking on top.
 Release-build benchmarks (`python bench/bench.py`), showing how many times
 faster YAMLRocks is:
 
-- **Parsing**: ~5-10x faster than PyYAML's C loader; ~85-135x faster than ruamel.
-- **Serializing**: ~15-19x faster than PyYAML's C dumper; ~155-210x faster than
+- **Parsing**: ~6-10x faster than PyYAML's C loader; ~105-141x faster than ruamel.
+- **Serializing**: ~17-19x faster than PyYAML's C dumper; ~160-208x faster than
   ruamel.
-- **Split configs with `!include`**: ~18x faster than a PyYAML `!include`
+- **Split configs with `!include`**: ~17x faster than a PyYAML `!include`
   constructor for hundreds of files.
 
 These are ratios, not absolute times, and they vary with payload shape and
@@ -51,17 +51,17 @@ both load and dump. Indicative wall-clock times from `python bench/compare.py`
 
 | Library       |  Impl  |     load |      dump |
 | ------------- | :----: | -------: | --------: |
-| **YAMLRocks** |  Rust  |  ~1.5 ms |   ~815 µs |
-| yaml-rs       |  Rust  |  ~1.8 ms |   ~1.1 ms |
-| fast-yaml     |  Rust  |  ~2.5 ms |   ~1.6 ms |
-| py-yaml12     |  Rust  |  ~3.5 ms |   ~1.2 ms |
-| ryaml         |  Rust  |  ~4.1 ms |   ~2.9 ms |
-| PyYAML (C)    |   C    | ~16.2 ms |  ~14.9 ms |
-| yamlium       | Python | ~59.6 ms |  ~10.1 ms |
-| PyYAML (pure) | Python |  ~150 ms |    ~87 ms |
-| oyaml         | Python |  ~151 ms |    ~87 ms |
-| ruamel.yaml   | Python |  ~234 ms |   ~177 ms |
-| strictyaml    | Python |  ~1.14 s | no dumper |
+| **YAMLRocks** |  Rust  |  ~1.7 ms |   ~1.0 ms |
+| yaml-rs       |  Rust  |  ~2.1 ms |   ~1.3 ms |
+| fast-yaml     |  Rust  |  ~2.9 ms |   ~1.7 ms |
+| py-yaml12     |  Rust  |  ~4.0 ms |   ~1.4 ms |
+| ryaml         |  Rust  |  ~4.7 ms |   ~3.4 ms |
+| PyYAML (C)    |   C    | ~17.1 ms |  ~16.1 ms |
+| yamlium       | Python |   ~71 ms |    ~11 ms |
+| PyYAML (pure) | Python |  ~177 ms |   ~106 ms |
+| oyaml         | Python |  ~177 ms |   ~106 ms |
+| ruamel.yaml   | Python |  ~260 ms |   ~199 ms |
+| strictyaml    | Python |  ~1.38 s | no dumper |
 
 Speed is only half of it. The Rust rivals differ in what they get right: yaml-rs,
 py-yaml12, and ryaml leave `<<` merge keys unresolved, and yaml-rs, py-yaml12, and

--- a/docs/src/content/docs/comparisons/vs-fast-yaml.md
+++ b/docs/src/content/docs/comparisons/vs-fast-yaml.md
@@ -24,7 +24,7 @@ and YAMLRocks is both more complete and faster.
 | Anchors/aliases resolved      |      Yes      |            Yes             |
 | Multi-document streams        |      Yes      |            Yes             |
 | Implementation                | Rust (saphyr) | Rust (own scanner/emitter) |
-| Speed (parse / dump)          |   baseline    |    ~1.6x / ~2.0x faster    |
+| Speed (parse / dump)          |   baseline    |    ~1.7x / ~1.7x faster    |
 
 ## A parser, or a toolkit
 
@@ -53,8 +53,8 @@ directions.
 
 | Operation | fast-yaml | YAMLRocks | YAMLRocks is |
 | --------- | --------: | --------: | -----------: |
-| Reading   |   ~2.5 ms |   ~1.5 ms | ~1.6x faster |
-| Writing   |   ~1.6 ms |   ~815 µs | ~2.0x faster |
+| Reading   |   ~2.9 ms |   ~1.7 ms | ~1.7x faster |
+| Writing   |   ~1.7 ms |   ~1.0 ms | ~1.7x faster |
 
 :::note[Reproduce it]
 Wall-clock times from one machine and payload set. Run `python bench/compare.py`

--- a/docs/src/content/docs/comparisons/vs-oyaml.md
+++ b/docs/src/content/docs/comparisons/vs-oyaml.md
@@ -26,8 +26,8 @@ and it applies here unchanged.
 | Round-trip (byte-for-byte) |        No        |         Yes          |
 | Native `!include`          |        No        |         Yes          |
 | JSON Schema validation     |        No        |         Yes          |
-| Speed (parse)              |     baseline     |     ~100x faster     |
-| Speed (dump)               |     baseline     |     ~105x faster     |
+| Speed (parse)              |     baseline     |     ~104x faster     |
+| Speed (dump)               |     baseline     |     ~107x faster     |
 
 ![YAMLRocks vs oyaml on reading and writing: YAMLRocks is about two orders of magnitude faster, because oyaml is PyYAML underneath.](/benchmarks/vs-oyaml.svg)
 

--- a/docs/src/content/docs/comparisons/vs-py-yaml12.md
+++ b/docs/src/content/docs/comparisons/vs-py-yaml12.md
@@ -22,7 +22,7 @@ schema, and YAMLRocks is both more complete and faster.
 | Multi-document streams        |        Yes        |            Yes             |
 | Merge keys (`<<`)             |        No         |            Yes             |
 | Implementation                |   Rust (saphyr)   | Rust (own scanner/emitter) |
-| Speed (parse / dump)          |     baseline      |    ~2.3x / ~1.5x faster    |
+| Speed (parse / dump)          |     baseline      |    ~2.4x / ~1.4x faster    |
 
 ## A parser, or a toolkit
 
@@ -50,8 +50,8 @@ both directions.
 
 | Operation | py-yaml12 | YAMLRocks | YAMLRocks is |
 | --------- | --------: | --------: | -----------: |
-| Reading   |   ~3.5 ms |   ~1.5 ms | ~2.3x faster |
-| Writing   |   ~1.2 ms |   ~815 µs | ~1.5x faster |
+| Reading   |   ~4.0 ms |   ~1.7 ms | ~2.4x faster |
+| Writing   |   ~1.4 ms |   ~1.0 ms | ~1.4x faster |
 
 :::note[Reproduce it]
 Wall-clock times from one machine and payload set. Run `python bench/compare.py`

--- a/docs/src/content/docs/comparisons/vs-pyyaml.md
+++ b/docs/src/content/docs/comparisons/vs-pyyaml.md
@@ -14,8 +14,8 @@ operation, safe by default, and far more capable.
 | Feature                       |      PyYAML       |            YAMLRocks             |
 | ----------------------------- | :---------------: | :------------------------------: |
 | YAML 1.2                      |   No (1.1 only)   |   Yes (1.2 default, 1.1 mode)    |
-| Speed (parse)                 |     C loader      | ~5-10x faster than the C loader  |
-| Speed (dump)                  |     C dumper      | ~15-19x faster than the C dumper |
+| Speed (parse)                 |     C loader      | ~6-10x faster than the C loader  |
+| Speed (dump)                  |     C dumper      | ~17-19x faster than the C dumper |
 | Comment preservation          |        No         |               Yes                |
 | Round-trip (byte-for-byte)    |        No         |               Yes                |
 | Anchors/aliases preserved     |        No         |               Yes                |
@@ -173,28 +173,28 @@ target; the pure-Python loader is what most environments fall back to.
 
 | Payload               | vs PyYAML (C) | vs PyYAML (pure) |
 | --------------------- | ------------: | ---------------: |
-| small (10 lines)      |    ~7x faster |      ~56x faster |
-| medium (k8s manifest) |    ~8x faster |      ~70x faster |
-| large (500 items)     |   ~10x faster |      ~83x faster |
-| deep (30 levels)      |    ~5x faster |      ~56x faster |
+| small (10 lines)      |    ~8x faster |      ~64x faster |
+| medium (k8s manifest) |    ~9x faster |      ~80x faster |
+| large (500 items)     |   ~10x faster |      ~87x faster |
+| deep (30 levels)      |    ~6x faster |      ~69x faster |
 
 **Serializing (`dumps`)**
 
 | Payload | vs PyYAML (C) | vs PyYAML (pure) |
 | ------- | ------------: | ---------------: |
-| small   |   ~17x faster |      ~86x faster |
-| medium  |   ~16x faster |      ~84x faster |
-| large   |   ~16x faster |      ~82x faster |
-| deep    |   ~17x faster |      ~71x faster |
+| small   |   ~18x faster |      ~94x faster |
+| medium  |   ~18x faster |      ~92x faster |
+| large   |   ~17x faster |      ~86x faster |
+| deep    |   ~17x faster |      ~75x faster |
 
 **Split configuration with `!include`** (Home Assistant style): YAMLRocks's native
 resolver versus a PyYAML `!include` constructor.
 
 | Files | YAMLRocks is |
 | ----- | -----------: |
-| 50    |  ~20x faster |
-| 200   |  ~20x faster |
-| 500   |  ~20x faster |
+| 50    |  ~17x faster |
+| 200   |  ~17x faster |
+| 500   |  ~17x faster |
 
 :::note[These are ratios]
 The numbers above are speed ratios, not wall-clock times. They depend on payload

--- a/docs/src/content/docs/comparisons/vs-ruamel.md
+++ b/docs/src/content/docs/comparisons/vs-ruamel.md
@@ -21,8 +21,8 @@ exhaustive comment surgery, covered honestly below.
 | Anchors/aliases preserved      |           Yes           |               Yes               |
 | Merge keys (`<<`)              |           Yes           |               Yes               |
 | Implementation                 |       Pure Python       |         Rust extension          |
-| Speed (parse)                  |        baseline         |         ~85-135x faster         |
-| Speed (dump)                   |        baseline         |        ~155-210x faster         |
+| Speed (parse)                  |        baseline         |        ~105-141x faster         |
+| Speed (dump)                   |        baseline         |        ~160-208x faster         |
 | Native `!include` + write-back |           No            |               Yes               |
 | Source line/column             |         partial         |      Yes (annotated mode)       |
 | JSON Schema validation         |           No            |               Yes               |
@@ -45,19 +45,19 @@ times **faster YAMLRocks is** than ruamel.yaml in `safe` mode.
 
 | Payload           | YAMLRocks is |
 | ----------------- | -----------: |
-| small             |  ~90x faster |
-| medium            | ~108x faster |
-| large (500 items) | ~133x faster |
-| deep              |  ~85x faster |
+| small             | ~105x faster |
+| medium            | ~124x faster |
+| large (500 items) | ~141x faster |
+| deep              | ~105x faster |
 
 **Serializing (`dumps`)**
 
 | Payload | YAMLRocks is |
 | ------- | -----------: |
-| small   | ~194x faster |
-| medium  | ~185x faster |
-| large   | ~191x faster |
-| deep    | ~156x faster |
+| small   | ~208x faster |
+| medium  | ~201x faster |
+| large   | ~199x faster |
+| deep    | ~163x faster |
 
 ruamel's round-trip mode is heavier still. YAMLRocks's round-trip path stays far
 faster while preserving comments, anchors, and formatting, with byte-for-byte

--- a/docs/src/content/docs/comparisons/vs-ryaml.md
+++ b/docs/src/content/docs/comparisons/vs-ryaml.md
@@ -23,7 +23,7 @@ it is several times faster.
 | Merge keys (`<<`)             |          No          |            Yes             |
 | Anchors/aliases resolved      |         Yes          |            Yes             |
 | Implementation                | Rust (libyaml-safer) | Rust (own scanner/emitter) |
-| Speed (parse / dump)          |       baseline       |    ~2.7x / ~3.6x faster    |
+| Speed (parse / dump)          |       baseline       |    ~2.8x / ~3.4x faster    |
 | Maturity                      |     0.5.x, alpha     |    Battle-tested corpus    |
 
 ## A parser, or a toolkit
@@ -52,8 +52,8 @@ Both are Rust extensions, so this is Rust vs Rust. YAMLRocks is well ahead on bo
 
 | Operation |   ryaml | YAMLRocks | YAMLRocks is |
 | --------- | ------: | --------: | -----------: |
-| Reading   | ~4.1 ms |   ~1.5 ms | ~2.7x faster |
-| Writing   | ~2.9 ms |   ~815 µs | ~3.6x faster |
+| Reading   | ~4.7 ms |   ~1.7 ms | ~2.8x faster |
+| Writing   | ~3.4 ms |   ~1.0 ms | ~3.4x faster |
 
 :::note[Reproduce it]
 Wall-clock times from one machine and payload set. Run `python bench/compare.py`

--- a/docs/src/content/docs/comparisons/vs-strictyaml.md
+++ b/docs/src/content/docs/comparisons/vs-strictyaml.md
@@ -44,7 +44,7 @@ giving up numbers, booleans, or a dumper.
 | Dumping arbitrary data    |  No general dumper   |          Yes          |
 | Comment preservation      |   Yes (via ruamel)   |          Yes          |
 | Implementation            | Pure Python (ruamel) |    Rust extension     |
-| Speed (parse)             |       baseline       |     ~760x faster      |
+| Speed (parse)             |       baseline       |     ~810x faster      |
 
 ## Speed
 
@@ -56,8 +56,8 @@ no general-purpose dumper to benchmark at all.
 
 | Operation | strictyaml | YAMLRocks | YAMLRocks is |
 | --------- | ---------: | --------: | -----------: |
-| load      |    ~1.14 s |   ~1.5 ms | ~760x faster |
-| dump      |  no dumper |   ~815 µs |            - |
+| load      |    ~1.38 s |   ~1.7 ms | ~810x faster |
+| dump      |  no dumper |   ~1.0 ms |            - |
 
 :::note[Reproduce it]
 Wall-clock times from one machine and payload set. Run `python bench/compare.py`

--- a/docs/src/content/docs/comparisons/vs-yaml-rs.md
+++ b/docs/src/content/docs/comparisons/vs-yaml-rs.md
@@ -26,7 +26,7 @@ on top.
 | Merge keys (`<<`)             |             No              |            Yes             |
 | Timestamp resolution          | On by default, incl. quoted | Opt-in, plain scalars only |
 | Implementation                |     Rust (saphyr fork)      | Rust (own scanner/emitter) |
-| Speed (parse / dump)          |          baseline           |    ~1.2x / ~1.4x faster    |
+| Speed (parse / dump)          |          baseline           |    ~1.2x / ~1.3x faster    |
 | Maturity                      |    0.1.x, public domain     |    Battle-tested corpus    |
 
 ## A parser, or a toolkit
@@ -63,8 +63,8 @@ the nearest rival on the field, and YAMLRocks is still ahead on both directions.
 
 | Operation | yaml-rs | YAMLRocks | YAMLRocks is |
 | --------- | ------: | --------: | -----------: |
-| Reading   | ~1.8 ms |   ~1.5 ms | ~1.2x faster |
-| Writing   | ~1.1 ms |   ~815 µs | ~1.4x faster |
+| Reading   | ~2.1 ms |   ~1.7 ms | ~1.2x faster |
+| Writing   | ~1.3 ms |   ~1.0 ms | ~1.3x faster |
 
 The gap is smaller than against a pure-Python library, as you would expect from
 two native implementations. Speed is real, but it is not the reason to choose

--- a/docs/src/content/docs/comparisons/vs-yamlium.md
+++ b/docs/src/content/docs/comparisons/vs-yamlium.md
@@ -22,7 +22,7 @@ schema validation that yamlium has no equivalent for.
 | Declared YAML version         |  Undocumented   |  1.2 (1.1 optional)  |
 | Anchors / merge keys          | Preserved / yes |   Preserved / yes    |
 | Implementation                |   Pure Python   |    Rust extension    |
-| Speed (parse / dump)          |    baseline     |  ~40x / ~12x faster  |
+| Speed (parse / dump)          |    baseline     |  ~42x / ~11x faster  |
 
 ## Speed: Rust vs pure Python
 
@@ -31,10 +31,10 @@ work in Rust, one to two orders of magnitude faster on both directions.
 
 ![YAMLRocks vs yamlium on reading and writing: YAMLRocks is an order of magnitude faster on both loads and dumps.](/benchmarks/vs-yamlium.svg)
 
-| Operation |  yamlium | YAMLRocks | YAMLRocks is |
-| --------- | -------: | --------: | -----------: |
-| Reading   | ~59.6 ms |   ~1.5 ms |  ~40x faster |
-| Writing   | ~10.1 ms |   ~815 µs |  ~12x faster |
+| Operation | yamlium | YAMLRocks | YAMLRocks is |
+| --------- | ------: | --------: | -----------: |
+| Reading   |  ~71 ms |   ~1.7 ms |  ~42x faster |
+| Writing   |  ~11 ms |   ~1.0 ms |  ~11x faster |
 
 :::note[Reproduce it]
 Wall-clock times from one machine and payload set. Run `python bench/compare.py`

--- a/docs/src/content/docs/guides/performance.md
+++ b/docs/src/content/docs/guides/performance.md
@@ -18,9 +18,9 @@ Your hardware, payload, and Python version will move them around.
 Loading and dumping a representative set of payloads once, across ten YAML
 libraries. Lower is faster, and the scale is logarithmic, so each gridline is 10x.
 
-![Parsing throughput across libraries: YAMLRocks is fastest, ahead of yaml_rs, py-yaml12, ryaml, PyYAML's C loader, and far ahead of the pure-Python libraries.](/benchmarks/load.svg)
+![Parsing throughput across libraries: YAMLRocks is fastest, ahead of yaml_rs, fast-yaml, py-yaml12, ryaml, PyYAML's C loader, and far ahead of the pure-Python libraries.](/benchmarks/load.svg)
 
-![Serializing throughput across libraries: YAMLRocks is fastest, ahead of yaml_rs, py-yaml12, ryaml, yamlium, PyYAML's C dumper, and the pure-Python libraries.](/benchmarks/dump.svg)
+![Serializing throughput across libraries: YAMLRocks is fastest, ahead of yaml_rs, py-yaml12, fast-yaml, ryaml, yamlium, PyYAML's C dumper, and the pure-Python libraries.](/benchmarks/dump.svg)
 
 YAMLRocks leads on both. The closest contenders are the other Rust-backed parsers
 (`yaml_rs`, `ryaml`, `py-yaml12`), and the comparison is not quite like for like:
@@ -40,13 +40,13 @@ the other libraries' release wheels).
 
 Every figure below is how many times **faster YAMLRocks is** than the named library.
 
-- **Parsing**: YAMLRocks is **~5-10x faster than PyYAML's C `CSafeLoader`**, ~55-85x
-  faster than pure-Python PyYAML, ~85-135x faster than ruamel.yaml, and ~22-33x
+- **Parsing**: YAMLRocks is **~6-10x faster than PyYAML's C `CSafeLoader`**, ~64-87x
+  faster than pure-Python PyYAML, ~105-141x faster than ruamel.yaml, and ~27-34x
   faster than yamlium.
-- **Serializing**: YAMLRocks is **~15-19x faster than PyYAML's C `CSafeDumper`**,
-  ~70-90x faster than pure-Python PyYAML, ~155-210x faster than ruamel.yaml, and
-  ~8-14x faster than yamlium.
-- **Native includes**: YAMLRocks is **~18x faster** than a PyYAML `!include`
+- **Serializing**: YAMLRocks is **~17-19x faster than PyYAML's C `CSafeDumper`**,
+  ~75-94x faster than pure-Python PyYAML, ~160-208x faster than ruamel.yaml, and
+  ~8-12x faster than yamlium.
+- **Native includes**: YAMLRocks is **~17x faster** than a PyYAML `!include`
   constructor for configurations split across hundreds of files, exactly the
   Home Assistant startup and reload pattern.
 
@@ -59,10 +59,10 @@ How many times faster YAMLRocks is at parsing each payload:
 
 | Payload               | vs PyYAML (C) | vs PyYAML (pure) |    vs ruamel |  vs yamlium |
 | --------------------- | ------------: | ---------------: | -----------: | ----------: |
-| small (10 lines)      |    ~7x faster |      ~56x faster |  ~90x faster | ~25x faster |
-| medium (k8s manifest) |    ~8x faster |      ~70x faster | ~108x faster | ~27x faster |
-| large (500 items)     |   ~10x faster |      ~83x faster | ~133x faster | ~32x faster |
-| deep (30 levels)      |    ~5x faster |      ~56x faster |  ~85x faster | ~22x faster |
+| small (10 lines)      |    ~8x faster |      ~64x faster | ~105x faster | ~28x faster |
+| medium (k8s manifest) |    ~9x faster |      ~80x faster | ~124x faster | ~31x faster |
+| large (500 items)     |   ~10x faster |      ~87x faster | ~141x faster | ~34x faster |
+| deep (30 levels)      |    ~6x faster |      ~69x faster | ~105x faster | ~27x faster |
 
 ## Serializing (`dumps`)
 
@@ -70,10 +70,10 @@ How many times faster YAMLRocks is at serializing each payload:
 
 | Payload | vs PyYAML (C) | vs PyYAML (pure) |    vs ruamel |  vs yamlium |
 | ------- | ------------: | ---------------: | -----------: | ----------: |
-| small   |   ~17x faster |      ~86x faster | ~194x faster | ~11x faster |
-| medium  |   ~16x faster |      ~84x faster | ~185x faster | ~11x faster |
-| large   |   ~16x faster |      ~82x faster | ~191x faster | ~13x faster |
-| deep    |   ~17x faster |      ~71x faster | ~156x faster |  ~8x faster |
+| small   |   ~18x faster |      ~94x faster | ~208x faster | ~11x faster |
+| medium  |   ~18x faster |      ~92x faster | ~201x faster | ~12x faster |
+| large   |   ~17x faster |      ~86x faster | ~199x faster | ~12x faster |
+| deep    |   ~17x faster |      ~75x faster | ~163x faster |  ~8x faster |
 
 yamlium emits comparatively quickly, so its dump gap is the smallest of the four,
 but YAMLRocks still leads on every shape. The margin narrows as individual strings
@@ -88,9 +88,9 @@ How many times faster YAMLRocks's native include resolver is than a PyYAML
 
 | Files | YAMLRocks is |
 | ----- | -----------: |
-| 50    |  ~18x faster |
-| 200   |  ~18x faster |
-| 500   |  ~18x faster |
+| 50    |  ~17x faster |
+| 200   |  ~17x faster |
+| 500   |  ~17x faster |
 
 The constructor approach re-enters the Python parser once per file and rebuilds
 the loader machinery each time. YAMLRocks resolves the whole include graph in Rust

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -42,9 +42,9 @@ feedback. See [stability and roadmap](/stability-roadmap/) for the 1.0 contract.
 
 <CardGrid>
   <Card title="Fast" icon="rocket">
-    Parsing runs about 5 to 10 times faster than PyYAML's C loader, and dumping
-    about 15 to 19 times faster. Native `!include` resolution over hundreds of
-    files is roughly 18 times faster than a PyYAML constructor.
+    Parsing runs about 6 to 10 times faster than PyYAML's C loader, and dumping
+    about 17 to 19 times faster. Native `!include` resolution over hundreds of
+    files is roughly 17 times faster than a PyYAML constructor.
   </Card>
   <Card title="Correct" icon="approve-check">
     A custom YAML 1.2 scanner and parser that passes the complete official YAML
@@ -162,21 +162,21 @@ behind. Release-build benchmarks, showing how many times faster YAMLRocks is:
       <td>
         Parse (<code>loads</code>)
       </td>
-      <td>~5-10x faster</td>
-      <td>~85-135x faster</td>
+      <td>~6-10x faster</td>
+      <td>~105-141x faster</td>
     </tr>
     <tr>
       <td>
         Serialize (<code>dumps</code>)
       </td>
-      <td>~15-19x faster</td>
-      <td>~155-210x faster</td>
+      <td>~17-19x faster</td>
+      <td>~160-208x faster</td>
     </tr>
     <tr>
       <td>
         Split config (<code>!include</code>)
       </td>
-      <td>~18x faster</td>
+      <td>~17x faster</td>
       <td>n/a</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Breaking change

None. Documentation and benchmark-asset refresh only.

## Proposed change

Regenerates the benchmark charts and updates every written benchmark figure to the current build, on this machine. After this session's loads-path work (quoted and block scalar scanning, the multi-document key cache, SIMD), the published numbers had drifted, they were measured against an older build and an older field.

- **Charts**: all 12 `docs/public/benchmarks/*.svg` re-rendered with `just charts` (load, dump, and the nine `vs-<lib>` head-to-heads).
- **Written numbers**: `guides/performance.md` (parse/dump/includes tables, headline ranges, chart alt-text), `comparisons/index.md` (ratio summary, feature-table speed rows, the cross-library ms table), `vs-pyyaml.md` (feature rows + per-payload tables), all eight `vs-<lib>.md` (head-to-head tables + speed rows), `README.md`, and the landing `index.mdx`.

Loads ratios held or improved across the board (parse vs PyYAML's C loader ~5-10x to ~6-10x, vs ruamel ~85-135x to ~105-141x). The dump ratios against the fastest Rust competitors are slightly tighter than the old docs claimed: the dump path was not touched this session, so this reflects those pinned competitors getting faster at dumping since the docs were last generated, not a regression here. YAMLRocks still leads every library on both operations.

Numbers are one machine, best-of-many per measurement (`bench/compare.py`), and reproduce within ~1-2% across runs. The text figures match the freshly rendered charts.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
