### PR TITLE
🐛 Collect repeated deferred `<<` merge keys instead of dropping all but one

### DIFF
--- a/src/decode/merge.rs
+++ b/src/decode/merge.rs
@@ -143,6 +143,10 @@ fn apply_merge_keys_inner(value: &mut Value<'_>) {
             // O(1) membership, so a `<<` over a large mapping stays linear.
             let mut result: Vec<(Value<'_>, Value<'_>)> = Vec::with_capacity(pairs.len());
             let mut index: HashMap<String, usize> = HashMap::new();
+            // The slot holding a preserved (deferred) `<<` value, tracked apart
+            // from `index` so a later preserved `<<` collects into it without a key
+            // signature lookup that a literal quoted `"<<"` key could occupy.
+            let mut preserved_slot: Option<usize> = None;
             for (key, val) in std::mem::take(pairs) {
                 if is_merge_key(&key) {
                     if let Some(unmerged) = merge_into(&mut result, &mut index, val) {
@@ -152,21 +156,27 @@ fn apply_merge_keys_inner(value: &mut Value<'_>) {
                         // the host). Keep it under the literal `<<` key rather than
                         // dropping it, so the host can run its own merge pass. (The
                         // marker is internal; it must not escape into the data.)
-                        let sig = key_sig(&literal_merge_key());
-                        match index.entry(sig) {
-                            Entry::Vacant(slot) => {
-                                slot.insert(result.len());
-                                result.push((literal_merge_key(), unmerged));
-                            }
-                            // A second preserved `<<` in the same mapping: a
-                            // mapping holds one `<<` slot, so collect into a
-                            // single `<<` sequence in document order rather than
-                            // dropping all but the first, matching the sequence
-                            // form and the annotated/round-trip paths. The host
-                            // applies its own merge semantics over the list.
-                            Entry::Occupied(slot) => {
-                                let idx = *slot.get();
-                                collect_preserved(&mut result[idx].1, unmerged);
+                        match preserved_slot {
+                            // A second preserved `<<` in the same mapping: a mapping
+                            // holds one `<<` slot, so collect into a single `<<`
+                            // sequence in document order rather than dropping all
+                            // but the first, matching the sequence form and the
+                            // annotated/round-trip paths. The host applies its own
+                            // merge semantics over the list.
+                            Some(idx) => collect_preserved(&mut result[idx].1, unmerged),
+                            // First preserved `<<`. Claim the literal slot only if
+                            // free: an explicit quoted `"<<"` key already there is
+                            // real data and wins (a mapping holds one `<<`), so keep
+                            // it and drop the merge rather than corrupting it.
+                            None => {
+                                if let Entry::Vacant(slot) =
+                                    index.entry(key_sig(&literal_merge_key()))
+                                {
+                                    let idx = result.len();
+                                    slot.insert(idx);
+                                    preserved_slot = Some(idx);
+                                    result.push((literal_merge_key(), unmerged));
+                                }
                             }
                         }
                     }
@@ -175,7 +185,15 @@ fn apply_merge_keys_inner(value: &mut Value<'_>) {
                     match index.get(&sig) {
                         // An explicit key already merged in: override its value in
                         // place, keeping the position it first appeared at.
-                        Some(&i) => result[i].1 = val,
+                        Some(&i) => {
+                            result[i].1 = val;
+                            // An explicit `"<<"` key overwrote the preserved slot; it
+                            // is plain data now, so later merges must not collect
+                            // into it.
+                            if preserved_slot == Some(i) {
+                                preserved_slot = None;
+                            }
+                        }
                         None => {
                             index.insert(sig, result.len());
                             result.push((key, val));
@@ -348,6 +366,23 @@ mod tests {
             get(&doc, "<<"),
             Some(&Value::Sequence(vec![s("a"), s("b")]))
         );
+    }
+
+    #[test]
+    fn explicit_quoted_merge_key_wins_over_a_preserved_merge() {
+        // A quoted `"<<"` is a literal string key, not a merge marker. It must
+        // never be rewritten into a preserved-merge sequence: the explicit data
+        // wins and the (unmergeable) merge is dropped, whichever order they
+        // appear in, so the literal value is never corrupted.
+        let tagged = || Value::Tagged("!t".to_owned(), Box::new(s("x")));
+        // Explicit first, then a deferred merge.
+        let mut doc = Value::Mapping(vec![(s("<<"), Value::Int(1)), (merge_key(), tagged())]);
+        apply_merge_keys(&mut doc);
+        assert_eq!(get(&doc, "<<"), Some(&Value::Int(1)));
+        // Deferred merge first, then the explicit key overwrites it.
+        let mut doc = Value::Mapping(vec![(merge_key(), tagged()), (s("<<"), Value::Int(1))]);
+        apply_merge_keys(&mut doc);
+        assert_eq!(get(&doc, "<<"), Some(&Value::Int(1)));
     }
 
     #[test]

--- a/src/decode/merge.rs
+++ b/src/decode/merge.rs
@@ -153,9 +153,21 @@ fn apply_merge_keys_inner(value: &mut Value<'_>) {
                         // dropping it, so the host can run its own merge pass. (The
                         // marker is internal; it must not escape into the data.)
                         let sig = key_sig(&literal_merge_key());
-                        if let Entry::Vacant(slot) = index.entry(sig) {
-                            slot.insert(result.len());
-                            result.push((literal_merge_key(), unmerged));
+                        match index.entry(sig) {
+                            Entry::Vacant(slot) => {
+                                slot.insert(result.len());
+                                result.push((literal_merge_key(), unmerged));
+                            }
+                            // A second preserved `<<` in the same mapping: a
+                            // mapping holds one `<<` slot, so collect into a
+                            // single `<<` sequence in document order rather than
+                            // dropping all but the first, matching the sequence
+                            // form and the annotated/round-trip paths. The host
+                            // applies its own merge semantics over the list.
+                            Entry::Occupied(slot) => {
+                                let idx = *slot.get();
+                                collect_preserved(&mut result[idx].1, unmerged);
+                            }
                         }
                     }
                 } else {
@@ -215,6 +227,25 @@ fn dedup_last_wins<'i>(pairs: Vec<(Value<'i>, Value<'i>)>) -> Vec<(Value<'i>, Va
         }
     }
     out
+}
+
+/// Collect a later preserved `<<` value into the one already under the literal
+/// merge key, building a single `<<` sequence in document order. Nothing is
+/// merged here: the values are deferred (a custom tag the host resolves), so we
+/// only gather them so the host can apply its own merge semantics over the list.
+/// A sequence value is flattened one level, so repeated deferred `<<`
+/// (`<<: a` / `<<: b`) and the sequence form (`<<: [a, b]`) produce the same
+/// shape, and the host sees every value instead of silently losing all but one.
+fn collect_preserved<'i>(existing: &mut Value<'i>, new: Value<'i>) {
+    let mut items = match std::mem::replace(existing, Value::Null) {
+        Value::Sequence(items) => items,
+        other => vec![other],
+    };
+    match new {
+        Value::Sequence(more) => items.extend(more),
+        other => items.push(other),
+    }
+    *existing = Value::Sequence(items);
 }
 
 /// Merge a `<<` value (a mapping, or a sequence of mappings) into `result`,
@@ -304,6 +335,34 @@ mod tests {
         assert_eq!(get(&doc, "c"), Some(&Value::Int(3)));
         // The `<<` key itself is consumed.
         assert_eq!(get(&doc, "<<"), None);
+    }
+
+    #[test]
+    fn repeated_unmergeable_merge_keys_collect_into_a_sequence() {
+        // Two `<<` whose values cannot be folded (a deferred tag, a scalar)
+        // collapse to one `<<` slot; keep both as a sequence in document order
+        // rather than dropping all but the first.
+        let mut doc = Value::Mapping(vec![(merge_key(), s("a")), (merge_key(), s("b"))]);
+        apply_merge_keys(&mut doc);
+        assert_eq!(
+            get(&doc, "<<"),
+            Some(&Value::Sequence(vec![s("a"), s("b")]))
+        );
+    }
+
+    #[test]
+    fn repeated_merge_flattens_a_preserved_sequence_one_level() {
+        // A `<<` sequence's leftovers meeting a later `<<` flatten into the same
+        // sequence, matching the shape the `<<: [a, b]` form already produces.
+        let mut doc = Value::Mapping(vec![
+            (merge_key(), Value::Sequence(vec![s("a"), s("b")])),
+            (merge_key(), s("c")),
+        ]);
+        apply_merge_keys(&mut doc);
+        assert_eq!(
+            get(&doc, "<<"),
+            Some(&Value::Sequence(vec![s("a"), s("b"), s("c")]))
+        );
     }
 
     #[test]

--- a/src/ffi/convert/annotate.rs
+++ b/src/ffi/convert/annotate.rs
@@ -8,7 +8,7 @@ use crate::ffi::types::{YAMLRocksAnnotatedDict, YAMLRocksAnnotatedList};
 use crate::resolver::{ResolvedValue, Schema};
 use crate::roundtrip::value::{
     is_ast_merge_key, key_is_collection, mapping_has_merge_key, merge_converted_into,
-    node_to_python_cached, node_to_python_key, ObjectCache,
+    node_to_python_cached, node_to_python_key, store_preserved_merge, ObjectCache,
 };
 use crate::roundtrip::{YamlNode, YamlNodeKind};
 use crate::scanner::ScalarStyle;
@@ -263,9 +263,7 @@ fn annotate_node_cached_inner(
                             annotate_numbers,
                             cache,
                         )?;
-                        if !dict.contains(&py_key)? {
-                            dict.set_item(py_key, preserve)?;
-                        }
+                        store_preserved_merge(dict, py_key.into_bound(py), preserve)?;
                     }
                     continue;
                 }
@@ -490,9 +488,7 @@ fn node_to_python_with_tags_cached_inner(
                     if let Some(preserve) = merge_converted_into(&dict, py_val.bind(py))? {
                         let py_key =
                             node_to_python_with_tags_cached(py, key, schema, tags, anchors, cache)?;
-                        if !dict.contains(&py_key)? {
-                            dict.set_item(py_key, preserve)?;
-                        }
+                        store_preserved_merge(&dict, py_key.into_bound(py), preserve)?;
                     }
                     continue;
                 }

--- a/src/ffi/convert/annotate.rs
+++ b/src/ffi/convert/annotate.rs
@@ -7,8 +7,9 @@ use pyo3::types::{PyDict, PyFloat, PyList};
 use crate::ffi::types::{YAMLRocksAnnotatedDict, YAMLRocksAnnotatedList};
 use crate::resolver::{ResolvedValue, Schema};
 use crate::roundtrip::value::{
-    is_ast_merge_key, key_is_collection, mapping_has_merge_key, merge_converted_into,
-    node_to_python_cached, node_to_python_key, store_preserved_merge, ObjectCache,
+    is_ast_merge_key, is_literal_merge_key_text, key_is_collection, mapping_has_merge_key,
+    merge_converted_into, node_to_python_cached, node_to_python_key, store_preserved_merge,
+    ObjectCache,
 };
 use crate::roundtrip::{YamlNode, YamlNodeKind};
 use crate::scanner::ScalarStyle;
@@ -237,6 +238,7 @@ fn annotate_node_cached_inner(
             let obj = Bound::new(py, init)?;
             let dict = obj.as_any().cast::<PyDict>()?;
             let has_merge = mapping_has_merge_key(pairs);
+            let mut preserved_merge = false;
             for (key, val) in pairs {
                 let py_val = annotate_node_cached(
                     py,
@@ -263,7 +265,12 @@ fn annotate_node_cached_inner(
                             annotate_numbers,
                             cache,
                         )?;
-                        store_preserved_merge(dict, py_key.into_bound(py), preserve)?;
+                        store_preserved_merge(
+                            dict,
+                            py_key.into_bound(py),
+                            preserve,
+                            &mut preserved_merge,
+                        )?;
                     }
                     continue;
                 }
@@ -296,6 +303,11 @@ fn annotate_node_cached_inner(
                     )?
                 };
                 dict.set_item(py_key, py_val)?;
+                // An explicit `"<<"` overwrote the preserved slot; it is plain
+                // data now, so later merges must not collect into it.
+                if preserved_merge && is_literal_merge_key_text(key) {
+                    preserved_merge = false;
+                }
             }
             Ok(obj.into_any().unbind())
         }
@@ -481,6 +493,7 @@ fn node_to_python_with_tags_cached_inner(
         YamlNodeKind::Mapping(pairs) => {
             let dict = PyDict::new(py);
             let has_merge = mapping_has_merge_key(pairs);
+            let mut preserved_merge = false;
             for (key, val) in pairs {
                 let py_val =
                     node_to_python_with_tags_cached(py, val, schema, tags, anchors, cache)?;
@@ -488,7 +501,12 @@ fn node_to_python_with_tags_cached_inner(
                     if let Some(preserve) = merge_converted_into(&dict, py_val.bind(py))? {
                         let py_key =
                             node_to_python_with_tags_cached(py, key, schema, tags, anchors, cache)?;
-                        store_preserved_merge(&dict, py_key.into_bound(py), preserve)?;
+                        store_preserved_merge(
+                            &dict,
+                            py_key.into_bound(py),
+                            preserve,
+                            &mut preserved_merge,
+                        )?;
                     }
                     continue;
                 }
@@ -505,6 +523,11 @@ fn node_to_python_with_tags_cached_inner(
                     node_to_python_with_tags_cached(py, key, schema, tags, anchors, cache)?
                 };
                 dict.set_item(py_key, py_val)?;
+                // An explicit `"<<"` overwrote the preserved slot; it is plain
+                // data now, so later merges must not collect into it.
+                if preserved_merge && is_literal_merge_key_text(key) {
+                    preserved_merge = false;
+                }
             }
             dict.into_any().unbind()
         }

--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -166,9 +166,7 @@ fn node_to_python_cached_inner(
                                 anchors,
                                 cache,
                             );
-                            if !dict.contains(&py_key).unwrap() {
-                                dict.set_item(py_key, preserve).unwrap();
-                            }
+                            store_preserved_merge(&dict, py_key.into_bound(py), preserve).unwrap();
                         }
                     } else {
                         // An explicit key wins over a merge, so it overwrites.
@@ -268,6 +266,46 @@ pub(crate) fn merge_converted_into<'py>(
     } else {
         Ok(Some(source.clone()))
     }
