### PR TITLE
🐛 Attach a `key:`/`-` line comment to the value it introduces

### DIFF
--- a/.github/scripts/test_wheel.sh
+++ b/.github/scripts/test_wheel.sh
@@ -24,8 +24,12 @@ uv pip install --python "${pyexe}" --group proptest \
   || echo "::notice::hypothesis has no wheel on this target; property tests will skip"
 
 # Install the just-built wheel, offline (never PyPI), no deps (yamlrocks has
-# none of its own).
-uv pip install --python "${pyexe}" --no-index --no-deps --find-links dist yamlrocks
+# none of its own). `--refresh-package` is what makes this test the *built*
+# wheel: every build produces the same name and version, so a wheel cached by an
+# earlier run (uv's cache is restored across jobs) satisfies the requirement and
+# is installed instead, silently smoke-testing yesterday's binary.
+uv pip install --python "${pyexe}" --no-index --no-deps --refresh-package yamlrocks \
+  --find-links dist yamlrocks
 
 # On a free-threaded (no-GIL) build, fail loudly if the GIL is actually enabled,
 # i.e. the build silently fell back to a GIL build or the import re-enabled it.

--- a/docs/src/content/docs/guides/round-trip.md
+++ b/docs/src/content/docs/guides/round-trip.md
@@ -311,6 +311,24 @@ Comment text is always bare (no leading `#`, no surrounding whitespace), so you
 read and write the words, not the punctuation. A multi-line `comment_before` or
 `comment_after` is returned as one string with `\n` between the lines.
 
+`comment` follows YAML, not the shape of the value. When the value is a block
+mapping or sequence, the trailing comment goes on the key's own line, and that is
+where `comment` reads and writes it:
+
+```python
+import yamlrocks
+
+doc = yamlrocks.loads(
+    b"servers: # the whole pool\n  - alpha\n  - beta\n",
+    option=yamlrocks.OPT_ROUND_TRIP,
+)
+
+doc.node["servers"].comment  # 'the whole pool'
+doc.node["servers"][0].comment  # None
+```
+
+The same holds for a sequence item written under its own dash (`- # note`).
+
 ### Writing metadata
 
 `value`, `comment`, `comment_before`, and `comment_after` are writable, and the

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -995,9 +995,66 @@ fn resolves_to_number(value: &str, schema: Schema) -> bool {
     )
 }
 