+}
+
+/// Store a preserved (deferred / unmergeable) `<<` value under the literal merge
+/// key. The first one is stored as-is; a later `<<` in the same mapping is
+/// collected with it into a single `<<` list in document order, matching the
+/// sequence form (`<<: [a, b]`), because a Python `dict` cannot hold two `<<`
+/// slots and the host must see both to run its own merge over them. Nothing is
+/// merged here: the values are deferred, so we only gather them and leave the
+/// merge semantics to the host. A preserved value that is already a list
+/// (leftovers from a `<<` sequence) is flattened one level rather than nested.
+/// Assigning an equal key leaves the original key object in place, so the first
+/// `<<` node's annotation is kept.
+pub(crate) fn store_preserved_merge<'py>(
+    dict: &Bound<'py, PyDict>,
+    key: Bound<'py, PyAny>,
+    preserve: Bound<'py, PyAny>,
+) -> PyResult<()> {
+    let Some(existing) = dict.get_item(&key)? else {
+        dict.set_item(key, preserve)?;
+        return Ok(());
+    };
+    // A second preserved `<<`: collect into one list, in document order.
+    let list = if let Ok(list) = existing.cast::<PyList>() {
+        list.clone()
+    } else {
+        let list = PyList::empty(dict.py());
+        list.append(&existing)?;
+        dict.set_item(&key, &list)?;
+        list
+    };
+    // Flatten a preserved list (leftovers from a `<<` sequence) one level in,
+    // rather than nesting it, so the shape matches the sequence merge form.
+    if let Ok(items) = preserve.cast::<PyList>() {
+        for item in items.iter() {
+            list.append(item)?;
+        }
+    } else {
+        list.append(&preserve)?;
+    }
+    Ok(())
 }
 
 /// Whether a mapping-key node is (or, for an alias, resolves to) a collection.

--- a/src/roundtrip/value.rs
+++ b/src/roundtrip/value.rs
@@ -148,6 +148,7 @@ fn node_to_python_cached_inner(
         YamlNodeKind::Mapping(pairs) => {
             let dict = PyDict::new(py);
             if mapping_has_merge_key(pairs) {
+                let mut preserved_merge = false;
                 for (key, val) in pairs {
                     let py_val =
                         node_to_python_cached(py, val, schema, resolve_timestamps, anchors, cache);
@@ -166,7 +167,13 @@ fn node_to_python_cached_inner(
                                 anchors,
                                 cache,
                             );
-                            store_preserved_merge(&dict, py_key.into_bound(py), preserve).unwrap();
+                            store_preserved_merge(
+                                &dict,
+                                py_key.into_bound(py),
+                                preserve,
+                                &mut preserved_merge,
+                            )
+                            .unwrap();
                         }
                     } else {
                         // An explicit key wins over a merge, so it overwrites.
@@ -175,6 +182,11 @@ fn node_to_python_cached_inner(
                             py_val,
                         )
                         .unwrap();
+                        // An explicit `"<<"` overwrote the preserved slot; it is
+                        // plain data now, so later merges must not collect into it.
+                        if preserved_merge && is_literal_merge_key_text(key) {
+                            preserved_merge = false;
+                        }
                     }
                 }
             } else {
@@ -278,16 +290,32 @@ pub(crate) fn merge_converted_into<'py>(
 /// (leftovers from a `<<` sequence) is flattened one level rather than nested.
 /// Assigning an equal key leaves the original key object in place, so the first
 /// `<<` node's annotation is kept.
+///
+/// `preserved` tracks whether the `<<` slot already holds a preserved merge, so a
+/// later `<<` collects into it rather than into an explicit quoted `"<<"` key. On
+/// the first preserved `<<`, an explicit `"<<"` already in the dict is real data
+/// and wins (a dict holds one `<<`): keep it and drop the merge rather than
+/// corrupting it. The caller clears `preserved` when an explicit `"<<"` later
+/// overwrites the slot, so the paths agree with the fast path.
 pub(crate) fn store_preserved_merge<'py>(
     dict: &Bound<'py, PyDict>,
     key: Bound<'py, PyAny>,
     preserve: Bound<'py, PyAny>,
+    preserved: &mut bool,
 ) -> PyResult<()> {
-    let Some(existing) = dict.get_item(&key)? else {
-        dict.set_item(key, preserve)?;
+    if !*preserved {
+        // No preserved merge in the `<<` slot yet. Only claim it when free; an
+        // explicit `"<<"` key already there is real data and wins.
+        if !dict.contains(&key)? {
+            dict.set_item(key, preserve)?;
+            *preserved = true;
+        }
         return Ok(());
-    };
+    }
     // A second preserved `<<`: collect into one list, in document order.
+    let existing = dict
+        .get_item(&key)?
+        .expect("preserved `<<` slot is populated");
     let list = if let Ok(list) = existing.cast::<PyList>() {
         list.clone()
     } else {
@@ -306,6 +334,15 @@ pub(crate) fn store_preserved_merge<'py>(
         list.append(&preserve)?;
     }
     Ok(())
+}
+
+/// Whether a mapping-key node is a literal `"<<"` (a quoted scalar whose text is
+/// `<<`), as opposed to a plain `<<` merge directive (which [`is_ast_merge_key`]
+/// catches). Used to clear the preserved-merge slot flag when such an explicit
+/// key overwrites the `<<` slot, so a later preserved `<<` does not collect into
+/// real data.
+pub(crate) fn is_literal_merge_key_text(key: &YamlNode) -> bool {
+    matches!(&key.kind, YamlNodeKind::Scalar(text, _) if text == "<<") && !is_ast_merge_key(key)
 }
 
 /// Whether a mapping-key node is (or, for an alias, resolves to) a collection.