+/// Whether a tag can be emitted as a single tag token, or the reason it cannot.
+///
+/// A tag is written verbatim before its value (`!tag value`), so one the scanner
+/// would read only part of splits on re-parse and silently corrupts the document.
+///
+/// Whitespace and control characters are invalid in any tag. For a shorthand tag
+/// (`!foo`, `!!foo`, `!handle!foo`) a flow indicator `,`/`]`/`}` also terminates
+/// the scan, so a `YAMLRocksTag("!foo,bar", "v")` would emit `!foo,bar v` and
+/// reload as the tag `!foo` on a (broken) value `,bar v`. A verbatim tag
+/// (`!<...>`) is delimited by its closing `>` and may carry such characters
+/// (URI commas), so it is exempt from the flow-indicator check but must close.
+///
+/// This is the single source of truth for the rule: the Python `dumps` path
+/// raises it as an error ([`crate::ffi::convert::encode::validate_tag`]), and the
+/// differential fuzz targets use it to skip values the fast emitter never
+/// promised to round-trip.
+pub(crate) fn emittable_tag(tag: &str) -> Result<(), String> {
+    if tag.is_empty() || !tag.starts_with('!') {
+        return Err(format!("invalid tag {tag:?}: a tag must start with '!'"));
+    }
+    if let Some(bad) = tag.chars().find(|c| c.is_whitespace() || c.is_control()) {
+        return Err(format!(
+            "invalid tag {tag:?}: a tag cannot contain whitespace or control characters (found {bad:?})"
+        ));
+    }
+    if let Some(verbatim) = tag.strip_prefix("!<") {
+        // A verbatim tag is `!<` + non-empty URI + `>`; the scanner rejects an
+        // unterminated or empty one on read, so refuse to emit one here too.
+        if verbatim.strip_suffix('>').map_or(true, str::is_empty) {
+            return Err(format!(
+                "invalid tag {tag:?}: a verbatim tag must be '!<...>' with non-empty content"
+            ));
+        }
+    } else {
+        // A shorthand tag is `!suffix` (primary handle) or `!!suffix`
+        // (secondary handle). A *named* handle (`!h!suffix`) needs a
+        // `%TAG !h! ...` directive, which `dumps` never writes, so the output
+        // would not reload ("undefined tag handle"); reject it, along with any
+        // other stray `!` (a literal `!` inside a suffix must be URI-escaped
+        // as `%21` per the spec).
+        let suffix_start = if tag.starts_with("!!") { 2 } else { 1 };
+        if tag[suffix_start..].contains('!') {
+            return Err(format!(
+                "invalid tag {tag:?}: a named tag handle (!name!suffix) needs a %TAG directive, \
+                 which dumps does not emit; use a primary (!suffix), secondary (!!suffix), or \
+                 verbatim (!<uri>) tag"
+            ));
+        }
+        if let Some(bad) = tag.chars().find(|c| matches!(c, ',' | ']' | '}')) {
+            return Err(format!(
+                "invalid tag {tag:?}: a shorthand tag cannot contain a flow indicator (found {bad:?})"
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{encode, EmitOptions, NullStyle};
+    use super::{emittable_tag, encode, EmitOptions, NullStyle};
     use crate::decode::Value;
     use crate::resolver::Schema;
 
@@ -1448,5 +1505,24 @@ mod tests {
         };
         let v = Value::Mapping(vec![(s("a"), Value::Int(1))]);
         assert_eq!(emit(&v, &opts), "---\na: 1\n...\n");
+    }
+    #[test]
+    fn emittable_tag_rejects_what_dumps_cannot_write() {
+        // Shorthand and verbatim tags are emittable as a single token.
+        assert!(emittable_tag("!foo").is_ok());
+        assert!(emittable_tag("!!str").is_ok());
+        assert!(emittable_tag("!<tag:example.com,2020:foo>").is_ok());
+
+        // A named handle needs a `%TAG` directive, which dumps never writes, so
+        // the output would reload as "undefined tag handle". A `%TAG`-expanded
+        // document reaches the differential fuzz targets with exactly such a tag.
+        assert!(emittable_tag("!h!suffix").is_err());
+        assert!(emittable_tag("!&G!!").is_err());
+
+        // A flow indicator or whitespace would end the tag token early.
+        assert!(emittable_tag("!foo,bar").is_err());
+        assert!(emittable_tag("!foo bar").is_err());
+        assert!(emittable_tag("!<>").is_err());
+        assert!(emittable_tag("").is_err());
     }
 }

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -1022,10 +1022,15 @@ pub(crate) fn emittable_tag(tag: &str) -> Result<(), String> {
     }
     if let Some(verbatim) = tag.strip_prefix("!<") {
         // A verbatim tag is `!<` + non-empty URI + `>`; the scanner rejects an
-        // unterminated or empty one on read, so refuse to emit one here too.
-        if verbatim.strip_suffix('>').map_or(true, str::is_empty) {
+        // unterminated or empty one on read, so refuse to emit one here too. It
+        // also stops at the *first* `>`, so an interior one would truncate the
+        // tag and spill the remainder into the document as content: `!<tag:a>b>`
+        // reloads as the tag `!<tag:a>` on a value that starts with `b>`.
+        let uri = verbatim.strip_suffix('>').unwrap_or_default();
+        if uri.is_empty() || uri.contains('>') {
             return Err(format!(
-                "invalid tag {tag:?}: a verbatim tag must be '!<...>' with non-empty content"
+                "invalid tag {tag:?}: a verbatim tag must be '!<...>' with non-empty content \
+                 and no interior '>'"
             ));
         }
     } else {
@@ -1523,6 +1528,10 @@ mod tests {
         assert!(emittable_tag("!foo,bar").is_err());
         assert!(emittable_tag("!foo bar").is_err());
         assert!(emittable_tag("!<>").is_err());
+        // The scanner stops at the first `>`, so an interior one would truncate
+        // the tag and leave the rest as document content.
+        assert!(emittable_tag("!<tag:a>b>").is_err());
+        assert!(emittable_tag("!<unterminated").is_err());
         assert!(emittable_tag("").is_err());
     }
 }

--- a/src/ffi/convert/encode.rs
+++ b/src/ffi/convert/encode.rs
@@ -176,57 +176,12 @@ fn python_to_value_inner(
     )))
 }
 
-/// Reject a tag that cannot be emitted as a single tag token. A tag is written
-/// verbatim before its value (`!tag value`), so one that the scanner would read
-/// only part of splits on re-parse and silently corrupts the document.
-///
-/// Whitespace and control characters are invalid in any tag. For a shorthand tag
-/// (`!foo`, `!!foo`, `!handle!foo`) a flow indicator `,`/`]`/`}` also terminates
-/// the scan, so `YAMLRocksTag("!foo,bar", "v")` would emit `!foo,bar v` and
-/// reload as the tag `!foo` on a (broken) value `,bar v`. A verbatim tag
-/// (`!<...>`) is delimited by its closing `>` and may carry such characters
-/// (URI commas), so it is exempt from the flow-indicator check but must close.
+/// Reject a tag the fast emitter cannot write as a single tag token, raising the
+/// Python-facing error. The rule itself lives in
+/// [`crate::encode::emittable_tag`], so the fuzz harness and this check cannot
+/// drift apart.
 pub(crate) fn validate_tag(tag: &str) -> PyResult<()> {
-    if tag.is_empty() || !tag.starts_with('!') {
-        return Err(errors::encode_error(format!(
-            "invalid tag {tag:?}: a tag must start with '!'"
-        )));
-    }
-    if let Some(bad) = tag.chars().find(|c| c.is_whitespace() || c.is_control()) {
-        return Err(errors::encode_error(format!(
-            "invalid tag {tag:?}: a tag cannot contain whitespace or control characters (found {bad:?})"
-        )));
-    }
-    if let Some(verbatim) = tag.strip_prefix("!<") {
-        // A verbatim tag is `!<` + non-empty URI + `>`; the scanner rejects an
-        // unterminated or empty one on read, so refuse to emit one here too.
-        if verbatim.strip_suffix('>').map_or(true, str::is_empty) {
-            return Err(errors::encode_error(format!(
-                "invalid tag {tag:?}: a verbatim tag must be '!<...>' with non-empty content"
-            )));
-        }
-    } else {
-        // A shorthand tag is `!suffix` (primary handle) or `!!suffix`
-        // (secondary handle). A *named* handle (`!h!suffix`) needs a
-        // `%TAG !h! ...` directive, which `dumps` never writes, so the output
-        // would not reload ("undefined tag handle"); reject it, along with any
-        // other stray `!` (a literal `!` inside a suffix must be URI-escaped
-        // as `%21` per the spec).
-        let suffix_start = if tag.starts_with("!!") { 2 } else { 1 };
-        if tag[suffix_start..].contains('!') {
-            return Err(errors::encode_error(format!(
-                "invalid tag {tag:?}: a named tag handle (!name!suffix) needs a %TAG directive, \
-                 which dumps does not emit; use a primary (!suffix), secondary (!!suffix), or \
-                 verbatim (!<uri>) tag"
-            )));
-        }
-        if let Some(bad) = tag.chars().find(|c| matches!(c, ',' | ']' | '}')) {
-            return Err(errors::encode_error(format!(
-                "invalid tag {tag:?}: a shorthand tag cannot contain a flow indicator (found {bad:?})"
-            )));
-        }
-    }
-    Ok(())
+    crate::encode::emittable_tag(tag).map_err(errors::encode_error)
 }
 
 /// Convert a [`YAMLRocksTag`] into a [`Value::Tagged`], serializing its inner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,11 +174,18 @@ pub mod fuzz {
     /// directives or shorthand handles on output. Skip such values here so the
     /// differential targets fuzz only inputs the fast emitter actually promises to
     /// round-trip.
+    ///
+    /// The rule is [`crate::encode::emittable_tag`], the one the public API
+    /// enforces: checking only the leading `!` here let a `%TAG`-expanded named
+    /// handle (`!h!suffix`) through, and the harness then asserted on output that
+    /// `dumps` itself refuses to produce.
     fn tags_fast_emittable(value: &crate::decode::Value<'_>) -> bool {
         use crate::decode::Value::{Mapping, Sequence, Tagged};
 
         match value {
-            Tagged(tag, inner) => tag.starts_with('!') && tags_fast_emittable(inner),
+            Tagged(tag, inner) => {
+                crate::encode::emittable_tag(tag).is_ok() && tags_fast_emittable(inner)
+            }
             Sequence(items) => items.iter().all(tags_fast_emittable),
             Mapping(pairs) => pairs
                 .iter()

--- a/src/roundtrip/ast.rs
+++ b/src/roundtrip/ast.rs
@@ -222,6 +222,19 @@ pub struct Comments {
     /// `false` for the usual trailing comment (`key: value # note`), which the
     /// emitter writes after the value.
     pub inline_before_value: bool,
+    /// How many of the trailing [`head`](Self::head) comments were written
+    /// *below* that introducer line rather than above it. A section comment can
+    /// sit above a `-` while the dash carries its own comment and further
+    /// comments follow underneath, so the two groups have to be told apart to
+    /// re-emit each on its own side of the dash.
+    ///
+    /// A `u8` because it costs nothing here: the struct's other scalars leave
+    /// exactly this much padding, and widening it would grow every node of the
+    /// tree for a count that never exceeds a handful. It saturates at
+    /// [`u8::MAX`], which then means *all* of them: 255 comment lines under a
+    /// single `-` is past any real document, and keeping that block together is
+    /// the least surprising thing to do with it.
+    pub head_below: u8,
     /// Number of spaces between this node's introducer (a mapping key's `:` or a
     /// sequence `-`) and an inline value sharing its line, preserving alignment
     /// like `example:      true` or `-    item`. `0` means "not captured" (a
@@ -240,6 +253,32 @@ pub struct Comments {
     pub foot: Vec<String>,
     /// Whether this node was modified since loading (for diff-based emission).
     pub modified: bool,
+}
+
+impl Comments {
+    /// The head comments written above this node's introducer (a sequence `-`).
+    /// Everything, for a node whose introducer carries no comment of its own.
+    pub fn head_above_introducer(&self) -> &[String] {
+        &self.head[..self.head.len() - self.head_below_count()]
+    }
+
+    /// The head comments written below that introducer, between its own comment
+    /// and the node's first line.
+    pub fn head_below_introducer(&self) -> &[String] {
+        &self.head[self.head.len() - self.head_below_count()..]
+    }
+
+    /// The recorded split, clamped to the comments actually present: an edit can
+    /// replace `head` wholesale (`comment_before = ...`), and a stale count must
+    /// not slice out of range. A saturated count means the whole block sits
+    /// below the introducer (see [`head_below`](Self::head_below)).
+    fn head_below_count(&self) -> usize {
+        if self.head_below == u8::MAX {
+            self.head.len()
+        } else {
+            (self.head_below as usize).min(self.head.len())
+        }
+    }
 }
 
 /// The presentation style of a node.
@@ -306,6 +345,26 @@ mod tests {
         assert_eq!(node.style, NodeStyle::Flow);
         assert_eq!(node.comments.head, vec!["note".to_owned()]);
         assert!(matches!(node.kind, YamlNodeKind::Scalar(..)));
+    }
+
+    #[test]
+    fn head_comments_split_around_their_introducer() {
+        let mut comments = Comments {
+            head: vec!["above".to_owned(), "below".to_owned()],
+            ..Default::default()
+        };
+        comments.head_below = 1;
+        assert_eq!(comments.head_above_introducer(), ["above".to_owned()]);
+        assert_eq!(comments.head_below_introducer(), ["below".to_owned()]);
+
+        // A count left over from a replaced block cannot slice out of range.
+        comments.head_below = 9;
+        assert_eq!(comments.head_below_introducer().len(), 2);
+
+        // A saturated count keeps the whole block below the introducer.
+        comments.head_below = u8::MAX;
+        assert!(comments.head_above_introducer().is_empty());
+        assert_eq!(comments.head_below_introducer().len(), 2);
     }
 
     #[test]

--- a/src/roundtrip/ast.rs
+++ b/src/roundtrip/ast.rs
@@ -208,7 +208,7 @@ pub struct Comments {
     /// document carries; a synthetic (edited-in) node defaults to `0`.
     pub blank_before: u32,
     /// Comments on their own line(s) before this node.
-    pub head: Vec<String>,
+    pub head: Vec<HeadComment>,
     /// Comment on the same line after this node's value.
     pub inline: Option<String>,
     /// Number of spaces between the value and the `#` of [`inline`](Self::inline),
@@ -222,19 +222,6 @@ pub struct Comments {
     /// `false` for the usual trailing comment (`key: value # note`), which the
     /// emitter writes after the value.
     pub inline_before_value: bool,
-    /// How many of the trailing [`head`](Self::head) comments were written
-    /// *below* that introducer line rather than above it. A section comment can
-    /// sit above a `-` while the dash carries its own comment and further
-    /// comments follow underneath, so the two groups have to be told apart to
-    /// re-emit each on its own side of the dash.
-    ///
-    /// A `u8` because it costs nothing here: the struct's other scalars leave
-    /// exactly this much padding, and widening it would grow every node of the
-    /// tree for a count that never exceeds a handful. It saturates at
-    /// [`u8::MAX`], which then means *all* of them: 255 comment lines under a
-    /// single `-` is past any real document, and keeping that block together is
-    /// the least surprising thing to do with it.
-    pub head_below: u8,
     /// Number of spaces between this node's introducer (a mapping key's `:` or a
     /// sequence `-`) and an inline value sharing its line, preserving alignment
     /// like `example:      true` or `-    item`. `0` means "not captured" (a
@@ -255,29 +242,53 @@ pub struct Comments {
     pub modified: bool,
 }
 
+/// A standalone comment line above a node, and which side of the node's
+/// introducer it was written on.
+///
+/// A section comment can sit above a `-` while the dash carries its own comment
+/// (`- # note`) and further comments follow underneath. They reach the node as
+/// one run, so each has to remember its own side to be re-emitted there.
+#[derive(Debug, Clone)]
+pub struct HeadComment {
+    /// The comment text, without the leading `#`. A `Box<str>` rather than a
+    /// `String`: the text never grows after attachment, and dropping the unused
+    /// capacity keeps this the same size the plain `String` was, so recording
+    /// the side costs nothing.
+    pub text: Box<str>,
+    /// Whether it was written *below* the comment on the node's introducer,
+    /// rather than above the introducer itself. Always `false` for a node whose
+    /// introducer carries no comment, where there is no dividing line.
+    pub below_introducer: bool,
+}
+
+impl HeadComment {
+    /// A comment above the node's introducer, the position every comment takes
+    /// when nothing divides the block.
+    pub fn above(text: impl Into<Box<str>>) -> Self {
+        Self {
+            text: text.into(),
+            below_introducer: false,
+        }
+    }
+}
+
 impl Comments {
     /// The head comments written above this node's introducer (a sequence `-`).
     /// Everything, for a node whose introducer carries no comment of its own.
-    pub fn head_above_introducer(&self) -> &[String] {
-        &self.head[..self.head.len() - self.head_below_count()]
+    pub fn head_above_introducer(&self) -> impl Iterator<Item = &str> {
+        self.head
+            .iter()
+            .filter(|comment| !comment.below_introducer)
+            .map(|comment| &*comment.text)
     }
 
     /// The head comments written below that introducer, between its own comment
     /// and the node's first line.
-    pub fn head_below_introducer(&self) -> &[String] {
-        &self.head[self.head.len() - self.head_below_count()..]
-    }
-
-    /// The recorded split, clamped to the comments actually present: an edit can
-    /// replace `head` wholesale (`comment_before = ...`), and a stale count must
-    /// not slice out of range. A saturated count means the whole block sits
-    /// below the introducer (see [`head_below`](Self::head_below)).
-    fn head_below_count(&self) -> usize {
-        if self.head_below == u8::MAX {
-            self.head.len()
-        } else {
-            (self.head_below as usize).min(self.head.len())
-        }
+    pub fn head_below_introducer(&self) -> impl Iterator<Item = &str> {
+        self.head
+            .iter()
+            .filter(|comment| comment.below_introducer)
+            .map(|comment| &*comment.text)
     }
 }
 
@@ -303,7 +314,7 @@ pub struct IncludeSource {
 
 #[cfg(test)]
 mod tests {
-    use super::{Comments, NodeStyle, YamlNode, YamlNodeKind};
+    use super::{Comments, HeadComment, NodeStyle, YamlNode, YamlNodeKind};
     use crate::scanner::{ScalarStyle, Span};
 
     fn span() -> Span {
@@ -329,7 +340,7 @@ mod tests {
     #[test]
     fn builders_set_each_field() {
         let comments = Comments {
-            head: vec!["note".to_owned()],
+            head: vec![HeadComment::above("note")],
             ..Default::default()
         };
         let node = YamlNode::new(
@@ -343,28 +354,35 @@ mod tests {
         assert_eq!(node.anchor.as_deref(), Some("a"));
         assert_eq!(node.tag.as_deref(), Some("!t"));
         assert_eq!(node.style, NodeStyle::Flow);
-        assert_eq!(node.comments.head, vec!["note".to_owned()]);
+        assert_eq!(node.comments.head[0].text.as_ref(), "note");
         assert!(matches!(node.kind, YamlNodeKind::Scalar(..)));
     }
 
     #[test]
     fn head_comments_split_around_their_introducer() {
-        let mut comments = Comments {
-            head: vec!["above".to_owned(), "below".to_owned()],
+        // A section comment above the `-`, then two written below its comment.
+        let comments = Comments {
+            head: vec![
+                HeadComment::above("above"),
+                HeadComment {
+                    text: "below".into(),
+                    below_introducer: true,
+                },
+                HeadComment {
+                    text: "further".into(),
+                    below_introducer: true,
+                },
+            ],
             ..Default::default()
         };
-        comments.head_below = 1;
-        assert_eq!(comments.head_above_introducer(), ["above".to_owned()]);
-        assert_eq!(comments.head_below_introducer(), ["below".to_owned()]);
-
-        // A count left over from a replaced block cannot slice out of range.
-        comments.head_below = 9;
-        assert_eq!(comments.head_below_introducer().len(), 2);
-
-        // A saturated count keeps the whole block below the introducer.
-        comments.head_below = u8::MAX;
-        assert!(comments.head_above_introducer().is_empty());
-        assert_eq!(comments.head_below_introducer().len(), 2);
+        assert_eq!(
+            comments.head_above_introducer().collect::<Vec<_>>(),
+            ["above"]
+        );
+        assert_eq!(
+            comments.head_below_introducer().collect::<Vec<_>>(),
+            ["below", "further"]
+        );
     }
 
     #[test]

--- a/src/roundtrip/ast.rs
+++ b/src/roundtrip/ast.rs
@@ -215,6 +215,13 @@ pub struct Comments {
     /// preserving alignment padding (`x: 1      # note`) across a re-emit. `0`
     /// means "not captured" (a synthetic comment), which emits as a single space.
     pub inline_spaces: u32,
+    /// Whether [`inline`](Self::inline) was written on the line that *introduces*
+    /// this value (after a mapping key's `:` or a sequence `-`) while the value
+    /// itself begins on a later line, as in `key: # note`. The emitter keeps such
+    /// a comment on the introducer line instead of moving it past the value.
+    /// `false` for the usual trailing comment (`key: value # note`), which the
+    /// emitter writes after the value.
+    pub inline_before_value: bool,
     /// Number of spaces between this node's introducer (a mapping key's `:` or a
     /// sequence `-`) and an inline value sharing its line, preserving alignment
     /// like `example:      true` or `-    item`. `0` means "not captured" (a

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -520,15 +520,16 @@ fn visit_for_comments_inner(
     is_value: bool,
     intro: Intro,
 ) {
-    claim_introducer_comment(node, context, state, intro);
-
     let line = node.span.line;
     let column = node.span.column;
     let style = node.style;
 
-    // This node's leading block starts at its first head comment (if one sits
-    // above it) or at the node's own line. Blank source lines between the
-    // previous content and that start are preserved so section spacing survives.
+    // This node's leading block starts at the first comment above it (its
+    // introducer's own comment, or a standalone one) or at the node's own line.
+    // Blank source lines between the previous content and that start are
+    // preserved so section spacing survives. Measured before the claim below,
+    // which advances past the introducer's line: the blank lines above a
+    // commented `-` still belong to this entry.
     let block_start = match context.comments.get(state.cursor) {
         Some(comment) if comment.span.line < line => comment.span.line,
         _ => line,
@@ -536,6 +537,8 @@ fn visit_for_comments_inner(
     if let Some(prev) = state.prev_line {
         node.comments.blank_before = blanks_between(context.blank_lines, prev, block_start);
     }
+
+    claim_introducer_comment(node, context, state, intro);
 
     // Head: standalone comment lines strictly above this node.
     while let Some(comment) = context.comments.get(state.cursor) {
@@ -573,8 +576,12 @@ fn visit_for_comments_inner(
                 // An explicit key (`? key`) carries its `:` on a line of its own,
                 // which the key's end position does not locate, and a flow mapping
                 // has no line for a comment to trail; both keep the plain
-                // head-comment handling.
-                let intro = if style == NodeStyle::Block && !key.explicit_key {
+                // head-comment handling. So does a key with no source position of
+                // its own: an empty implicit key (`: value`) is a synthetic null
+                // that reports the start of the document, which would measure the
+                // introducer against an unrelated line.
+                let key_located = key.end_line >= line;
+                let intro = if style == NodeStyle::Block && !key.explicit_key && key_located {
                     Intro::AfterKey(key.end_line, key.end_column)
                 } else {
                     Intro::None

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -4,7 +4,7 @@ use crate::parser::{Event, EventKind, Parser};
 use crate::resolver::{ResolvedValue, Schema};
 use crate::scanner::{Comment, ScalarStyle, ScanError, Span};
 
-use super::ast::{Comments, NodeStyle, YamlNode, YamlNodeKind};
+use super::ast::{Comments, HeadComment, NodeStyle, YamlNode, YamlNodeKind};
 
 /// Compose a YAML string into a rich AST that preserves all structure,
 /// including comments reattached to their nearest nodes.
@@ -494,13 +494,12 @@ fn attach_comment_above(
             }
             node.comments.inline_before_value = true;
         }
-        _ => {
-            node.comments.head.push(comment.text.clone());
-            // Comments reaching here after the introducer's own belong below it.
-            if node.comments.inline_before_value {
-                node.comments.head_below = node.comments.head_below.saturating_add(1);
-            }
-        }
+        // A standalone line above the node. One reaching here *after* the
+        // introducer's own comment was claimed was written below it.
+        _ => node.comments.head.push(HeadComment {
+            text: comment.text.as_str().into(),
+            below_introducer: node.comments.inline_before_value,
+        }),
     }
 }
 
@@ -894,7 +893,10 @@ impl<'input> Composer<'input> {
         let tag = self.pending_tag.take();
         let anchor = self.pending_anchor.take();
         let comments = Comments {
-            head: std::mem::take(&mut self.pending_comments),
+            head: std::mem::take(&mut self.pending_comments)
+                .into_iter()
+                .map(HeadComment::above)
+                .collect(),
             ..Comments::default()
         };
 
@@ -1442,7 +1444,7 @@ mod tests {
         // A leading comment before the first key is preserved in head position
         // (on the document root or the key itself, depending on attachment).
         let head_seen = r.comments.head.iter().chain(&k.comments.head);
-        assert!(head_seen.into_iter().any(|c| c.contains("leading")));
+        assert!(head_seen.into_iter().any(|c| c.text.contains("leading")));
         assert_eq!(v.comments.inline.as_deref(), Some("trailing"));
     }
 
@@ -1476,7 +1478,7 @@ mod tests {
         let r = root("key:\n  # note\n  a: 1\n");
         let v = get(&r, "key");
         assert!(v.comments.inline.is_none());
-        assert_eq!(v.comments.head, vec!["note".to_owned()]);
+        assert_eq!(v.comments.head[0].text.as_ref(), "note");
     }
 
     #[test]

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -13,7 +13,7 @@ pub fn compose(input: &str) -> Result<Vec<YamlNode>, ScanError> {
     let (events, comments) = parser.parse_all_with_comments()?;
     let mut composer = Composer::new(input);
     let mut nodes = composer.compose_stream(&events, false)?;
-    attach_comments(&mut nodes, &comments, input);
+    attach_comments(&mut nodes, &comments, input, &composer.dash_positions);
     mark_leading_bom(&mut nodes, parser.had_bom());
     Ok(nodes)
 }
@@ -39,7 +39,7 @@ pub fn compose_all(input: &str) -> Result<Vec<YamlNode>, ScanError> {
     let (events, comments) = parser.parse_all_with_comments()?;
     let mut composer = Composer::new(input);
     let mut nodes = composer.compose_stream(&events, true)?;
-    attach_comments(&mut nodes, &comments, input);
+    attach_comments(&mut nodes, &comments, input, &composer.dash_positions);
     mark_leading_bom(&mut nodes, parser.had_bom());
     Ok(nodes)
 }
@@ -51,7 +51,7 @@ pub fn compose_with_file_id(input: &str, file_id: u32) -> Result<Vec<YamlNode>, 
     let (events, comments) = parser.parse_all_with_comments()?;
     let mut composer = Composer::new(input);
     let mut nodes = composer.compose_stream(&events, false)?;
-    attach_comments(&mut nodes, &comments, input);
+    attach_comments(&mut nodes, &comments, input, &composer.dash_positions);
     mark_leading_bom(&mut nodes, parser.had_bom());
     Ok(nodes)
 }
@@ -257,7 +257,12 @@ fn key_display(node: &YamlNode) -> String {
 ///
 /// Any comments left after the walk (trailing the final node) become foot
 /// comments on the last top-level node.
-fn attach_comments(nodes: &mut [YamlNode], comments: &[Comment], input: &str) {
+fn attach_comments(
+    nodes: &mut [YamlNode],
+    comments: &[Comment],
+    input: &str,
+    dash_positions: &std::collections::HashSet<(u32, u32)>,
+) {
     // Unlike comment attachment, blank-line spacing must be recorded even for a
     // document with no comments at all, so this walk always runs.
     //
@@ -272,21 +277,21 @@ fn attach_comments(nodes: &mut [YamlNode], comments: &[Comment], input: &str) {
         .filter(|(_, text)| text.trim().is_empty())
         .map(|(i, _)| i as u32)
         .collect();
-    let mut cursor = 0usize;
-    let mut prev_line: Option<u32> = None;
+    let context = CommentContext {
+        comments,
+        blank_lines: &blank_lines,
+        dash_positions,
+    };
+    let mut state = WalkState {
+        cursor: 0,
+        prev_line: None,
+    };
     for node in nodes.iter_mut() {
-        visit_for_comments(
-            node,
-            comments,
-            &blank_lines,
-            &mut cursor,
-            &mut prev_line,
-            true,
-        );
+        visit_for_comments(node, &context, &mut state, true, Intro::None);
     }
-    if cursor < comments.len() {
+    if state.cursor < comments.len() {
         if let Some(last) = nodes.last_mut() {
-            for comment in &comments[cursor..] {
+            for comment in &comments[state.cursor..] {
                 // Route each trailing comment to the deepest block it is indented
                 // into, so a comment at the end of a nested final block is owned
                 // by that block and re-emits at its indent instead of flattening
@@ -344,9 +349,22 @@ fn is_block_collection(node: &YamlNode) -> bool {
         }
 }
 
-/// Raise the running "last source line seen" to at least `line`.
-fn bump(prev_line: &mut Option<u32>, line: u32) {
-    *prev_line = Some(prev_line.map_or(line, |p| p.max(line)));
+/// The walk's running position: which comment comes next, and the last source
+/// line consumed. Paired with [`CommentContext`] so the recursive walk carries
+/// two references per level instead of four.
+struct WalkState {
+    /// Index of the next unattached comment in [`CommentContext::comments`].
+    cursor: usize,
+    /// The last source line seen, or `None` before the first node, so the blank
+    /// gap before a node can be measured.
+    prev_line: Option<u32>,
+}
+
+impl WalkState {
+    /// Raise the running "last source line seen" to at least `line`.
+    fn bump(&mut self, line: u32) {
+        self.prev_line = Some(self.prev_line.map_or(line, |prev| prev.max(line)));
+    }
 }
 
 /// Flag a block-sequence item that opened on its parent's dash line (`- - 1`),
@@ -390,62 +408,151 @@ fn blanks_between(
         .count() as u32
 }
 
+/// The read-only source facts the comment walk consults at every node, bundled
+/// into one reference. The walk recurses once per level of nesting, so passing
+/// three separate references would put their width on the stack a thousand times
+/// over on a deeply nested document.
+struct CommentContext<'a> {
+    /// The document's comments, in source order.
+    comments: &'a [Comment],
+    /// The source lines that hold no content, for measuring section spacing.
+    blank_lines: &'a std::collections::HashSet<u32>,
+    /// See [`Composer::dash_positions`].
+    dash_positions: &'a std::collections::HashSet<(u32, u32)>,
+}
+
+/// How a node was introduced, so the walk can claim a comment left on that
+/// introducer's own line (`key: # note`, `- # note`).
+///
+/// Passed *into* the walk rather than handled at the call site: the walk recurses
+/// once per level of nesting, and in an unoptimized build every value live across
+/// a call in its body is spilled to the frame, which a deeply nested document
+/// then pays a thousand times over. Resolving this in the callee's prologue,
+/// where nothing else is live yet, keeps that frame small.
+#[derive(Clone, Copy)]
+enum Intro {
+    /// A document root, or a node that cannot own a trailing comment (a mapping
+    /// key, an explicit-key pair's value, anything inside a flow collection).
+    None,
+    /// A block mapping value: the `:` sits at the given `(line, column)`, just
+    /// past the key.
+    AfterKey(u32, u32),
+    /// A block sequence item: its `-` sits at this column, on one of the lines
+    /// the composer recorded in [`Composer::dash_positions`].
+    AfterDash(u32),
+}
+
+/// Give `node` the comment written after the `:` or `-` that introduced it, when
+/// the value itself starts on a later line (`key: # note`).
+///
+/// Such a comment belongs to the entry. Left to the head walk in
+/// [`visit_for_comments`], it would become a standalone comment above the value:
+/// invisible to `.comment`, and for a collection value leaking onto its first
+/// child's `comment_before`.
+fn claim_introducer_comment(
+    node: &mut YamlNode,
+    context: &CommentContext<'_>,
+    state: &mut WalkState,
+    intro: Intro,
+) {
+    let Some(comment) = context.comments.get(state.cursor) else {
+        return;
+    };
+    // Only a comment above the node's own first line can sit on the introducer.
+    if comment.span.line >= node.span.line {
+        return;
+    }
+    // The column just past the introducer, which the comment must follow.
+    let after_intro = match intro {
+        Intro::None => return,
+        // The `:` follows the key directly, so the introducer ends one column
+        // past the key's exact end.
+        Intro::AfterKey(line, column) if line == comment.span.line => column + 1,
+        // Every `-` of a block sequence sits at the sequence's own column, and
+        // the composer recorded the ones whose item begins further down. A
+        // comment on any other line above the item is a standalone comment and
+        // stays a head comment.
+        Intro::AfterDash(column)
+            if context
+                .dash_positions
+                .contains(&(comment.span.line, column)) =>
+        {
+            column + 1
+        }
+        _ => return,
+    };
+    if comment.span.column < after_intro {
+        return;
+    }
+    node.comments.inline = Some(comment.text.clone());
+    // Alignment padding, measured from just past the `:`/`-`. An anchor or tag is
+    // emitted in that gap (`key: &a # note`), so measuring across it would
+    // overcount; those fall back to a single space, as the `value_pad` rule does.
+    if node.anchor.is_none() && node.tag.is_none() {
+        node.comments.inline_spaces = comment.span.column - after_intro;
+    }
+    node.comments.inline_before_value = true;
+    state.bump(comment.span.line);
+    state.cursor += 1;
+}
+
 /// Walk a single node, recording its leading blank lines, consuming head
 /// comments before it, and capturing an inline comment (with its spacing) after
-/// it. `prev_line` threads the last source line seen so blank gaps can be
-/// measured. `is_value` marks nodes that may own a trailing inline comment
-/// (mapping values, sequence items, document roots); mapping keys never do.
+/// it. `is_value` marks nodes that may own a trailing inline comment (mapping
+/// values, sequence items, document roots); mapping keys never do. `intro` says
+/// what introduced this node, for a comment left on that line.
 fn visit_for_comments(
     node: &mut YamlNode,
-    comments: &[Comment],
-    blank_lines: &std::collections::HashSet<u32>,
-    cursor: &mut usize,
-    prev_line: &mut Option<u32>,
+    context: &CommentContext<'_>,
+    state: &mut WalkState,
     is_value: bool,
+    intro: Intro,
 ) {
     // Grow the native stack on demand so reattaching comments over a deeply
     // nested document cannot overflow a small thread stack. See [`crate::stack`].
-    crate::stack::guard(|| {
-        visit_for_comments_inner(node, comments, blank_lines, cursor, prev_line, is_value)
-    })
+    crate::stack::guard(|| visit_for_comments_inner(node, context, state, is_value, intro))
 }
 
 fn visit_for_comments_inner(
     node: &mut YamlNode,
-    comments: &[Comment],
-    blank_lines: &std::collections::HashSet<u32>,
-    cursor: &mut usize,
-    prev_line: &mut Option<u32>,
+    context: &CommentContext<'_>,
+    state: &mut WalkState,
     is_value: bool,
+    intro: Intro,
 ) {
+    claim_introducer_comment(node, context, state, intro);
+
     let line = node.span.line;
     let column = node.span.column;
+    let style = node.style;
 
     // This node's leading block starts at its first head comment (if one sits
     // above it) or at the node's own line. Blank source lines between the
     // previous content and that start are preserved so section spacing survives.
-    let block_start = if *cursor < comments.len() && comments[*cursor].span.line < line {
-        comments[*cursor].span.line
-    } else {
-        line
+    let block_start = match context.comments.get(state.cursor) {
+        Some(comment) if comment.span.line < line => comment.span.line,
+        _ => line,
     };
-    if let Some(prev) = *prev_line {
-        node.comments.blank_before = blanks_between(blank_lines, prev, block_start);
+    if let Some(prev) = state.prev_line {
+        node.comments.blank_before = blanks_between(context.blank_lines, prev, block_start);
     }
 
     // Head: standalone comment lines strictly above this node.
-    while *cursor < comments.len() && comments[*cursor].span.line < line {
-        node.comments.head.push(comments[*cursor].text.clone());
-        bump(prev_line, comments[*cursor].span.line);
-        *cursor += 1;
+    while let Some(comment) = context.comments.get(state.cursor) {
+        if comment.span.line >= line {
+            break;
+        }
+        node.comments.head.push(comment.text.clone());
+        state.bump(comment.span.line);
+        state.cursor += 1;
     }
-    bump(prev_line, line);
+    state.bump(line);
 
     // Recurse into children in document order.
     match &mut node.kind {
         YamlNodeKind::Mapping(pairs) => {
             for (key, val) in pairs.iter_mut() {
-                visit_for_comments(key, comments, blank_lines, cursor, prev_line, false);
+                visit_for_comments(key, context, state, false, Intro::None);
                 // Padding between the key's `:` and an inline value sharing its
                 // line (`example:      true`). The colon sits just past the key,
                 // so the gap is the value column minus the key end, less one.
@@ -463,12 +570,21 @@ fn visit_for_comments_inner(
                 {
                     val.comments.value_pad = val.span.column - key_end_col - 1;
                 }
-                visit_for_comments(val, comments, blank_lines, cursor, prev_line, true);
+                // An explicit key (`? key`) carries its `:` on a line of its own,
+                // which the key's end position does not locate, and a flow mapping
+                // has no line for a comment to trail; both keep the plain
+                // head-comment handling.
+                let intro = if style == NodeStyle::Block && !key.explicit_key {
+                    Intro::AfterKey(key.end_line, key.end_column)
+                } else {
+                    Intro::None
+                };
+                visit_for_comments(val, context, state, true, intro);
             }
         }
         YamlNodeKind::Sequence(items) => {
             for item in items.iter_mut() {
-                visit_for_comments(item, comments, blank_lines, cursor, prev_line, true);
+                visit_for_comments(item, context, state, true, Intro::AfterDash(column));
             }
         }
         _ => {}
@@ -478,24 +594,25 @@ fn visit_for_comments_inner(
     // this also covers the trailing blank lines that source includes, so the
     // next node's `blank_before` does not re-count them.
     match &node.comments.raw {
-        Some(raw) => bump(prev_line, line + raw.matches('\n').count() as u32),
-        None => bump(prev_line, node.end().0),
+        Some(raw) => state.bump(line + raw.matches('\n').count() as u32),
+        None => state.bump(node.end().0),
     }
 
     // Inline: a comment trailing this value on its own start line.
-    if is_value && *cursor < comments.len() {
-        let comment = &comments[*cursor];
-        if comment.span.line == line && comment.span.column > column {
-            // Preserve the gap between the value's end and the `#` so alignment
-            // padding survives a re-emit. The value ends on this line for the
-            // single-line scalars inline comments attach to; otherwise the gap is
-            // left uncaptured (re-emits as one space).
-            let (end_line, end_col) = node.end();
-            if end_line == comment.span.line && comment.span.column > end_col {
-                node.comments.inline_spaces = comment.span.column - end_col;
+    if is_value {
+        if let Some(comment) = context.comments.get(state.cursor) {
+            if comment.span.line == line && comment.span.column > column {
+                // Preserve the gap between the value's end and the `#` so
+                // alignment padding survives a re-emit. The value ends on this
+                // line for the single-line scalars inline comments attach to;
+                // otherwise the gap is left uncaptured (re-emits as one space).
+                let (end_line, end_col) = node.end();
+                if end_line == comment.span.line && comment.span.column > end_col {
+                    node.comments.inline_spaces = comment.span.column - end_col;
+                }
+                node.comments.inline = Some(comment.text.clone());
+                state.cursor += 1;
             }
-            node.comments.inline = Some(comment.text.clone());
-            *cursor += 1;
         }
     }
 }
@@ -558,6 +675,13 @@ struct Composer<'input> {
     /// (an unknown or forward reference), matching the fast decoder and PyYAML.
     /// Anchors do not cross documents, so this is cleared at each document start.
     anchors_seen: HashSet<String>,
+    /// The `(line, column)` of every block sequence `-` whose item begins on a
+    /// *later* line, the only shape where a comment can sit between the two
+    /// (`- # note`). Comment attachment uses it to tell such a comment from a
+    /// standalone comment line above the item. Recorded here because the dash
+    /// position exists only while composing, and kept to the rare shape so an
+    /// ordinary document allocates nothing.
+    dash_positions: HashSet<(u32, u32)>,
 }
 
 impl<'input> Composer<'input> {
@@ -571,6 +695,18 @@ impl<'input> Composer<'input> {
             pending_comments: Vec::new(),
             depth: 0,
             anchors_seen: HashSet::new(),
+            dash_positions: HashSet::new(),
+        }
+    }
+
+    /// Remember a block sequence `-` whose item starts on a later line, so
+    /// comment attachment can recognise a comment left on the dash's own line.
+    /// An item that opens on the dash line (the ordinary `- item`) has no room
+    /// for one and is not recorded.
+    fn record_detached_dash(&mut self, node: &YamlNode, dash_span: Span) {
+        if node.span.line > dash_span.line {
+            self.dash_positions
+                .insert((dash_span.line, dash_span.column));
         }
     }
 
@@ -1009,6 +1145,7 @@ impl<'input> Composer<'input> {
                         mark_compact_nested_sequence(&mut node, dash_span.line);
                         if block {
                             mark_dash_pad(&mut node, dash_span);
+                            self.record_detached_dash(&node, dash_span);
                         }
                         items.push(node);
                     }
@@ -1155,6 +1292,7 @@ impl<'input> Composer<'input> {
                     if let Some(mut node) = self.compose_block_entry(events, dash_span)? {
                         mark_compact_nested_sequence(&mut node, dash_span.line);
                         mark_dash_pad(&mut node, dash_span);
+                        self.record_detached_dash(&node, dash_span);
                         items.push(node);
                     }
                 }
@@ -1280,6 +1418,39 @@ mod tests {
         let head_seen = r.comments.head.iter().chain(&k.comments.head);
         assert!(head_seen.into_iter().any(|c| c.contains("leading")));
         assert_eq!(v.comments.inline.as_deref(), Some("trailing"));
+    }
+
+    #[test]
+    fn key_line_comment_belongs_to_a_block_value() {
+        // `key: # note` trails the entry, so it is the value's inline comment
+        // even though the value itself starts on the next line. Filing it as a
+        // head comment would hide it from `.comment` and, for a collection,
+        // hand it to the first child.
+        let r = root("key: # note\n  a: 1\n");
+        let v = get(&r, "key");
+        assert_eq!(v.comments.inline.as_deref(), Some("note"));
+        assert!(v.comments.inline_before_value);
+        assert!(v.comments.head.is_empty());
+    }
+
+    #[test]
+    fn dash_line_comment_belongs_to_the_item() {
+        let r = root("- # note\n  a: 1\n");
+        let YamlNodeKind::Sequence(items) = &r.kind else {
+            panic!("expected a sequence");
+        };
+        assert_eq!(items[0].comments.inline.as_deref(), Some("note"));
+        assert!(items[0].comments.inline_before_value);
+    }
+
+    #[test]
+    fn standalone_comment_above_a_value_stays_a_head_comment() {
+        // Only the introducer's own line counts: a comment on a line of its own
+        // still belongs above the value it precedes.
+        let r = root("key:\n  # note\n  a: 1\n");
+        let v = get(&r, "key");
+        assert!(v.comments.inline.is_none());
+        assert_eq!(v.comments.head, vec!["note".to_owned()]);
     }
 
     #[test]

--- a/src/roundtrip/composer.rs
+++ b/src/roundtrip/composer.rs
@@ -442,58 +442,66 @@ enum Intro {
     AfterDash(u32),
 }
 
-/// Give `node` the comment written after the `:` or `-` that introduced it, when
-/// the value itself starts on a later line (`key: # note`).
-///
-/// Such a comment belongs to the entry. Left to the head walk in
-/// [`visit_for_comments`], it would become a standalone comment above the value:
-/// invisible to `.comment`, and for a collection value leaking onto its first
-/// child's `comment_before`.
-fn claim_introducer_comment(
-    node: &mut YamlNode,
-    context: &CommentContext<'_>,
-    state: &mut WalkState,
-    intro: Intro,
-) {
-    let Some(comment) = context.comments.get(state.cursor) else {
-        return;
-    };
-    // Only a comment above the node's own first line can sit on the introducer.
-    if comment.span.line >= node.span.line {
-        return;
-    }
-    // The column just past the introducer, which the comment must follow.
+/// The column just past the introducer when `comment` was written on the
+/// introducer's own line, or `None` when it is a standalone line above the node.
+fn introducer_gap(intro: Intro, comment: &Comment, context: &CommentContext<'_>) -> Option<u32> {
     let after_intro = match intro {
-        Intro::None => return,
+        Intro::None => return None,
         // The `:` follows the key directly, so the introducer ends one column
         // past the key's exact end.
         Intro::AfterKey(line, column) if line == comment.span.line => column + 1,
         // Every `-` of a block sequence sits at the sequence's own column, and
-        // the composer recorded the ones whose item begins further down. A
-        // comment on any other line above the item is a standalone comment and
-        // stays a head comment.
+        // the composer recorded the ones whose item begins further down. That set
+        // is empty for a document that has no such dash at all, which is nearly
+        // all of them, so check that before hashing a lookup for every comment.
         Intro::AfterDash(column)
-            if context
-                .dash_positions
-                .contains(&(comment.span.line, column)) =>
+            if !context.dash_positions.is_empty()
+                && context
+                    .dash_positions
+                    .contains(&(comment.span.line, column)) =>
         {
             column + 1
         }
-        _ => return,
+        _ => return None,
     };
-    if comment.span.column < after_intro {
-        return;
+    (comment.span.column >= after_intro).then_some(after_intro)
+}
+
+/// Attach one comment written above `node`.
+///
+/// A comment on the line that *introduces* the node (`key: # note`, `- # note`)
+/// trails the entry, and is its inline comment even though the value starts
+/// further down. Filed as a head comment instead it would be invisible to
+/// `.comment`, and for a collection value would leak onto its first child's
+/// `comment_before`. Every other comment above the node is a standalone line and
+/// becomes a head comment, so the two can interleave: a section comment above a
+/// `-`, the dash's own comment, then more lines below it.
+fn attach_comment_above(
+    node: &mut YamlNode,
+    comment: &Comment,
+    intro: Intro,
+    context: &CommentContext<'_>,
+) {
+    match introducer_gap(intro, comment, context) {
+        Some(after_intro) if node.comments.inline.is_none() => {
+            node.comments.inline = Some(comment.text.clone());
+            // Alignment padding, measured from just past the `:`/`-`. An anchor
+            // or tag is emitted in that gap (`key: &a # note`), so measuring
+            // across it would overcount; those fall back to a single space, as
+            // the `value_pad` rule does.
+            if node.anchor.is_none() && node.tag.is_none() {
+                node.comments.inline_spaces = comment.span.column - after_intro;
+            }
+            node.comments.inline_before_value = true;
+        }
+        _ => {
+            node.comments.head.push(comment.text.clone());
+            // Comments reaching here after the introducer's own belong below it.
+            if node.comments.inline_before_value {
+                node.comments.head_below = node.comments.head_below.saturating_add(1);
+            }
+        }
     }
-    node.comments.inline = Some(comment.text.clone());
-    // Alignment padding, measured from just past the `:`/`-`. An anchor or tag is
-    // emitted in that gap (`key: &a # note`), so measuring across it would
-    // overcount; those fall back to a single space, as the `value_pad` rule does.
-    if node.anchor.is_none() && node.tag.is_none() {
-        node.comments.inline_spaces = comment.span.column - after_intro;
-    }
-    node.comments.inline_before_value = true;
-    state.bump(comment.span.line);
-    state.cursor += 1;
 }
 
 /// Walk a single node, recording its leading blank lines, consuming head
@@ -538,14 +546,13 @@ fn visit_for_comments_inner(
         node.comments.blank_before = blanks_between(context.blank_lines, prev, block_start);
     }
 
-    claim_introducer_comment(node, context, state, intro);
-
-    // Head: standalone comment lines strictly above this node.
+    // The comments above this node's own line: the one written on the line that
+    // introduced it trails this entry, the rest are standalone lines above it.
     while let Some(comment) = context.comments.get(state.cursor) {
         if comment.span.line >= line {
             break;
         }
-        node.comments.head.push(comment.text.clone());
+        attach_comment_above(node, comment, intro, context);
         state.bump(comment.span.line);
         state.cursor += 1;
     }
@@ -1084,9 +1091,21 @@ impl<'input> Composer<'input> {
                             span,
                         ));
                     }
-                    let key = self
-                        .compose_node(events, false)?
-                        .unwrap_or_else(|| YamlNode::new(YamlNodeKind::Null, Span::default()));
+                    let key = match self.compose_node(events, false)? {
+                        Some(node) => node,
+                        // An implicit key with no node of its own (`: value`) has
+                        // no source text to point at. Place it at the `:` that
+                        // introduces the pair, so its position - and the
+                        // introducer a trailing comment is measured against - is
+                        // the real one rather than the start of the document.
+                        None => {
+                            let span = events
+                                .get(self.pos)
+                                .filter(|event| matches!(event.kind, EventKind::Value))
+                                .map_or_else(Span::default, |event| event.span);
+                            YamlNode::new(YamlNodeKind::Null, span)
+                        }
+                    };
                     let has_value = self.pos < events.len()
                         && matches!(events[self.pos].kind, EventKind::Value);
                     if has_value {

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -838,8 +838,9 @@ impl YAMLRocksDocumentView {
 ///
 /// Comments follow YAML's own placement. `comment_before` is the standalone
 /// comment above a node (above its key, for a mapping value) and `comment` is
-/// the inline comment trailing the value on the same line. Both read and write
-/// the bare comment text, without the leading `#`.
+/// the comment trailing the entry: after the value on its own line, or after the
+/// `key:`/`-` that introduces it when the value is a block written below. Both
+/// read and write the bare comment text, without the leading `#`.
 #[pyclass(name = "YAMLRocksNode")]
 pub struct YAMLRocksNode {
     root: Py<YAMLRocksDocument>,
@@ -949,8 +950,14 @@ impl YAMLRocksNode {
             .map(|p| p.to_string_lossy().into_owned()))
     }
 
-    /// The inline comment trailing this node's value, or `None`. The returned
-    /// text has no leading `#` or surrounding whitespace.
+    /// The comment trailing this node, or `None`. The returned text has no
+    /// leading `#` or surrounding whitespace.
+    ///
+    /// For a value written on the key's own line this is the comment after it
+    /// (`port: 8080  # the http port`). For a block mapping or sequence, whose
+    /// value starts on the line below, YAML puts that comment after the key
+    /// instead (`servers: # the whole pool`), and it is read there. A sequence
+    /// item written under its own dash (`- # note`) works the same way.
     #[getter]
     fn comment(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let doc = self.root.borrow(py);
@@ -958,7 +965,9 @@ impl YAMLRocksNode {
         Ok(node.comments.inline.clone())
     }
 
-    /// Set or clear the inline comment. Pass the bare text (no `#`) or `None`.
+    /// Set or clear the trailing comment. Pass the bare text (no `#`) or `None`.
+    /// It is written where YAML puts it for this node: after the value, or after
+    /// the `key:`/`-` when the value is a block written on the lines below.
     #[setter]
     fn set_comment(&self, py: Python<'_>, text: Option<String>) -> PyResult<()> {
         let mut doc = self.root.borrow_mut(py);

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -873,6 +873,7 @@ impl YAMLRocksNode {
         let node = resolve_path_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
         let mut new_val = python_to_node(py, value, double_quotes, schema)?;
         new_val.comments.head = std::mem::take(&mut node.comments.head);
+        new_val.comments.head_below = node.comments.head_below;
         new_val.comments.inline = node.comments.inline.take();
         // Keep the alignment padding around the value so an edit preserves the
         // author's layout: the gap between the key's `:` and the value, and the
@@ -1000,6 +1001,9 @@ impl YAMLRocksNode {
         let mut doc = self.root.borrow_mut(py);
         let node = resolve_head_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
         node.comments.head = split_comment_lines(text);
+        // A comment written through this setter sits *before* the node, which for
+        // a sequence item means above its `-`, not below a comment on it.
+        node.comments.head_below = 0;
         node.mark_modified();
         Ok(())
     }
@@ -1613,6 +1617,7 @@ fn set_child(
                 // comments, anchor, and tag), matching `YAMLRocksNode.set_value`, so
                 // an edit does not silently drop nearby comments or markup.
                 new_val.comments.head = std::mem::take(&mut v.comments.head);
+                new_val.comments.head_below = v.comments.head_below;
                 new_val.comments.inline = v.comments.inline.take();
                 new_val.comments.value_pad = v.comments.value_pad;
                 new_val.comments.inline_spaces = v.comments.inline_spaces;
@@ -1642,6 +1647,7 @@ fn set_child(
             // the new value so editing a list entry preserves the markup around
             // it, matching `YAMLRocksNode.set_value`.
             new_val.comments.head = std::mem::take(&mut target.comments.head);
+            new_val.comments.head_below = target.comments.head_below;
             new_val.comments.inline = target.comments.inline.take();
             new_val.comments.value_pad = target.comments.value_pad;
             new_val.comments.inline_spaces = target.comments.inline_spaces;

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -19,7 +19,7 @@ use super::anchors::{
     alias_target_path, build_anchor_map, collect_alias_paths, collect_anchor_paths,
     collect_anchor_refs, detached_clone, find_anchor_path, path_precedes,
 };
-use super::ast::{NodeStyle, YamlNode, YamlNodeKind};
+use super::ast::{HeadComment, NodeStyle, YamlNode, YamlNodeKind};
 use super::emit;
 use super::emit::{emit_roundtrip_all_with, emit_roundtrip_with};
 use super::value::{node_to_python_key, node_to_python_with, python_to_node, ObjectCache};
@@ -873,7 +873,6 @@ impl YAMLRocksNode {
         let node = resolve_path_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
         let mut new_val = python_to_node(py, value, double_quotes, schema)?;
         new_val.comments.head = std::mem::take(&mut node.comments.head);
-        new_val.comments.head_below = node.comments.head_below;
         new_val.comments.inline = node.comments.inline.take();
         // Keep the alignment padding around the value so an edit preserves the
         // author's layout: the gap between the key's `:` and the value, and the
@@ -991,7 +990,14 @@ impl YAMLRocksNode {
     fn comment_before(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let doc = self.root.borrow(py);
         let node = resolve_head(&doc.nodes, &self.path).ok_or_else(stale_node)?;
-        Ok(join_comment_lines(&node.comments.head))
+        Ok(join_comment_lines(
+            &node
+                .comments
+                .head
+                .iter()
+                .map(|comment| comment.text.to_string())
+                .collect::<Vec<_>>(),
+        ))
     }
 
     /// Set or clear the standalone comment above this node. A multi-line string
@@ -1000,10 +1006,12 @@ impl YAMLRocksNode {
     fn set_comment_before(&self, py: Python<'_>, text: Option<String>) -> PyResult<()> {
         let mut doc = self.root.borrow_mut(py);
         let node = resolve_head_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
-        node.comments.head = split_comment_lines(text);
         // A comment written through this setter sits *before* the node, which for
         // a sequence item means above its `-`, not below a comment on it.
-        node.comments.head_below = 0;
+        node.comments.head = split_comment_lines(text)
+            .into_iter()
+            .map(HeadComment::above)
+            .collect();
         node.mark_modified();
         Ok(())
     }
@@ -1617,7 +1625,6 @@ fn set_child(
                 // comments, anchor, and tag), matching `YAMLRocksNode.set_value`, so
                 // an edit does not silently drop nearby comments or markup.
                 new_val.comments.head = std::mem::take(&mut v.comments.head);
-                new_val.comments.head_below = v.comments.head_below;
                 new_val.comments.inline = v.comments.inline.take();
                 new_val.comments.value_pad = v.comments.value_pad;
                 new_val.comments.inline_spaces = v.comments.inline_spaces;
@@ -1647,7 +1654,6 @@ fn set_child(
             // the new value so editing a list entry preserves the markup around
             // it, matching `YAMLRocksNode.set_value`.
             new_val.comments.head = std::mem::take(&mut target.comments.head);
-            new_val.comments.head_below = target.comments.head_below;
             new_val.comments.inline = target.comments.inline.take();
             new_val.comments.value_pad = target.comments.value_pad;
             new_val.comments.inline_spaces = target.comments.inline_spaces;

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -987,24 +987,31 @@ impl YAMLRocksNode {
     /// The standalone comment line(s) above this node, joined by newlines, or
     /// `None`. For a mapping value this is the comment above its key.
     ///
-    /// A sequence item reports only the block above its `-`. Comments written
-    /// *below* a comment on that dash (`- # note`) sit inside the entry, and
-    /// this property both reads and writes the block above it.
+    /// A sequence item's head block can straddle its `-`: the item itself
+    /// reports the comments above the dash, while the first key inside it
+    /// reports the ones written below a comment on that dash, which is where
+    /// they sit relative to that key. Each writes back the part it reads.
     #[getter]
     fn comment_before(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let doc = self.root.borrow(py);
-        let node = resolve_head(&doc.nodes, &self.path).ok_or_else(stale_node)?;
-        let lines: Vec<String> = if self.heads_a_sequence_item() {
-            node.comments
-                .head_above_introducer()
-                .map(str::to_owned)
-                .collect()
-        } else {
-            node.comments
+        let (node, scope) = resolve_head(&doc.nodes, &self.path).ok_or_else(stale_node)?;
+        let lines: Vec<String> = match scope {
+            HeadScope::All => node
+                .comments
                 .head
                 .iter()
                 .map(|comment| comment.text.to_string())
-                .collect()
+                .collect(),
+            HeadScope::AboveDash => node
+                .comments
+                .head_above_introducer()
+                .map(str::to_owned)
+                .collect(),
+            HeadScope::BelowDash => node
+                .comments
+                .head_below_introducer()
+                .map(str::to_owned)
+                .collect(),
         };
         Ok(join_comment_lines(&lines))
     }
@@ -1014,39 +1021,34 @@ impl YAMLRocksNode {
     #[setter]
     fn set_comment_before(&self, py: Python<'_>, text: Option<String>) -> PyResult<()> {
         let mut doc = self.root.borrow_mut(py);
-        // Keep whatever sits below a sequence item's dash comment: the getter
-        // does not report it, so replacing it here would delete a comment the
-        // caller never saw.
-        let keep_below: Vec<HeadComment> = if self.heads_a_sequence_item() {
-            let node = resolve_head(&doc.nodes, &self.path).ok_or_else(stale_node)?;
-            node.comments
+        let (node, scope) = resolve_head_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
+        // Replace only the part this cursor reads, and keep the other side of the
+        // dash: the caller never saw it, so overwriting it would delete a comment
+        // out from under them.
+        let kept: Vec<HeadComment> = match scope {
+            HeadScope::All => Vec::new(),
+            HeadScope::AboveDash | HeadScope::BelowDash => node
+                .comments
                 .head
                 .iter()
-                .filter(|comment| comment.below_introducer)
+                .filter(|comment| comment.below_introducer == (scope == HeadScope::AboveDash))
                 .cloned()
-                .collect()
-        } else {
-            Vec::new()
+                .collect(),
         };
-        let node = resolve_head_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
-        // A comment written through this setter sits *before* the node, which for
-        // a sequence item means above its `-`, not below a comment on it.
-        node.comments.head = split_comment_lines(text)
+        let written = split_comment_lines(text)
             .into_iter()
-            .map(HeadComment::above)
-            .chain(keep_below)
-            .collect();
+            .map(|text| HeadComment {
+                text: text.into_boxed_str(),
+                below_introducer: scope == HeadScope::BelowDash,
+            });
+        // Source order: everything above the dash, then everything below it.
+        node.comments.head = if scope == HeadScope::BelowDash {
+            kept.into_iter().chain(written).collect()
+        } else {
+            written.chain(kept).collect()
+        };
         node.mark_modified();
         Ok(())
-    }
-
-    /// Whether `comment_before` on this cursor addresses a sequence item's own
-    /// head comments. Every other path resolves either to a node that cannot
-    /// carry an introducer comment (a mapping key, the document root) or, for a
-    /// mapping's first key, to the mapping node itself - whose head comments are
-    /// that mapping's leading block, and must stay readable in full.
-    fn heads_a_sequence_item(&self) -> bool {
-        matches!(self.path.last(), Some(PathSeg::Index(_)))
     }
 
     /// The trailing comment line(s) after this node, joined by newlines, or
@@ -1419,9 +1421,33 @@ fn renders_foot(node: &YamlNode) -> bool {
 /// comment the composer attaches to the enclosing mapping (which is rendered
 /// just above that first key). This returns whichever node actually holds it, so
 /// `comment_before` reads and writes the same place the emitter renders.
-fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<&'a YamlNode> {
+/// Which part of a node's head comments a `comment_before` cursor addresses.
+///
+/// A sequence item's head block can straddle its `-`: comments above the dash
+/// precede the whole entry, while comments below a dash comment (`- # note`) sit
+/// inside it, directly above its first key. The two are stored together, so the
+/// cursor decides which of them it means.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HeadScope {
+    /// The whole block: a mapping's leading comments, a key node's own, or the
+    /// document root's. Nothing divides these.
+    All,
+    /// The comments above a sequence item's `-`.
+    AboveDash,
+    /// The comments below that dash's own comment, which are the ones directly
+    /// above the first key inside the item.
+    BelowDash,
+}
+
+/// Resolve the node holding this cursor's "before" comments, and which part of
+/// them the cursor addresses.
+///
+/// Returning both together is deliberate: deciding the scope separately means a
+/// second copy of this walk, and the two then disagree about which node a path
+/// reached.
+fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<(&'a YamlNode, HeadScope)> {
     match path.split_last() {
-        None => roots.first(),
+        None => roots.first().map(|node| (node, HeadScope::All)),
         Some((PathSeg::Key(k), parent)) => {
             let parent_node = resolve_path(roots, parent)?;
             let YamlNodeKind::Mapping(pairs) = &parent_node.kind else {
@@ -1432,20 +1458,39 @@ fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<&'a YamlN
             // above the first key); any later pair carries its own.
             let idx = pairs.iter().rposition(|(key, _)| scalar_eq(key, k))?;
             if idx == 0 {
-                Some(parent_node)
+                Some((parent_node, head_scope_of_parent(parent)))
             } else {
-                Some(&pairs[idx].0)
+                Some((&pairs[idx].0, HeadScope::All))
             }
         }
-        // A sequence element or a key node holds its own head comment.
-        Some((PathSeg::Index(_) | PathSeg::KeyNode(_), _)) => resolve_path(roots, path),
+        // A sequence element holds its own head comment, and owns the block
+        // above its dash; a key node holds its own with nothing to divide.
+        Some((PathSeg::Index(_), _)) => {
+            resolve_path(roots, path).map(|node| (node, HeadScope::AboveDash))
+        }
+        Some((PathSeg::KeyNode(_), _)) => {
+            resolve_path(roots, path).map(|node| (node, HeadScope::All))
+        }
     }
 }
 
-/// Mutable counterpart to [`resolve_head`].
-fn resolve_head_mut<'a>(roots: &'a mut [YamlNode], path: &[PathSeg]) -> Option<&'a mut YamlNode> {
+/// The scope for a first-key cursor, whose head comments live on the mapping
+/// itself. When that mapping *is* a sequence item, they are the comments below
+/// its dash; anywhere else there is no dash to divide them.
+fn head_scope_of_parent(parent: &[PathSeg]) -> HeadScope {
+    match parent.last() {
+        Some(PathSeg::Index(_)) => HeadScope::BelowDash,
+        _ => HeadScope::All,
+    }
+}
+
+/// Mutable counterpart to [`resolve_head`], reporting the same scope.
+fn resolve_head_mut<'a>(
+    roots: &'a mut [YamlNode],
+    path: &[PathSeg],
+) -> Option<(&'a mut YamlNode, HeadScope)> {
     match path.split_last() {
-        None => roots.first_mut(),
+        None => roots.first_mut().map(|node| (node, HeadScope::All)),
         Some((PathSeg::Key(k), parent)) => {
             let parent_node = resolve_path_mut(roots, parent)?;
             // Mirror [`resolve_head`]: the last occurrence is the effective key,
@@ -1457,14 +1502,20 @@ fn resolve_head_mut<'a>(roots: &'a mut [YamlNode], path: &[PathSeg]) -> Option<&
                 _ => return None,
             }?;
             if idx == 0 {
-                Some(parent_node)
+                let scope = head_scope_of_parent(parent);
+                Some((parent_node, scope))
             } else if let YamlNodeKind::Mapping(pairs) = &mut parent_node.kind {
-                Some(&mut pairs[idx].0)
+                Some((&mut pairs[idx].0, HeadScope::All))
             } else {
                 None
             }
         }
-        Some((PathSeg::Index(_) | PathSeg::KeyNode(_), _)) => resolve_path_mut(roots, path),
+        Some((PathSeg::Index(_), _)) => {
+            resolve_path_mut(roots, path).map(|node| (node, HeadScope::AboveDash))
+        }
+        Some((PathSeg::KeyNode(_), _)) => {
+            resolve_path_mut(roots, path).map(|node| (node, HeadScope::All))
+        }
     }
 }
 

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -986,18 +986,27 @@ impl YAMLRocksNode {
 
     /// The standalone comment line(s) above this node, joined by newlines, or
     /// `None`. For a mapping value this is the comment above its key.
+    ///
+    /// A sequence item reports only the block above its `-`. Comments written
+    /// *below* a comment on that dash (`- # note`) sit inside the entry, and
+    /// this property both reads and writes the block above it.
     #[getter]
     fn comment_before(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let doc = self.root.borrow(py);
         let node = resolve_head(&doc.nodes, &self.path).ok_or_else(stale_node)?;
-        Ok(join_comment_lines(
-            &node
-                .comments
+        let lines: Vec<String> = if self.heads_a_sequence_item() {
+            node.comments
+                .head_above_introducer()
+                .map(str::to_owned)
+                .collect()
+        } else {
+            node.comments
                 .head
                 .iter()
                 .map(|comment| comment.text.to_string())
-                .collect::<Vec<_>>(),
-        ))
+                .collect()
+        };
+        Ok(join_comment_lines(&lines))
     }
 
     /// Set or clear the standalone comment above this node. A multi-line string
@@ -1005,15 +1014,39 @@ impl YAMLRocksNode {
     #[setter]
     fn set_comment_before(&self, py: Python<'_>, text: Option<String>) -> PyResult<()> {
         let mut doc = self.root.borrow_mut(py);
+        // Keep whatever sits below a sequence item's dash comment: the getter
+        // does not report it, so replacing it here would delete a comment the
+        // caller never saw.
+        let keep_below: Vec<HeadComment> = if self.heads_a_sequence_item() {
+            let node = resolve_head(&doc.nodes, &self.path).ok_or_else(stale_node)?;
+            node.comments
+                .head
+                .iter()
+                .filter(|comment| comment.below_introducer)
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
         let node = resolve_head_mut(&mut doc.nodes, &self.path).ok_or_else(stale_node)?;
         // A comment written through this setter sits *before* the node, which for
         // a sequence item means above its `-`, not below a comment on it.
         node.comments.head = split_comment_lines(text)
             .into_iter()
             .map(HeadComment::above)
+            .chain(keep_below)
             .collect();
         node.mark_modified();
         Ok(())
+    }
+
+    /// Whether `comment_before` on this cursor addresses a sequence item's own
+    /// head comments. Every other path resolves either to a node that cannot
+    /// carry an introducer comment (a mapping key, the document root) or, for a
+    /// mapping's first key, to the mapping node itself - whose head comments are
+    /// that mapping's leading block, and must stay readable in full.
+    fn heads_a_sequence_item(&self) -> bool {
+        matches!(self.path.last(), Some(PathSeg::Index(_)))
     }
 
     /// The trailing comment line(s) after this node, joined by newlines, or

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -879,6 +879,10 @@ impl YAMLRocksNode {
         // run of spaces before an inline `#`.
         new_val.comments.value_pad = node.comments.value_pad;
         new_val.comments.inline_spaces = node.comments.inline_spaces;
+        // Where that comment sits travels with it. Dropping this would move a
+        // `key: # note` comment after the new value, and for a sequence item
+        // would strand the head comments written below its dash.
+        new_val.comments.inline_before_value = node.comments.inline_before_value;
         new_val.comments.foot = std::mem::take(&mut node.comments.foot);
         new_val.anchor = node.anchor.take();
         new_val.tag = node.tag.take();
@@ -1612,6 +1616,7 @@ fn set_child(
                 new_val.comments.inline = v.comments.inline.take();
                 new_val.comments.value_pad = v.comments.value_pad;
                 new_val.comments.inline_spaces = v.comments.inline_spaces;
+                new_val.comments.inline_before_value = v.comments.inline_before_value;
                 new_val.comments.foot = std::mem::take(&mut v.comments.foot);
                 new_val.anchor = v.anchor.take();
                 new_val.tag = v.tag.take();
@@ -1640,6 +1645,7 @@ fn set_child(
             new_val.comments.inline = target.comments.inline.take();
             new_val.comments.value_pad = target.comments.value_pad;
             new_val.comments.inline_spaces = target.comments.inline_spaces;
+            new_val.comments.inline_before_value = target.comments.inline_before_value;
             new_val.comments.foot = std::mem::take(&mut target.comments.foot);
             new_val.anchor = target.anchor.take();
             new_val.tag = target.tag.take();

--- a/src/roundtrip/document.rs
+++ b/src/roundtrip/document.rs
@@ -1458,7 +1458,7 @@ fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<(&'a Yaml
             // above the first key); any later pair carries its own.
             let idx = pairs.iter().rposition(|(key, _)| scalar_eq(key, k))?;
             if idx == 0 {
-                Some((parent_node, head_scope_of_parent(parent)))
+                Some((parent_node, head_scope_of_parent(parent, parent_node)))
             } else {
                 Some((&pairs[idx].0, HeadScope::All))
             }
@@ -1466,7 +1466,7 @@ fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<(&'a Yaml
         // A sequence element holds its own head comment, and owns the block
         // above its dash; a key node holds its own with nothing to divide.
         Some((PathSeg::Index(_), _)) => {
-            resolve_path(roots, path).map(|node| (node, HeadScope::AboveDash))
+            resolve_path(roots, path).map(|node| (node, head_scope_of_item(node)))
         }
         Some((PathSeg::KeyNode(_), _)) => {
             resolve_path(roots, path).map(|node| (node, HeadScope::All))
@@ -1475,12 +1475,23 @@ fn resolve_head<'a>(roots: &'a [YamlNode], path: &[PathSeg]) -> Option<(&'a Yaml
 }
 
 /// The scope for a first-key cursor, whose head comments live on the mapping
-/// itself. When that mapping *is* a sequence item, they are the comments below
-/// its dash; anywhere else there is no dash to divide them.
-fn head_scope_of_parent(parent: &[PathSeg]) -> HeadScope {
+/// itself. When that mapping is a sequence item whose dash carries a comment,
+/// they are the lines below that comment; with no dash comment there is nothing
+/// dividing the block, and the whole of it sits above the key.
+fn head_scope_of_parent(parent: &[PathSeg], parent_node: &YamlNode) -> HeadScope {
     match parent.last() {
-        Some(PathSeg::Index(_)) => HeadScope::BelowDash,
+        Some(PathSeg::Index(_)) if parent_node.comments.inline_before_value => HeadScope::BelowDash,
         _ => HeadScope::All,
+    }
+}
+
+/// The scope for a cursor addressing a sequence item itself. Without a comment
+/// on its dash there is no dividing line, so the item owns its whole block.
+fn head_scope_of_item(item: &YamlNode) -> HeadScope {
+    if item.comments.inline_before_value {
+        HeadScope::AboveDash
+    } else {
+        HeadScope::All
     }
 }
 
@@ -1502,7 +1513,7 @@ fn resolve_head_mut<'a>(
                 _ => return None,
             }?;
             if idx == 0 {
-                let scope = head_scope_of_parent(parent);
+                let scope = head_scope_of_parent(parent, parent_node);
                 Some((parent_node, scope))
             } else if let YamlNodeKind::Mapping(pairs) = &mut parent_node.kind {
                 Some((&mut pairs[idx].0, HeadScope::All))
@@ -1510,9 +1521,10 @@ fn resolve_head_mut<'a>(
                 None
             }
         }
-        Some((PathSeg::Index(_), _)) => {
-            resolve_path_mut(roots, path).map(|node| (node, HeadScope::AboveDash))
-        }
+        Some((PathSeg::Index(_), _)) => resolve_path_mut(roots, path).map(|node| {
+            let scope = head_scope_of_item(node);
+            (node, scope)
+        }),
         Some((PathSeg::KeyNode(_), _)) => {
             resolve_path_mut(roots, path).map(|node| (node, HeadScope::All))
         }

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -438,7 +438,12 @@ impl RoundTripEmitter {
         self.emit_anchor_tag_compact(val);
         self.emit_inline_comment(&val.comments);
         self.buf.push(b'\n');
-        self.emit_head(&val.comments, indent);
+        // Only the comments written below the introducer: a sequence item's own
+        // caller has already emitted the ones above its `-`, and a mapping value
+        // has none there (they belong to the key, which was walked first).
+        for comment in val.comments.head_below_introducer() {
+            self.emit_comment_line(comment, indent);
+        }
         self.write_indent(indent);
         self.emit_inline_content(val, indent);
         self.end_line();

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -762,7 +762,7 @@ impl RoundTripEmitter {
 
     fn emit_head(&mut self, comments: &Comments, indent: usize) {
         for comment in &comments.head {
-            self.emit_comment_line(comment, indent);
+            self.emit_comment_line(&comment.text, indent);
         }
     }
 

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -468,7 +468,11 @@ impl RoundTripEmitter {
     /// *below* that dash instead, where the author wrote them, so they are left
     /// to [`emit_head_below_dash`](Self::emit_head_below_dash).
     fn emit_head_above_dash(&mut self, item: &YamlNode, indent: usize) {
-        if !item.comments.inline_before_value {
+        if item.comments.inline_before_value {
+            for comment in item.comments.head_above_introducer() {
+                self.emit_comment_line(comment, indent);
+            }
+        } else {
             self.emit_head(&item.comments, indent);
         }
     }
@@ -477,7 +481,9 @@ impl RoundTripEmitter {
     /// on the lines between a dash-line comment and the item's own content.
     fn emit_head_below_dash(&mut self, item: &YamlNode, indent: usize) {
         if item.comments.inline_before_value {
-            self.emit_head(&item.comments, indent);
+            for comment in item.comments.head_below_introducer() {
+                self.emit_comment_line(comment, indent);
+            }
         }
     }
 

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -403,6 +403,12 @@ impl RoundTripEmitter {
                 self.emit_anchor_tag_compact(val);
                 self.buf.push(b'\n');
             }
+            // A value the author wrote below its key, with a comment left on the
+            // key line (`key: # note`). Keep both where they were: pushing the
+            // comment past the value would move it onto a line it was never on.
+            _ if val.comments.inline_before_value => {
+                self.emit_value_below_introducer(val, child);
+            }
             _ => {
                 // Restore the padding between the `:` and an inline value
                 // (`example:      true`); one space for a synthetic value.
@@ -420,6 +426,20 @@ impl RoundTripEmitter {
         }
     }
 
+    /// Emit a value that sits on the line(s) below its introducer, after the
+    /// comment the author left on the `key:`/`-` line itself. The cursor sits
+    /// just past that introducer; the comment closes the line, any standalone
+    /// comments between the two follow, then the value at `indent`.
+    fn emit_value_below_introducer(&mut self, val: &YamlNode, indent: usize) {
+        self.emit_inline_comment(&val.comments);
+        self.buf.push(b'\n');
+        self.emit_head(&val.comments, indent);
+        self.write_indent(indent);
+        self.emit_anchor_tag(val);
+        self.emit_inline_content(val, indent);
+        self.end_line();
+    }
+
     /// Ensure the buffer ends with exactly one newline (block scalars emit
     /// their own trailing newlines; plain scalars do not).
     fn end_line(&mut self) {
@@ -433,9 +453,27 @@ impl RoundTripEmitter {
     fn emit_block_sequence(&mut self, items: &[YamlNode], indent: usize) {
         for item in items {
             self.emit_blank_before(&item.comments);
-            self.emit_head(&item.comments, indent);
+            self.emit_head_above_dash(item, indent);
             self.write_indent(indent);
             self.emit_sequence_item_body(item, indent);
+        }
+    }
+
+    /// Emit the standalone comments that precede a sequence item's `-`. An item
+    /// whose dash line ends in a comment (`- # note`) holds its head comments
+    /// *below* that dash instead, where the author wrote them, so they are left
+    /// to [`emit_head_below_dash`](Self::emit_head_below_dash).
+    fn emit_head_above_dash(&mut self, item: &YamlNode, indent: usize) {
+        if !item.comments.inline_before_value {
+            self.emit_head(&item.comments, indent);
+        }
+    }
+
+    /// The counterpart: emit the head comments an item carries *below* its dash,
+    /// on the lines between a dash-line comment and the item's own content.
+    fn emit_head_below_dash(&mut self, item: &YamlNode, indent: usize) {
+        if item.comments.inline_before_value {
+            self.emit_head(&item.comments, indent);
         }
     }
 
@@ -447,7 +485,7 @@ impl RoundTripEmitter {
         for (i, item) in items.iter().enumerate() {
             if i > 0 {
                 self.emit_blank_before(&item.comments);
-                self.emit_head(&item.comments, indent);
+                self.emit_head_above_dash(item, indent);
                 self.write_indent(indent);
             }
             self.emit_sequence_item_body(item, indent);
@@ -502,8 +540,18 @@ impl RoundTripEmitter {
                     // item through `emit_value_after_colon`), not the fixed +2 of
                     // the compact inline form below.
                     self.emit_anchor_tag_compact(item);
+                    self.emit_inline_comment(&item.comments);
                     self.buf.push(b'\n');
+                    self.emit_head_below_dash(item, indent + self.step());
                     self.emit_block_mapping(m, indent + self.step());
+                } else if item.comments.inline.is_some() {
+                    // A comment closing the dash line (`- # note`) keeps the
+                    // first key off it, so the mapping opens on the next line at
+                    // the item indent instead of sharing the dash.
+                    self.emit_inline_comment(&item.comments);
+                    self.buf.push(b'\n');
+                    self.emit_head_below_dash(item, child);
+                    self.emit_block_mapping(m, child);
                 } else {
                     self.buf.push(b' ');
                     self.emit_block_mapping_after_dash(m, child);
@@ -519,7 +567,9 @@ impl RoundTripEmitter {
                     // nested sequence's items sit two columns past the dash (the
                     // fast path's fixed offset), unlike a mapping item above.
                     self.emit_anchor_tag_compact(item);
+                    self.emit_inline_comment(&item.comments);
                     self.buf.push(b'\n');
+                    self.emit_head_below_dash(item, child);
                     self.emit_block_sequence(s, child);
                 } else if item.comments.compact {
                     // A compact nested sequence (`- - 1`) keeps its first item on
@@ -527,11 +577,20 @@ impl RoundTripEmitter {
                     self.buf.push(b' ');
                     self.emit_block_sequence_after_dash(s, child);
                 } else {
+                    // As for a mapping item, a comment closing the dash line
+                    // stays there and the nested items open below it.
+                    self.emit_inline_comment(&item.comments);
                     self.buf.push(b'\n');
+                    self.emit_head_below_dash(item, child);
                     self.emit_block_sequence(s, child);
                 }
                 // A trailing comment block at the end of this item's sequence.
                 self.emit_foot(&item.comments, child);
+            }
+            // An item written below its `-`, with a comment left on the dash
+            // line; both keep their place (see the mapping-value arm).
+            _ if item.comments.inline_before_value => {
+                self.emit_value_below_introducer(item, child);
             }
             _ => {
                 // Restore the padding between the `-` and an inline item

--- a/src/roundtrip/emit.rs
+++ b/src/roundtrip/emit.rs
@@ -431,11 +431,15 @@ impl RoundTripEmitter {
     /// just past that introducer; the comment closes the line, any standalone
     /// comments between the two follow, then the value at `indent`.
     fn emit_value_below_introducer(&mut self, val: &YamlNode, indent: usize) {
+        // An anchor or tag stays on the introducer line, ahead of the comment,
+        // where the author wrote it (`key: &a # note`). It binds to the value
+        // either way, but moving it onto the value's line is a reflow this path
+        // exists to avoid.
+        self.emit_anchor_tag_compact(val);
         self.emit_inline_comment(&val.comments);
         self.buf.push(b'\n');
         self.emit_head(&val.comments, indent);
         self.write_indent(indent);
-        self.emit_anchor_tag(val);
         self.emit_inline_content(val, indent);
         self.end_line();
     }
@@ -544,10 +548,12 @@ impl RoundTripEmitter {
                     self.buf.push(b'\n');
                     self.emit_head_below_dash(item, indent + self.step());
                     self.emit_block_mapping(m, indent + self.step());
-                } else if item.comments.inline.is_some() {
+                } else if item.comments.inline.is_some() || item.comments.inline_before_value {
                     // A comment closing the dash line (`- # note`) keeps the
                     // first key off it, so the mapping opens on the next line at
-                    // the item indent instead of sharing the dash.
+                    // the item indent instead of sharing the dash. The placement
+                    // flag holds this open after the comment itself is cleared,
+                    // so the head comments below the dash keep their home.
                     self.emit_inline_comment(&item.comments);
                     self.buf.push(b'\n');
                     self.emit_head_below_dash(item, child);

--- a/tests/features/test_tags.py
+++ b/tests/features/test_tags.py
@@ -342,7 +342,9 @@ def test_dumps_malformed_verbatim_tag_is_rejected():
     """A verbatim tag must be `!<...>` with non-empty content and a closing `>`."""
     import pytest
 
-    for bad in ["!<>", "!<unterminated", "!<tag:foo"]:
+    # `!<tag:a>b>` closes at the first `>`, so emitting it would truncate the tag
+    # and leave `b>` in the document as content.
+    for bad in ["!<>", "!<unterminated", "!<tag:foo", "!<tag:a>b>"]:
         with pytest.raises(yamlrocks.YAMLRocksEncodeError, match="verbatim tag"):
             yamlrocks.dumps(yamlrocks.YAMLRocksTag(bad, "v"))
 

--- a/tests/roundtrip/test_comment_placement.py
+++ b/tests/roundtrip/test_comment_placement.py
@@ -106,74 +106,127 @@ def test_an_unrelated_edit_keeps_every_comment_on_its_line(name: str) -> None:
     assert lines(doc.to_yaml()) == lines(source)
 
 
-# Every cursor that can address a "before" comment, with what it must report.
-# A sequence item owns the block above its dash; the first key inside it owns
-# the block below the dash's own comment, which is where those lines sit
-# relative to that key.
-CURSORS = [
-    (b"- # c2\n  # c3\n  a: 1\n- x\n", "item", lambda d: d.node[0], None),
-    (
-        b"- # c2\n  # c3\n  a: 1\n- x\n",
-        "item-first-key",
-        lambda d: d.node[0]["a"],
-        "c3",
-    ),
-    (b"- y\n# c1\n- # c2\n  # c3\n  a: 1\n", "later-item", lambda d: d.node[1], "c1"),
-    (
-        b"- y\n# c1\n- # c2\n  # c3\n  a: 1\n",
-        "later-item-first-key",
-        lambda d: d.node[1]["a"],
-        "c3",
-    ),
-    (
-        b"- y\n# c1\n- # c2\n  a: 1\n  b: 2\n",
-        "item-second-key",
-        lambda d: d.node[1]["b"],
-        None,
-    ),
-    (b"- y\n# c1\n- a: 1\n", "item-without-dash-comment", lambda d: d.node[1], "c1"),
-    (
-        b"- y\n- a: 1\n  # c3\n  b: 2\n",
-        "second-key-in-plain-item",
-        lambda d: d.node[1]["b"],
-        "c3",
-    ),
-    (
-        b"parent: # c2\n  # c3\n  first: 1\n",
-        "mapping-first-key",
-        lambda d: d.node["parent"]["first"],
-        "c3",
-    ),
-    (b"# c1\nparent:\n  first: 1\n", "mapping-value", lambda d: d.node["parent"], "c1"),
-    (b"k: v\n# c1\nz: 9\n", "later-key", lambda d: d.node["z"], "c1"),
-]
+# Every combination of a sequence item with or without a comment on its dash,
+# with or without comments above and below it, addressed from every cursor that
+# can reach one. Generated rather than listed: the cell this missed the first
+# time (the first key of an item whose dash carries no comment) is exactly the
+# kind a hand-written list of examples leaves out.
+def _item_sources() -> dict[str, bytes]:
+    sources = {}
+    for above in ("", "# above\n"):
+        for dash in ("", " # dash"):
+            for below in ("", "  # below\n"):
+                # A comment below the dash needs one on the dash to sit under.
+                if below and not dash:
+                    continue
+                name = f"above={bool(above)},dash={bool(dash)},below={bool(below)}"
+                sources[name] = (
+                    b"- first: 0\n"
+                    + above.encode()
+                    + b"-"
+                    + dash.encode()
+                    + b"\n"
+                    + below.encode()
+                    + b"  a: 1\n  b: 2\n"
+                ).replace(b"-\n  a: 1", b"- a: 1")
+    return sources
 
 
-@pytest.mark.parametrize(
-    ("source", "label", "cursor", "expected"),
-    CURSORS,
-    ids=[case[1] for case in CURSORS],
-)
-def test_comment_before_reports_the_block_that_cursor_owns(
-    source: bytes, label: str, cursor, expected: str | None
+ITEM_SOURCES = _item_sources()
+
+# Which node each cursor addresses, and how to find the line its "before"
+# comments precede. The item's line is its own `-`, which is the *second* dash
+# in these sources; the keys are found by their text. When the dash carries no
+# comment the item and its first key share that one line, so the two cursors
+# address the same block by design.
+CURSORS = {
+    "item": (lambda doc: doc.node[1], lambda lines: _second_dash(lines)),
+    "first-key": (
+        lambda doc: doc.node[1]["a"],
+        lambda lines: _line_with(lines, b"a: 1"),
+    ),
+    "second-key": (
+        lambda doc: doc.node[1]["b"],
+        lambda lines: _line_with(lines, b"b: 2"),
+    ),
+}
+
+
+def _second_dash(lines: list[bytes]) -> int:
+    """The line of the second item's `-`."""
+    dashes = [i for i, line in enumerate(lines) if line.lstrip().startswith(b"-")]
+    return dashes[1]
+
+
+def _line_with(lines: list[bytes], text: bytes) -> int:
+    return next(i for i, line in enumerate(lines) if text in line)
+
+
+def _comments_directly_above(source: bytes, line_of) -> str | None:
+    """The comment lines immediately above a line, the oracle for the getter.
+
+    Whatever a reader sees written above that line, and nothing further up.
+    """
+    lines = source.split(b"\n")
+    index = line_of(lines)
+    collected = []
+    while index > 0 and lines[index - 1].strip().startswith(b"#"):
+        index -= 1
+        collected.insert(0, lines[index].strip().lstrip(b"#").strip().decode())
+    return "\n".join(collected) if collected else None
+
+
+@pytest.mark.parametrize("name", sorted(ITEM_SOURCES))
+@pytest.mark.parametrize("cursor", sorted(CURSORS))
+def test_comment_before_matches_what_is_written_above_that_line(
+    name: str, cursor: str
 ) -> None:
-    """Each cursor reports the comment block written for it, and no other."""
+    """Each cursor reports exactly the comment lines written above its own line."""
+    source = ITEM_SOURCES[name]
+    resolve, line_of = CURSORS[cursor]
     doc = yamlrocks.loads(source, option=RT)
-    assert cursor(doc).comment_before == expected
+
+    assert resolve(doc).comment_before == _comments_directly_above(source, line_of)
 
 
-@pytest.mark.parametrize(
-    ("source", "label", "cursor", "expected"),
-    CURSORS,
-    ids=[case[1] for case in CURSORS],
-)
-def test_comment_before_writes_back_where_it_was_read(
-    source: bytes, label: str, cursor, expected: str | None
-) -> None:
-    """Assigning ``comment_before`` its own value changes nothing."""
+@pytest.mark.parametrize("name", sorted(ITEM_SOURCES))
+@pytest.mark.parametrize("cursor", sorted(CURSORS))
+def test_comment_before_writes_back_where_it_was_read(name: str, cursor: str) -> None:
+    """Assigning ``comment_before`` its own value changes nothing, from any cursor."""
+    source = ITEM_SOURCES[name]
+    resolve, _ = CURSORS[cursor]
     doc = yamlrocks.loads(source, option=RT)
-    node = cursor(doc)
+    node = resolve(doc)
     node.comment_before = node.comment_before
     # Force the AST path, so the source cache cannot hide a move.
     doc.node.comment_after = doc.node.comment_after
     assert doc.to_yaml() == source
+
+
+@pytest.mark.parametrize(
+    "name", sorted(name for name in ITEM_SOURCES if "dash=True" in name)
+)
+def test_writing_one_side_of_a_dash_leaves_the_other_alone(name: str) -> None:
+    """With a comment on the dash, the item and its first key own separate blocks.
+
+    Without one they share a line, and so address the same block on purpose;
+    only a dash comment splits them.
+    """
+    source = ITEM_SOURCES[name]
+    doc = yamlrocks.loads(source, option=RT)
+    below = doc.node[1]["a"].comment_before
+    doc.node[1].comment_before = "written above"
+    assert doc.node[1]["a"].comment_before == below
+
+    doc = yamlrocks.loads(source, option=RT)
+    above = doc.node[1].comment_before
+    doc.node[1]["a"].comment_before = "written below"
+    assert doc.node[1].comment_before == above
+
+
+# The comment on a mapping's own key line, reached from the first key inside it.
+def test_mapping_first_key_reports_the_leading_block() -> None:
+    """A mapping's leading comments stay readable from its first key."""
+    doc = yamlrocks.loads(b"parent: # note\n  # leading\n  first: 1\n", option=RT)
+    assert doc.node["parent"].comment == "note"
+    assert doc.node["parent"]["first"].comment_before == "leading"

--- a/tests/roundtrip/test_comment_placement.py
+++ b/tests/roundtrip/test_comment_placement.py
@@ -1,0 +1,179 @@
+"""Comment placement across every shape, edit, and cursor.
+
+The introducer-line comment (`key: # note`, `- # note`) is stored with the
+node's other head comments, and the two can straddle a sequence dash: some
+lines belong above it, some below. That split is easy to get right for one
+shape and wrong for the next, so these sweeps assert the invariants over the
+whole matrix rather than case by case:
+
+* an edit anywhere must not lose a comment, move it to another line, or make
+  the document unparsable, and
+* reading ``comment_before`` from any cursor and assigning it straight back
+  must leave the document byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import yaml
+
+import yamlrocks
+
+RT = yamlrocks.OPT_ROUND_TRIP
+COMMENT = re.compile(rb"#\s*(c\d+)")
+
+# One shape per node kind an introducer comment can precede. `c1` sits above the
+# introducer, `c2` on it, `c3` below it.
+SHAPES = {
+    "map-block-map": b"k: # c2\n  # c3\n  a: 1\nz: 9\n",
+    "map-block-seq": b"k: # c2\n  # c3\n  - 1\nz: 9\n",
+    "map-scalar": b"k: # c2\n  # c3\n  v\nz: 9\n",
+    "map-flow": b"k: # c2\n  # c3\n  [1]\nz: 9\n",
+    "map-block-scalar": b"k: # c2\n  # c3\n  |\n  text\nz: 9\n",
+    "map-anchored": b"k: &a # c2\n  # c3\n  v\nz: 9\n",
+    "map-above-and-on": b"# c1\nk: # c2\n  a: 1\nz: 9\n",
+    "seq-block-map": b"- x\n# c1\n- # c2\n  # c3\n  a: 1\n",
+    "seq-block-seq": b"- x\n# c1\n- # c2\n  # c3\n  - 1\n",
+    "seq-scalar": b"- x\n# c1\n- # c2\n  # c3\n  v\n",
+    "seq-flow": b"- x\n# c1\n- # c2\n  # c3\n  [1]\n",
+    "seq-anchored": b"- x\n# c1\n- &a # c2\n  # c3\n  a: 1\n",
+    "seq-nested": b"- x\n# c1\n- # c2\n  - 1\n",
+    "map-trailing": b"k: v # c2\nz: 9\n",
+    "seq-trailing": b"- y\n- v # c2\n",
+}
+
+# Each operation is applied to the commented entry, except the first, which
+# edits an unrelated one to force the AST path.
+OPERATIONS = [
+    "edit elsewhere",
+    "read comment",
+    "set same comment",
+    "set same comment_before",
+    "replace value",
+]
+
+
+def _entries(doc, name):
+    """The commented node and an unrelated one, for a shape."""
+    if name.startswith("seq"):
+        return doc.node[1], doc.node[0]
+    return doc.node["k"], doc.node["z"]
+
+
+def _apply(operation, target, other):
+    if operation == "edit elsewhere":
+        other.value = "EDITED"
+    elif operation == "read comment":
+        # A read alone must not disturb anything either.
+        assert target.comment is None or isinstance(target.comment, str)
+    elif operation == "set same comment":
+        target.comment = target.comment
+    elif operation == "set same comment_before":
+        target.comment_before = target.comment_before
+    elif operation == "replace value":
+        target.value = {"new": 1}
+
+
+@pytest.mark.parametrize("name", sorted(SHAPES))
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_no_edit_loses_a_comment(name: str, operation: str) -> None:
+    """Every comment survives every edit, and the result still parses."""
+    source = SHAPES[name]
+    doc = yamlrocks.loads(source, option=RT)
+    _apply(operation, *_entries(doc, name))
+    emitted = doc.to_yaml()
+
+    assert sorted(COMMENT.findall(emitted)) == sorted(COMMENT.findall(source))
+    yaml.safe_load(emitted)
+
+
+@pytest.mark.parametrize("name", sorted(SHAPES))
+def test_an_unrelated_edit_keeps_every_comment_on_its_line(name: str) -> None:
+    """Editing one value moves nothing else: each comment keeps its own line."""
+    source = SHAPES[name]
+    doc = yamlrocks.loads(source, option=RT)
+    _apply("edit elsewhere", *_entries(doc, name))
+
+    def lines(text: bytes) -> dict[bytes, int]:
+        return {
+            found: number
+            for number, line in enumerate(text.split(b"\n"))
+            for found in COMMENT.findall(line)
+        }
+
+    assert lines(doc.to_yaml()) == lines(source)
+
+
+# Every cursor that can address a "before" comment, with what it must report.
+# A sequence item owns the block above its dash; the first key inside it owns
+# the block below the dash's own comment, which is where those lines sit
+# relative to that key.
+CURSORS = [
+    (b"- # c2\n  # c3\n  a: 1\n- x\n", "item", lambda d: d.node[0], None),
+    (
+        b"- # c2\n  # c3\n  a: 1\n- x\n",
+        "item-first-key",
+        lambda d: d.node[0]["a"],
+        "c3",
+    ),
+    (b"- y\n# c1\n- # c2\n  # c3\n  a: 1\n", "later-item", lambda d: d.node[1], "c1"),
+    (
+        b"- y\n# c1\n- # c2\n  # c3\n  a: 1\n",
+        "later-item-first-key",
+        lambda d: d.node[1]["a"],
+        "c3",
+    ),
+    (
+        b"- y\n# c1\n- # c2\n  a: 1\n  b: 2\n",
+        "item-second-key",
+        lambda d: d.node[1]["b"],
+        None,
+    ),
+    (b"- y\n# c1\n- a: 1\n", "item-without-dash-comment", lambda d: d.node[1], "c1"),
+    (
+        b"- y\n- a: 1\n  # c3\n  b: 2\n",
+        "second-key-in-plain-item",
+        lambda d: d.node[1]["b"],
+        "c3",
+    ),
+    (
+        b"parent: # c2\n  # c3\n  first: 1\n",
+        "mapping-first-key",
+        lambda d: d.node["parent"]["first"],
+        "c3",
+    ),
+    (b"# c1\nparent:\n  first: 1\n", "mapping-value", lambda d: d.node["parent"], "c1"),
+    (b"k: v\n# c1\nz: 9\n", "later-key", lambda d: d.node["z"], "c1"),
+]
+
+
+@pytest.mark.parametrize(
+    ("source", "label", "cursor", "expected"),
+    CURSORS,
+    ids=[case[1] for case in CURSORS],
+)
+def test_comment_before_reports_the_block_that_cursor_owns(
+    source: bytes, label: str, cursor, expected: str | None
+) -> None:
+    """Each cursor reports the comment block written for it, and no other."""
+    doc = yamlrocks.loads(source, option=RT)
+    assert cursor(doc).comment_before == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "label", "cursor", "expected"),
+    CURSORS,
+    ids=[case[1] for case in CURSORS],
+)
+def test_comment_before_writes_back_where_it_was_read(
+    source: bytes, label: str, cursor, expected: str | None
+) -> None:
+    """Assigning ``comment_before`` its own value changes nothing."""
+    doc = yamlrocks.loads(source, option=RT)
+    node = cursor(doc)
+    node.comment_before = node.comment_before
+    # Force the AST path, so the source cache cannot hide a move.
+    doc.node.comment_after = doc.node.comment_after
+    assert doc.to_yaml() == source

--- a/tests/roundtrip/test_node.py
+++ b/tests/roundtrip/test_node.py
@@ -148,6 +148,54 @@ def test_comment_before_absent_is_none():
     assert load().node["server"]["host"].comment_before is None
 
 
+def test_read_comment_on_a_block_mapping_value():
+    """A comment after a key whose value is a block mapping is that node's.
+
+    YAML has nowhere else to put it: the value starts on the next line, so the
+    trailing comment sits on the key's line.
+    """
+    doc = load(b"server: # the http front end\n  host: localhost\n")
+    assert doc.node["server"].comment == "the http front end"
+
+
+def test_read_comment_on_a_block_sequence_value():
+    """The same holds when the value is a block sequence."""
+    doc = load(b"my_cool_list: # hey its a comment\n  - cool-thing\n  - other\n")
+    assert doc.node["my_cool_list"].comment == "hey its a comment"
+
+
+def test_key_line_comment_does_not_leak_to_the_first_child():
+    """The comment belongs to the entry, not to the first key inside it.
+
+    ``comment_before`` of a mapping's first key resolves to the mapping node, so
+    a key-line comment filed as that mapping's head comment would surface as a
+    comment above a child it was never written above.
+    """
+    doc = load(b"server: # the http front end\n  host: localhost\n")
+    assert doc.node["server"]["host"].comment_before is None
+
+
+def test_read_comment_on_a_sequence_item_written_below_its_dash():
+    """A comment after a `-` belongs to that item, not to what follows it."""
+    doc = load(b"- # the first one\n  a: 1\n- b: 2\n")
+    assert doc.node[0].comment == "the first one"
+    assert doc.node[0].comment_before is None
+    assert doc.node[0]["a"].comment_before is None
+
+
+def test_read_comment_on_a_value_written_below_its_key():
+    """A plain scalar written under its key still reports the key-line comment."""
+    doc = load(b"key: # explain\n  value\n")
+    assert doc.node["key"].comment == "explain"
+
+
+def test_standalone_comment_above_a_value_is_not_its_comment():
+    """A comment on a line of its own stays a "before" comment, not a trailing one."""
+    doc = load(b"server:\n  # about host\n  host: localhost\n")
+    assert doc.node["server"].comment is None
+    assert doc.node["server"]["host"].comment_before == "about host"
+
+
 # -- Comments: writing -------------------------------------------------------
 
 
@@ -165,6 +213,21 @@ def test_clear_inline_comment():
     doc = load()
     doc.node["server"]["port"].comment = None
     assert "#" not in doc.to_yaml().decode().split("port: 8080")[1].splitlines()[0]
+
+
+def test_set_comment_on_a_block_value_writes_it_on_the_key_line():
+    """A comment set on a collection lands where YAML puts it: after the key."""
+    doc = load(b"server:\n  host: localhost\n")
+    doc.node["server"].comment = "the http front end"
+    assert doc.to_yaml() == b"server: # the http front end\n  host: localhost\n"
+
+
+def test_clear_comment_on_a_block_value():
+    """Clearing it removes the comment and leaves the key bare."""
+    doc = load(b"server: # the http front end\n  host: localhost\n")
+    doc.node["server"].comment = None
+    doc.node["server"]["host"].value = "127.0.0.1"
+    assert doc.to_yaml() == b"server:\n  host: 127.0.0.1\n"
 
 
 def test_set_comment_before_adds_a_line_above_the_key():

--- a/tests/roundtrip/test_node.py
+++ b/tests/roundtrip/test_node.py
@@ -244,6 +244,36 @@ def test_set_multiline_comment_before():
     assert doc.to_yaml().decode() == "# line one\n# line two\nkey: value\n"
 
 
+def test_comment_before_on_an_item_is_the_block_above_its_dash():
+    """A sequence item reports the comments above its `-`, not the ones inside it.
+
+    A comment written below `- # note` sits in the entry's interior, and the
+    setter writes above the dash, so reporting it here would make reading a
+    comment and writing it straight back move it.
+    """
+    doc = load(b"- # inline\n  # below\n  value\n- x\n")
+    assert doc.node[0].comment == "inline"
+    assert doc.node[0].comment_before is None
+    assert doc.node[1].comment_before is None
+
+
+def test_setting_comment_before_keeps_an_item_interior_comment():
+    """Writing the block above a dash leaves the comments below it alone."""
+    doc = load(b"- # inline\n  # below\n  value\n- x\n")
+    doc.node[0].comment_before = "section"
+    assert doc.to_yaml() == b"# section\n- # inline\n  # below\n  value\n- x\n"
+
+
+def test_comment_before_round_trips_through_the_api():
+    """Reading ``comment_before`` and writing it back changes nothing."""
+    src = b"- a\n# above\n- # inline\n  # below\n  value\n"
+    doc = load(src)
+    assert doc.node[1].comment_before == "above"
+    doc.node[1].comment_before = doc.node[1].comment_before
+    doc.node[0].value = "a"
+    assert doc.to_yaml() == src
+
+
 def test_comment_before_on_first_key_replaces_leading_comment():
     """The leading comment lives above the first key; setting it replaces it."""
     doc = load(b"# old leading\nkey: value\nother: 2\n")

--- a/tests/roundtrip/test_roundtrip.py
+++ b/tests/roundtrip/test_roundtrip.py
@@ -189,16 +189,51 @@ def test_tag_stays_on_the_key_line_beside_its_comment():
     assert doc.to_yaml() == b"key: !t # note\n  value\nz: 2\n"
 
 
-def test_empty_implicit_key_does_not_claim_an_unrelated_comment():
-    """An empty key (`: value`) has no source position, so it introduces nothing.
+def test_section_comment_above_a_commented_dash_stays_above_it():
+    """A comment above the `-` and one on it keep their own sides of the dash.
 
-    Its synthetic null reports the start of the document, which must not be
-    mistaken for an introducer sitting on some other line's comment.
+    They arrive as one run of comments, so the split between them has to be
+    recorded: re-emitting the lot on either side reorders them against the
+    comment written on the dash itself.
     """
-    src = b"outer:\n  : # note\n    child: value\nz: 1\n"
+    src = b"- a\n# about next\n- # inline\n  b: 1\n"
+    doc = yamlrocks.loads(src, option=RT)
+    assert doc.node[1].comment == "inline"
+    doc.node[0].value = "A"
+    assert doc.to_yaml() == b"- A\n# about next\n- # inline\n  b: 1\n"
+
+
+def test_comments_on_both_sides_of_a_commented_dash_survive():
+    """A comment above the dash, one on it, and one below all keep their place."""
+    src = b"- a\n# above\n- # inline\n  # below\n  b: 1\n"
+    doc = yamlrocks.loads(src, option=RT)
+    doc.node[0].value = "A"
+    assert doc.to_yaml() == b"- A\n# above\n- # inline\n  # below\n  b: 1\n"
+    # The split travels with the comments when the item itself is replaced.
+    doc = yamlrocks.loads(src, option=RT)
+    doc.node[1].value = {"b": 9}
+    assert doc.to_yaml() == b"- a\n# above\n- # inline\n  # below\n  b: 9\n"
+
+
+def test_comment_before_on_an_item_lands_above_its_dash():
+    """``comment_before`` replaces the head block and writes above the `-`."""
+    doc = yamlrocks.loads(b"- a\n# above\n- # inline\n  b: 1\n", option=RT)
+    doc.node[1].comment_before = "fresh"
+    assert doc.to_yaml() == b"- a\n# fresh\n- # inline\n  b: 1\n"
+
+
+def test_empty_implicit_key_introduces_from_its_own_colon():
+    """An empty key (`: value`) is placed at its `:`, so it introduces from there.
+
+    The node has no source text of its own; left at the document start (the
+    obvious default) it would measure the introducer against an unrelated line,
+    either missing the comment or claiming one written somewhere else entirely.
+    """
+    src = b"a: 1\n: # note\n  child: v\n"
     doc = yamlrocks.loads(src, option=RT)
     assert doc.to_yaml() == src
-    assert doc.node["outer"].comment is None
+    doc.node["a"].value = 2
+    assert doc.to_yaml() == b"a: 2\nnull: # note\n  child: v\n"
 
 
 def test_quoting_styles_preserved():

--- a/tests/roundtrip/test_roundtrip.py
+++ b/tests/roundtrip/test_roundtrip.py
@@ -215,6 +215,25 @@ def test_comments_on_both_sides_of_a_commented_dash_survive():
     assert doc.to_yaml() == b"- a\n# above\n- # inline\n  # below\n  b: 9\n"
 
 
+def test_a_scalar_item_does_not_repeat_the_comment_above_its_dash():
+    """A scalar item emits only the comments written below its `-`.
+
+    The comments above the dash are written by the sequence itself, before the
+    dash; emitting the whole block again from the item body repeated them under
+    it.
+    """
+    doc = yamlrocks.loads(b"- a\n# above\n- # inline\n  value\n", option=RT)
+    doc.node[0].value = "A"
+    assert doc.to_yaml() == b"- A\n# above\n- # inline\n  value\n"
+
+
+def test_a_scalar_item_keeps_comments_on_both_sides_of_its_dash():
+    """The same item still emits the comments written below the dash."""
+    doc = yamlrocks.loads(b"- a\n# above\n- # inline\n  # below\n  value\n", option=RT)
+    doc.node[0].value = "A"
+    assert doc.to_yaml() == b"- A\n# above\n- # inline\n  # below\n  value\n"
+
+
 def test_comment_before_on_an_item_lands_above_its_dash():
     """``comment_before`` replaces the head block and writes above the `-`."""
     doc = yamlrocks.loads(b"- a\n# above\n- # inline\n  b: 1\n", option=RT)

--- a/tests/roundtrip/test_roundtrip.py
+++ b/tests/roundtrip/test_roundtrip.py
@@ -85,6 +85,54 @@ def test_sequence_comments_preserved():
     assert roundtrip(src) == src
 
 
+def test_key_line_comment_stays_on_the_key_after_an_edit():
+    """A comment after `key:` stays there when the value is a block below it.
+
+    Unmodified documents re-emit from the source cache, which hides the
+    placement; an edit forces the AST path, where the comment used to slide down
+    and become a standalone line above the first child.
+    """
+    doc = yamlrocks.loads(b"servers: # the pool\n  - alpha\nport: 80\n", option=RT)
+    doc["port"] = 8080
+    assert doc.to_yaml() == b"servers: # the pool\n  - alpha\nport: 8080\n"
+
+
+def test_key_line_comment_survives_an_edit_for_a_scalar_below_the_key():
+    """The same for a plain scalar written under its key, where it was dropped."""
+    doc = yamlrocks.loads(b"name: # explain\n  app\nport: 80\n", option=RT)
+    doc["port"] = 8080
+    assert doc.to_yaml() == b"name: # explain\n  app\nport: 8080\n"
+
+
+def test_key_line_comment_keeps_its_alignment_padding():
+    """The gap between the `:` and the `#` survives the AST path."""
+    doc = yamlrocks.loads(b"servers:    # the pool\n  - alpha\nport: 80\n", option=RT)
+    doc["port"] = 8080
+    assert doc.to_yaml() == b"servers:    # the pool\n  - alpha\nport: 8080\n"
+
+
+def test_dash_line_comment_stays_on_the_dash_after_an_edit():
+    """A comment after a `-` keeps its place, with the item below it."""
+    doc = yamlrocks.loads(b"- # the first one\n  a: 1\n- b: 2\n", option=RT)
+    doc[1]["b"] = 9
+    assert doc.to_yaml() == b"- # the first one\n  a: 1\n- b: 9\n"
+
+
+def test_comments_below_a_dash_line_comment_stay_below_it():
+    """Head comments written under `- # note` belong there, not above the dash."""
+    src = b"- # first\n  # second\n  a: 1\n- b: 2\n"
+    doc = yamlrocks.loads(src, option=RT)
+    doc[1]["b"] = 9
+    assert doc.to_yaml() == b"- # first\n  # second\n  a: 1\n- b: 9\n"
+
+
+def test_key_line_comment_kept_when_the_value_itself_is_replaced():
+    """Replacing a block value keeps the comment on the key line."""
+    doc = yamlrocks.loads(b"servers: # the pool\n  - alpha\n", option=RT)
+    doc.node["servers"].value = ["beta", "gamma"]
+    assert doc.to_yaml().startswith(b"servers: # the pool\n")
+
+
 def test_quoting_styles_preserved():
     """Round-trip preserves single and double quoting styles."""
     src = "double: \"quoted value\"\nsingle: 'sq'\n"

--- a/tests/roundtrip/test_roundtrip.py
+++ b/tests/roundtrip/test_roundtrip.py
@@ -234,6 +234,15 @@ def test_a_scalar_item_keeps_comments_on_both_sides_of_its_dash():
     assert doc.to_yaml() == b"- A\n# above\n- # inline\n  # below\n  value\n"
 
 
+def test_a_long_comment_block_below_a_dash_stays_below_it():
+    """Each head comment records its own side, so the block has no length limit."""
+    below = b"".join(b"  # c%d\n" % i for i in range(300))
+    src = b"- a\n# above\n- # inline\n" + below + b"  value\n"
+    doc = yamlrocks.loads(src, option=RT)
+    doc.node[0].value = "A"
+    assert doc.to_yaml() == b"- A\n# above\n- # inline\n" + below + b"  value\n"
+
+
 def test_comment_before_on_an_item_lands_above_its_dash():
     """``comment_before`` replaces the head block and writes above the `-`."""
     doc = yamlrocks.loads(b"- a\n# above\n- # inline\n  b: 1\n", option=RT)

--- a/tests/roundtrip/test_roundtrip.py
+++ b/tests/roundtrip/test_roundtrip.py
@@ -133,6 +133,74 @@ def test_key_line_comment_kept_when_the_value_itself_is_replaced():
     assert doc.to_yaml().startswith(b"servers: # the pool\n")
 
 
+def test_replacing_a_value_below_its_key_keeps_the_comment_there():
+    """A replaced scalar stays under the key, with the comment above it."""
+    doc = yamlrocks.loads(b"name: # explain\n  app\nport: 80\n", option=RT)
+    doc.node["name"].value = "web"
+    assert doc.to_yaml() == b"name: # explain\n  web\nport: 80\n"
+
+
+def test_replacing_an_item_keeps_its_comments_in_order():
+    """Replacing an item written under `- # note` keeps both comments in place.
+
+    The head comments below the dash are emitted by the item body, so an edit
+    that dropped the placement flag would re-emit them above the dash instead,
+    reordering them against the comment on the dash itself.
+    """
+    doc = yamlrocks.loads(b"- # first\n  # second\n  a: 1\n- b: 2\n", option=RT)
+    doc.node[0].value = {"a": 9}
+    assert doc.to_yaml() == b"- # first\n  # second\n  a: 9\n- b: 2\n"
+
+
+def test_blank_line_above_a_commented_dash_survives():
+    """Section spacing before `- # note` is measured from the dash, not the item."""
+    doc = yamlrocks.loads(b"- one\n\n- # note\n  two\n", option=RT)
+    doc.node[0].value = "ONE"
+    assert doc.to_yaml() == b"- ONE\n\n- # note\n  two\n"
+
+
+def test_a_commented_dash_does_not_invent_a_leading_blank_line():
+    """A blank line *inside* the entry is not re-emitted above its dash."""
+    doc = yamlrocks.loads(b"- # note\n\n  two\n- x\n", option=RT)
+    doc.node[1].value = "X"
+    assert doc.to_yaml() == b"- # note\n  two\n- X\n"
+
+
+def test_clearing_a_dash_line_comment_keeps_the_comments_below_it():
+    """Clearing `- # note` keeps the head comments written under that dash."""
+    doc = yamlrocks.loads(b"- # first\n  # second\n  a: 1\n- b: 2\n", option=RT)
+    doc.node[0].comment = None
+    assert doc.to_yaml() == b"-\n  # second\n  a: 1\n- b: 2\n"
+
+
+def test_anchor_stays_on_the_key_line_beside_its_comment():
+    """An anchor written before the comment stays there, not on the value's line."""
+    doc = yamlrocks.loads(b"key: &a # note\n  value\nz: 1\n", option=RT)
+    doc.node["z"].value = 2
+    assert doc.to_yaml() == b"key: &a # note\n  value\nz: 2\n"
+
+
+def test_tag_stays_on_the_key_line_beside_its_comment():
+    """The same for a tag written between the `:` and the comment."""
+    doc = yamlrocks.loads(
+        b"key: !t # note\n  value\nz: 1\n", option=RT | yamlrocks.OPT_PASSTHROUGH_TAG
+    )
+    doc.node["z"].value = 2
+    assert doc.to_yaml() == b"key: !t # note\n  value\nz: 2\n"
+
+
+def test_empty_implicit_key_does_not_claim_an_unrelated_comment():
+    """An empty key (`: value`) has no source position, so it introduces nothing.
+
+    Its synthetic null reports the start of the document, which must not be
+    mistaken for an introducer sitting on some other line's comment.
+    """
+    src = b"outer:\n  : # note\n    child: value\nz: 1\n"
+    doc = yamlrocks.loads(src, option=RT)
+    assert doc.to_yaml() == src
+    assert doc.node["outer"].comment is None
+
+
 def test_quoting_styles_preserved():
     """Round-trip preserves single and double quoting styles."""
     src = "double: \"quoted value\"\nsingle: 'sq'\n"


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to YAMLRocks!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different parse
  or emit result, a removed or renamed option)? If so, describe what breaks, how
  to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

No API changes, but the corrected attribution is observable in two places.

A comment on a key's line used to land on the first key *inside* the value. Anyone reading it there gets `None` now, and reads it from the entry instead:

```python
# Before: doc.node["server"]["host"].comment_before == "the http front end"
# After:  doc.node["server"].comment == "the http front end"
```

Re-emitting a *modified* document also changes. Where the comment previously slid down to a line of its own (or vanished, for a scalar or flow value below the key), it now stays on the key's line, exactly where it was written. Unmodified documents were and remain byte-for-byte identical.

Both are the point of the fix: the old placement attributed a comment to a node it was never written near, and the old emit lost it.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

A comment written after a mapping key's `:` or a sequence `-`, with the value itself starting on the next line, was filed as the *head* comment of that value:

```yaml
my_cool_list: # hey its a comment
  - cool-thing
```

That is the only place YAML has to put a trailing comment when the value is a block, so it belongs to the entry. Three things went wrong from there:

1. `YAMLRocksNode.comment` returned `None`, and `comment_before` looks at the key node, so nothing in the public API could reach it.
2. A mapping's first key resolves `comment_before` to the mapping node, so `doc.node["parent"]["first"].comment_before` returned the comment written about `parent`. A comment surfaced above a child it was never above.
3. On the AST path (any modified document) it moved down onto its own line, and for a scalar or flow value written below the key it was dropped entirely.

Comments on the introducer line are now the value node's inline comment, marked `inline_before_value` so the emitter writes them back where the author put them. Sequence items work the same way, head comments written under a `- # note` included: they stay under it instead of jumping above the dash.

Explicit keys (`? key`) and flow mappings keep the old handling on purpose. An explicit key carries its `:` on a line that the key's end position cannot locate, and the flow emitters render no comments at all.

The comment walk recurses once per level of nesting, so its frame is paid a thousand times over on a deeply nested document. Rather than thread the new information through it, the walk now carries its read-only inputs and its running position as two bundled references instead of four, resolves the introducer in the callee's prologue, and reads the rare detached `-` from a set the composer records. `YamlNode` keeps its original size, and the deep-nesting path ends up with *more* headroom than before this change: measured in the coverage job's own configuration (unoptimized plus instrumented), depth-900 input needs 796 KiB of thread stack against main's 832 KiB. Round-trip load throughput is unchanged (13.0 ms against main's 13.2 over five interleaved runs of a 398-document corpus).

Verification beyond the suite: a comment-fidelity sweep over the real-world corpus, forcing every document through the AST path and comparing every node's comments before and after. Mismatching files drop from 15 to 9, and the remaining 9 are all a separate gap (comments in and after flow collections, which the flow emitters never write). Two minutes each on the `roundtrip` and `differential_options` fuzz targets found nothing.

### The second commit

`test_wheel.sh` installed the freshly built wheel with `uv pip install --no-index --find-links dist yamlrocks`. Every build produces the identical name and version, and uv's cache is restored across jobs on a key that hashes `pyproject.toml`/`uv.lock`, so a wheel cached by an earlier run satisfied the requirement and was installed instead. The job then smoke-tested an older binary and reported it as a pass. It shows in the logs: jobs that ran the stale wheel have no `Prepared 1 package` line, jobs that ran the fresh one do.

This surfaced here because this is the first change in a while whose behavior differs enough for the stale binary to fail the new tests. It is fixed with `--refresh-package yamlrocks`, and is in this PR because the wheel jobs cannot verify the first commit without it.

### The third commit

`tags_fast_emittable` filters differential fuzz inputs down to what `dumps` promises to round-trip, but it checked only the leading `!`. A `%TAG` directive expands to a *named* handle (`!h!suffix`), which needs a `%TAG` directive on output that `dumps` never writes, so the emitted document does not reload. The public API rejects such a tag with a clear error; the internal encoder the harness drives does not, so the harness asserted on output `dumps` itself refuses to produce, and `Fuzz changed code` failed on:

```
input:    "%TAG\t! !&G!! \r---\t\t!!-bbbb\t!"
emitted:  "!&G!! \"\"\n"
error:    undefined tag handle: !&G!
```

This is pre-existing and reproduces on `main` through the same internal path; the fuzzer had simply never generated the input before. The rule now lives in one place, `encode::emittable_tag`, used by both the Python path and the fuzz filter, so the two cannot drift apart again. Behavior and error messages are unchanged.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #348
- Two adjacent comment gaps found while working on this, both left alone and worth their own issues: comments in and after flow collections are dropped on a modified re-emit, and a head comment above a non-container value (`k:` / `  # note` / `  value`) is dropped as well.
- One robustness gap, also left alone: `YamlNode::end()` recurses per level with no `stack::guard`, unlike every other recursive descent in the crate, so deeply nested input segfaults on a 128 KiB thread stack (musl's default) on `main` today. Guarding it works but costs ~2% on round-trip loads; caching the collection end at compose time would fix it and make `end()` O(1) instead of O(subtree).

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] I have read the [AI Policy](../AI_POLICY.md), and this pull request was not created by an autonomous agent.
- [ ] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run pytest` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- [x] Round-trip fidelity is preserved: an unmodified document still re-emits byte-for-byte.
- [x] No commented-out or dead code is left in the pull request.

If the change is user-facing:

- [x] Documentation under `docs/` is added or updated, and `docs/verify_examples.py` still passes.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