--- a/tests/core/test_merge_keys.py
+++ b/tests/core/test_merge_keys.py
@@ -251,12 +251,20 @@ def test_repeated_unmergeable_merge_keys_collect_into_a_list():
     tags = {"!x": lambda v: f"<{v}>"}
     src = b"<<: !x a\n<<: !x b\n"
     expected = {"<<": ["<a>", "<b>"]}
-    # Fast path and annotated path resolve the tag and collect identically.
+    # All three tag-resolving paths collect identically: fast, annotated, and
+    # the includes/tagged converter.
     assert yamlrocks.loads(src, tags=tags) == expected
     assert (
         dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED, tags=tags))
         == expected
     )
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES, tags=tags) == expected
+    # The round-trip `to_dict()` path does not run the tag callback, so the
+    # deferred values stay as their scalar text, but they still collect into one
+    # list in document order.
+    assert yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict() == {
+        "<<": ["a", "b"]
+    }
     # The sequence form already produced this shape and still does.
     assert yamlrocks.loads(b"<<: [!x a, !x b]\n", tags=tags) == expected
     # ESPHome's exact option combination (the reported case).
@@ -271,11 +279,37 @@ def test_repeated_unmergeable_merge_keys_collect_into_a_list():
 
 def test_repeated_merge_flattens_a_preserved_sequence_one_level():
     """A `<<` sequence value meeting a later `<<` flattens into one list rather
-    than nesting, so either order yields the same flat sequence."""
+    than nesting, so either order yields the same flat sequence, on every path."""
     tags = {"!x": lambda v: f"<{v}>"}
     flat = {"<<": ["<a>", "<b>", "<c>"]}
-    assert yamlrocks.loads(b"<<: [!x a, !x b]\n<<: !x c\n", tags=tags) == flat
-    assert yamlrocks.loads(b"<<: !x a\n<<: [!x b, !x c]\n", tags=tags) == flat
+    for src in (b"<<: [!x a, !x b]\n<<: !x c\n", b"<<: !x a\n<<: [!x b, !x c]\n"):
+        assert yamlrocks.loads(src, tags=tags) == flat
+        assert (
+            dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED, tags=tags))
+            == flat
+        )
+        assert yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES, tags=tags) == flat
+
+
+def test_explicit_quoted_merge_key_is_not_corrupted_by_a_deferred_merge():
+    """A quoted `"<<"` is a literal string key, not a merge marker, so a deferred
+    `<<` must never rewrite it into a collected sequence. The explicit data wins
+    and the unmergeable merge is dropped (a dict holds one `<<`), whichever order
+    they appear in, on every path."""
+    tags = {"!x": lambda v: f"<{v}>"}
+    expected = {"<<": "explicit"}
+    for src in (b'"<<": explicit\n<<: !x a\n', b'<<: !x a\n"<<": explicit\n'):
+        assert yamlrocks.loads(src, tags=tags) == expected
+        assert (
+            dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED, tags=tags))
+            == expected
+        )
+        assert (
+            yamlrocks.loads(src, option=yamlrocks.OPT_INCLUDES, tags=tags) == expected
+        )
+        assert (
+            yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict() == expected
+        )
 
 
 def test_repeated_merge_mixes_mergeable_and_deferred():

--- a/tests/core/test_merge_keys.py
+++ b/tests/core/test_merge_keys.py
@@ -239,3 +239,54 @@ def test_null_merge_value_is_dropped_on_every_path():
             yamlrocks.loads(src, option=yamlrocks.OPT_ROUND_TRIP).to_dict()["base"]
             == expected
         )
+
+
+def test_repeated_unmergeable_merge_keys_collect_into_a_list():
+    """A mapping may carry `<<` more than once (`<<: !include a` / `<<: !include
+    b`). When the values are deferred (resolved by the host, not mergeable here),
+    a Python dict cannot hold two `<<` slots, so both are kept under one `<<` as
+    a list in document order, matching the `<<: [a, b]` sequence form. This lets
+    a host like ESPHome run its own repeated-merge pass instead of silently
+    losing all but one `<<`."""
+    tags = {"!x": lambda v: f"<{v}>"}
+    src = b"<<: !x a\n<<: !x b\n"
+    expected = {"<<": ["<a>", "<b>"]}
+    # Fast path and annotated path resolve the tag and collect identically.
+    assert yamlrocks.loads(src, tags=tags) == expected
+    assert (
+        dict(yamlrocks.loads(src, option=yamlrocks.OPT_ANNOTATED, tags=tags))
+        == expected
+    )
+    # The sequence form already produced this shape and still does.
+    assert yamlrocks.loads(b"<<: [!x a, !x b]\n", tags=tags) == expected
+    # ESPHome's exact option combination (the reported case).
+    esphome = (
+        yamlrocks.OPT_ANNOTATED
+        | yamlrocks.OPT_PYYAML_COMPAT
+        | yamlrocks.OPT_ANNOTATE_NUMBERS
+        | yamlrocks.OPT_DUPLICATE_KEYS_ERROR
+    )
+    assert dict(yamlrocks.loads(src, option=esphome, tags=tags)) == expected
+
+
+def test_repeated_merge_flattens_a_preserved_sequence_one_level():
+    """A `<<` sequence value meeting a later `<<` flattens into one list rather
+    than nesting, so either order yields the same flat sequence."""
+    tags = {"!x": lambda v: f"<{v}>"}
+    flat = {"<<": ["<a>", "<b>", "<c>"]}
+    assert yamlrocks.loads(b"<<: [!x a, !x b]\n<<: !x c\n", tags=tags) == flat
+    assert yamlrocks.loads(b"<<: !x a\n<<: [!x b, !x c]\n", tags=tags) == flat
+
+
+def test_repeated_merge_mixes_mergeable_and_deferred():
+    """A mergeable `<<` (a plain mapping) still folds into the dict; only the
+    deferred `<<` values are preserved, keeping document order."""
+    tags = {"!x": lambda v: f"<{v}>"}
+    assert yamlrocks.loads(b"<<: {p: 1}\n<<: !x b\n", tags=tags) == {
+        "p": 1,
+        "<<": "<b>",
+    }
+    assert yamlrocks.loads(b"<<: !x a\n<<: {p: 1}\n", tags=tags) == {
+        "<<": "<a>",
+        "p": 1,
+    }


### PR DESCRIPTION
## Breaking change

None. A single `<<` still resolves exactly as before; this only changes what happens when a mapping carries `<<` more than once with deferred values, a case that previously lost data.

## Proposed change

A YAML mapping can carry the `<<` merge key more than once:

```yaml
<<: !include a.yaml
<<: !include b.yaml
```

PyYAML, ruamel, and libyaml all accept this repeated-key form and merge every `<<` in document order. YAMLRocks did not preserve it: when the values are deferred custom tags the parser cannot fold itself (`!include` and friends), each was stored under the literal `<<` key behind a `!dict.contains(<<)` guard. A Python `dict` only holds one `<<` slot, so all but one were silently dropped before the host converter ever ran. The data was simply gone, with no host-side recovery.

This collects repeated preserved `<<` values into a single `<<` list in document order, matching the shape the sequence form (`<<: [a, b]`) already produces. Nothing is merged here: the values are deferred, so YAMLRocks only gathers them and leaves the merge semantics to the host. A single preserved `<<` stays a scalar (no change), and a preserved list (leftovers from a `<<` sequence) is flattened one level rather than nested.

The same single-slot pattern lived in all four decode-to-Python paths, so the fix is applied to each (fast, annotated, tagged/includes, round-trip value) via a shared `store_preserved_merge` helper on the Python side and `collect_preserved` on the fast path, keeping every path's shape identical.

This unblocks a downstream host (ESPHome) that resolves `!include` itself and needs both deferred values to run its own merge pass.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [ ] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.
